### PR TITLE
Gpl 073 sample sheet generation

### DIFF
--- a/src/api/Config.json
+++ b/src/api/Config.json
@@ -54,6 +54,10 @@
         "tubes": {
           "name": "tubes",
           "include": "material"
+        },
+        "runs": {
+          "name": "runs",
+          "include": ""
         }
       }
     }

--- a/src/store/traction/pacbio/index.js
+++ b/src/store/traction/pacbio/index.js
@@ -1,9 +1,11 @@
 import pacbioTubesModule from '@/store/traction/pacbio/tubes'
+import pacbioRunsModule from '@/store/traction/pacbio/runs'
 
 const pacbio = {
   namespaced: true,
   modules: {
-    tubes: pacbioTubesModule
+    tubes: pacbioTubesModule,
+    runs: pacbioRunsModule
   },
   state: {
     labelTemplateId: process.env.VUE_APP_PACBIO_LABEL_TEMPLATE_ID,

--- a/src/store/traction/pacbio/runs/actions.js
+++ b/src/store/traction/pacbio/runs/actions.js
@@ -1,0 +1,24 @@
+import handlePromise from '@/api/PromiseHelper'
+
+const setRuns = async ({ commit, getters }) => {
+    let request = getters.runRequest
+    let promise = request.get()
+    let response = await handlePromise(promise)
+
+    if (response.successful && !response.empty) {
+        let runs = response.deserialize.runs
+        commit('setRuns', runs)
+    }
+
+    return response
+}
+
+const actions = {
+    setRuns
+}
+
+export {
+    setRuns
+}
+
+export default actions

--- a/src/store/traction/pacbio/runs/actions.js
+++ b/src/store/traction/pacbio/runs/actions.js
@@ -13,12 +13,19 @@ const setRuns = async ({ commit, getters }) => {
     return response
 }
 
+const generateSampleSheet = async (id) => {
+    console.log(id)
+    console.log("generateSampleSheet")
+}
+
 const actions = {
-    setRuns
+    setRuns,
+    generateSampleSheet
 }
 
 export {
-    setRuns
+    setRuns,
+    generateSampleSheet
 }
 
 export default actions

--- a/src/store/traction/pacbio/runs/actions.js
+++ b/src/store/traction/pacbio/runs/actions.js
@@ -13,19 +13,12 @@ const setRuns = async ({ commit, getters }) => {
     return response
 }
 
-const generateSampleSheet = async (id) => {
-    console.log(id)
-    console.log("generateSampleSheet")
-}
-
 const actions = {
-    setRuns,
-    generateSampleSheet
+    setRuns
 }
 
 export {
-    setRuns,
-    generateSampleSheet
+    setRuns
 }
 
 export default actions

--- a/src/store/traction/pacbio/runs/getters.js
+++ b/src/store/traction/pacbio/runs/getters.js
@@ -1,0 +1,6 @@
+const getters = {
+    runs: state => state.runs,
+    runRequest: (state, getters, rootState) => rootState.api.traction.pacbio.runs
+}
+
+export default getters

--- a/src/store/traction/pacbio/runs/index.js
+++ b/src/store/traction/pacbio/runs/index.js
@@ -1,0 +1,14 @@
+import state from './state'
+import getters from './getters'
+import mutations from './mutations'
+import actions from './actions'
+
+const runs = {
+  namespaced: true,
+  state,
+  getters,
+  mutations,
+  actions
+}
+
+export default runs

--- a/src/store/traction/pacbio/runs/mutations.js
+++ b/src/store/traction/pacbio/runs/mutations.js
@@ -1,0 +1,7 @@
+const mutations = {
+    setRuns(state, runs) {
+        state.runs = runs
+    }
+}
+
+export default mutations

--- a/src/store/traction/pacbio/runs/state.js
+++ b/src/store/traction/pacbio/runs/state.js
@@ -1,0 +1,5 @@
+const state = {
+    runs: []
+}
+
+export default state

--- a/src/views/pacbio/PacbioRuns.vue
+++ b/src/views/pacbio/PacbioRuns.vue
@@ -31,6 +31,13 @@
           :per-page="perPage"
           :current-page="currentPage"
           @filtered="onFiltered">
+
+        <template v-slot:cell(actions)="row">
+          <a :id="generateId('generate-sample-sheet', row.item.id)"
+             :href="generateSampleSheetPath(row.item.id)">
+             Generate Sample Sheet
+          </a>
+        </template>
     </b-table>
 
     <span class="font-weight-bold">Total records: {{ runs.length }}</span>

--- a/src/views/pacbio/PacbioRuns.vue
+++ b/src/views/pacbio/PacbioRuns.vue
@@ -33,13 +33,10 @@
           @filtered="onFiltered">
 
         <template v-slot:cell(actions)="row">
-          <b-button :id="generateId('generate-sample-sheet', row.item.id)"
-                    variant="outline-dark"
-                    size="sm"
-                    class="mr-1"
-                    @click="generateSampleSheet(row.item.id)">
-            Generate Sample Sheet
-          </b-button>
+          <a :id="generateId('generate-sample-sheet', row.item.id)"
+             :href="generateSampleSheetPath(row.item.id)">
+             Generate Sample Sheet
+          </a>
         </template>
 
     </b-table>
@@ -93,6 +90,9 @@ export default {
     },
     generateId(text, id) {
       return `${text}-${id}`
+    },
+    generateSampleSheetPath(id) {
+      return process.env.VUE_APP_TRACTION_BASE_URL + '/v1/pacbio/runs/' + id + '/sample_sheet'
     },
     ...mapActions([
       'setRuns',

--- a/src/views/pacbio/PacbioRuns.vue
+++ b/src/views/pacbio/PacbioRuns.vue
@@ -1,28 +1,100 @@
 <template>
-  <div class="runs">
-    <h5>Pacbio Runs</h5>
+  <div>
+    <alert ref='alert'></alert>
+
+    <b-form-group label="Filter"
+                label-cols-sm="1"
+                label-align-sm="right"
+                label-for="filterInput"
+                class="mb-0">
+      <b-input-group>
+        <b-form-input v-model="filter"
+                      type="search"
+                      id="filterInput"
+                      placeholder="Type to Search">
+        </b-form-input>
+        <b-input-group-append>
+          <b-button :disabled="!filter" @click="filter = ''">Clear</b-button>
+        </b-input-group-append>
+      </b-input-group>
+    </b-form-group>
+    <br>
+
+    <b-table id="runs-table"
+          hover
+          show-empty
+          :items="runs"
+          :fields="fields"
+          :filter="filter"
+          :sort-by.sync="sortBy"
+          :sort-desc.sync="sortDesc"
+          :per-page="perPage"
+          :current-page="currentPage"
+          @filtered="onFiltered">
+  </b-table>
+
   </div>
 </template>
 
 <script>
+import Alert from '@/components/Alert'
+import Helper from '@/mixins/Helper'
+import TableHelper from '@/mixins/TableHelper'
+
+import { createNamespacedHelpers } from 'vuex'
+const { mapActions, mapGetters } = createNamespacedHelpers('traction/pacbio/runs')
 
 export default {
   name: 'PacbioRuns',
-  mixins: [],
+  mixins: [Helper, TableHelper],
   props: {
   },
   data () {
     return {
+      fields: [
+        { key: 'id', label: 'Run ID', sortable: true },
+        { key: 'name', label: 'Name', sortable: true },
+        { key: 'state', label: 'State', sortable: true },
+        { key: 'template_prep_kit_box_barcode', label: 'Template Prep Kit BB', sortable: true },
+        { key: 'binding_kit_box_barcode', label: 'Binding Kit BB', sortable: true },
+        { key: 'template_prep_kit_box_barcode', label: 'Template Prep Kit BB', sortable: true },
+        { key: 'sequencing_kit_box_barcode', label: 'Sequencing Kit BB', sortable: true },
+        { key: 'dna_control_complex_box_barcode', label: 'DNA Control Complex BB', sortable: true },
+        { key: 'system_name', label: 'System Name', sortable: true },
+        { key: 'created_at', label: 'Created at', sortable: true },
+        { key: 'actions', label: 'Actions' },
+      ],
+      filteredItems: [],
+      filter: null,
+      sortBy: 'created_at',
+      sortDesc: true,
+      perPage: 5,
+      currentPage: 1,
     }
   },
   methods: {
+    async provider() {
+      try {
+        await this.setRuns()
+      } catch (error) {
+        this.showAlert("Failed to get runs: " + error.message, 'danger')
+      }
+    },
+    ...mapActions([
+      'setRuns'
+    ])
   },
   components: {
+    Alert
   },
   computed: {
+    ...mapGetters([
+      'runs'
+    ])
   },
-  created () {
-  }
+  created() {
+    this.provider()
+  },
 }
 </script>
 

--- a/src/views/pacbio/PacbioRuns.vue
+++ b/src/views/pacbio/PacbioRuns.vue
@@ -31,7 +31,18 @@
           :per-page="perPage"
           :current-page="currentPage"
           @filtered="onFiltered">
-  </b-table>
+
+        <template v-slot:cell(actions)="row">
+          <b-button :id="generateId('generate-sample-sheet', row.item.id)"
+                    variant="outline-dark"
+                    size="sm"
+                    class="mr-1"
+                    @click="generateSampleSheet(row.item.id)">
+            Generate Sample Sheet
+          </b-button>
+        </template>
+
+    </b-table>
 
   </div>
 </template>
@@ -80,8 +91,12 @@ export default {
         this.showAlert("Failed to get runs: " + error.message, 'danger')
       }
     },
+    generateId(text, id) {
+      return `${text}-${id}`
+    },
     ...mapActions([
-      'setRuns'
+      'setRuns',
+      'generateSampleSheet'
     ])
   },
   components: {

--- a/tests/data/index.js
+++ b/tests/data/index.js
@@ -20,6 +20,7 @@ import TubeWithLibrary from './tubeWithLibrary'
 import TractionPacbioTubesWithRequest from './tractionPacbioTubesWithRequest'
 import PacbioTubeWithLibrary from './pacbioTubeWithLibrary'
 import TractionPacbioLibraries from './tractionPacbioLibraries'
+import PacbioRuns from './pacbioRuns'
 
 export default {
   CreateChip,
@@ -43,5 +44,6 @@ export default {
   TubeWithLibrary,
   TractionPacbioTubesWithRequest,
   PacbioTubeWithLibrary,
-  TractionPacbioLibraries
+  TractionPacbioLibraries,
+  PacbioRuns
 }

--- a/tests/data/pacbioRuns.json
+++ b/tests/data/pacbioRuns.json
@@ -1,0 +1,42 @@
+{
+    "data": {
+        "data": [
+            {
+                "id": "1",
+                "type": "runs",
+                "links": {
+                    "self": "http://localhost:3100/v1/pacbio/runs/1"
+                },
+                "attributes": {
+                    "name": "aname",
+                    "template_prep_kit_box_barcode": "DM111710025910011171",
+                    "binding_kit_box_barcode": "DM11171008622001111",
+                    "sequencing_kit_box_barcode": "DM000110086180012311",
+                    "dna_control_complex_box_barcode": "Lxxxxx10171760012311",
+                    "system_name": "Sequel I",
+                    "created_at": "11/09/2019 01:11"
+                }
+            },
+            {
+                "id": "2",
+                "type": "runs",
+                "links": {
+                    "self": "http://localhost:3100/v1/pacbio/runs/1"
+                },
+                "attributes": {
+                    "name": "anothername",
+                    "template_prep_kit_box_barcode": "DM111710025910011172",
+                    "binding_kit_box_barcode": "DM11171008622001112",
+                    "sequencing_kit_box_barcode": "DM000110086180012312",
+                    "dna_control_complex_box_barcode": "Lxxxxx10171760012312",
+                    "system_name": "Sequel II",
+                    "created_at": "12/09/2019 02:22"
+                }
+            }
+        ],
+        "included": [
+        ]
+    },
+    "status": 200,
+    "statusText": "Success"
+}

--- a/tests/unit/store/traction/pacbio/runs/actions.spec.js
+++ b/tests/unit/store/traction/pacbio/runs/actions.spec.js
@@ -1,0 +1,38 @@
+import Response from '@/api/Response'
+import * as Actions from '@/store/traction/saphyr/runs/actions'
+import { Data } from '../../../../testHelper'
+
+describe('#setRuns', () => {
+  let commit, get, getters, failedResponse
+
+  beforeEach(() => {
+    commit = jest.fn()
+    get = jest.fn()
+    getters = { 'runRequest': { 'get': get } }
+
+    failedResponse = { data: { data: [] }, status: 500, statusText: 'Internal Server Error' }
+  })
+
+  it('successfully', async () => {
+    get.mockReturnValue(Data.PacbioRuns)
+
+    let expectedResponse = new Response(Data.PacbioRuns)
+    let expectedRuns = expectedResponse.deserialize.runs
+
+    let response = await Actions.setRuns({ commit, getters })
+
+    expect(commit).toHaveBeenCalledWith("setRuns", expectedRuns)
+    expect(response).toEqual(expectedResponse)
+  })
+
+  it('unsuccessfully', async () => {
+    get.mockReturnValue(failedResponse)
+
+    let expectedResponse = new Response(failedResponse)
+
+    let response = await Actions.setRuns({ commit, getters })
+
+    expect(commit).not.toHaveBeenCalled()
+    expect(response).toEqual(expectedResponse)
+  })
+})

--- a/tests/unit/views/pacbio/PacbioRuns.spec.js
+++ b/tests/unit/views/pacbio/PacbioRuns.spec.js
@@ -1,0 +1,146 @@
+import PacbioRuns from '@/views/pacbio/PacbioRuns'
+import { mount, localVue, Vuex, Data } from '../../testHelper'
+import Response from '@/api/Response'
+import Alert from '@/components/Alert'
+
+describe('Runs.vue', () => {
+
+    let wrapper, runs, mockRuns, store
+
+    beforeEach(() => {
+        mockRuns = new Response(Data.PacbioRuns).deserialize.runs
+
+        store = new Vuex.Store({
+            modules: {
+                traction: {
+                    namespaced: true,
+                    modules: {
+                        pacbio: {
+                            namespaced: true,
+                            modules: {
+                                runs: {
+                                    namespaced: true,
+                                    state: {
+                                        runs: mockRuns
+                                    },
+                                    getters: {
+                                        runs: state => state.runs,
+                                    },
+                                    actions: {
+                                        setRuns: jest.fn()
+                                    }
+                                }
+                            }
+
+                        }
+                    }
+                }
+            }
+        })
+
+        wrapper = mount(PacbioRuns, { store, localVue, methods: { provider() { return } } })
+        runs = wrapper.vm
+    })
+
+    describe('created hook', () => {
+        it('sets the runs data', () => {
+            expect(runs.runs).toEqual(mockRuns)
+        })
+    })
+
+    describe('alert', () => {
+        it('has a alert', () => {
+            expect(wrapper.contains(Alert)).toBe(true)
+        })
+    })
+
+    it('contains a table', () => {
+        expect(wrapper.contains('table')).toBe(true)
+    })
+
+    describe('sorting', () => {
+        it('will sort the runs by created at', () => {
+            expect(wrapper.find('tbody').findAll('tr').at(0).text()).toMatch(/Sequel II/)
+        })
+    })
+
+    describe('filtering runs', () => {
+        beforeEach(() => {
+            wrapper = mount(PacbioRuns, {
+                store,
+                localVue,
+                methods: {
+                    provider() {
+                        return
+                    }
+                },
+                data() {
+                    return {
+                        filter: mockRuns[0].name
+                    }
+                }
+            })
+        })
+
+        it('will filter the runs in the table', () => {
+            expect(wrapper.find('tbody').findAll('tr').length).toEqual(1)
+            expect(wrapper.find('tbody').findAll('tr').at(0).text()).toMatch(/Sequel I/)
+        })
+    })
+
+    describe('#showAlert', () => {
+        it('emits an event with the message', () => {
+            runs.showAlert(/show this message/)
+            expect(wrapper.find(Alert).text()).toMatch(/show this message/)
+        })
+    })
+
+    describe('pagination', () => {
+        beforeEach(() => {
+            wrapper = mount(PacbioRuns, {
+                store,
+                localVue,
+                methods: {
+                    provider() {
+                        return
+                    }
+                },
+                data() {
+                    return {
+                        perPage: 2,
+                        currentPage: 1
+                    }
+                }
+            })
+        })
+
+        it('will paginate the runs in the table', () => {
+            expect(wrapper.find('tbody').findAll('tr').length).toEqual(2)
+        })
+
+    })
+
+    describe('#provider', () => {
+        beforeEach(() => {
+            wrapper = mount(PacbioRuns, { store, localVue })
+            runs = wrapper.vm
+
+            runs.setRuns = jest.fn()
+            runs.showAlert = jest.fn()
+        })
+
+        it('calls setRuns successfully', () => {
+            runs.provider()
+            expect(runs.setRuns).toBeCalled()
+        })
+
+        it('calls setRuns unsuccessfully', () => {
+            runs.setRuns.mockImplementation(() => {
+                throw Error('Raise this error')
+            })
+            runs.provider()
+            expect(runs.showAlert).toBeCalled()
+        })
+
+    })
+})

--- a/tests/unit/views/pacbio/PacbioRuns.spec.js
+++ b/tests/unit/views/pacbio/PacbioRuns.spec.js
@@ -144,21 +144,20 @@ describe('Runs.vue', () => {
 
     })
 
-    describe('generate sample sheet button', () => {
-        let button
+    describe('generate sample sheet link', () => {
+        let link, id
 
-        it('exists', () => {
-            button = wrapper.find('#generate-sample-sheet-1')
-            expect(button).toBeTruthy()
+        beforeEach(() => {
+            id = 1
+            link = wrapper.find('#generate-sample-sheet-' + id)
         })
 
-        it('on click generateSampleSheet is called', () => {
-            runs.generateSampleSheet = jest.fn()
+        it('exists', () => {
+            expect(link).toBeTruthy()
+        })
 
-            button = wrapper.find('#generate-sample-sheet-1')
-            button.trigger('click')
-
-            expect(runs.generateSampleSheet).toBeCalledWith("1")
+        it('has the correct href link', () => {
+            expect(link.attributes("href")).toBe(process.env.VUE_APP_TRACTION_BASE_URL + "/v1/pacbio/runs/" + id + "/sample_sheet")
         })
     })
 })

--- a/tests/unit/views/pacbio/PacbioRuns.spec.js
+++ b/tests/unit/views/pacbio/PacbioRuns.spec.js
@@ -143,4 +143,22 @@ describe('Runs.vue', () => {
         })
 
     })
+
+    describe('generate sample sheet button', () => {
+        let button
+
+        it('exists', () => {
+            button = wrapper.find('#generate-sample-sheet-1')
+            expect(button).toBeTruthy()
+        })
+
+        it('on click generateSampleSheet is called', () => {
+            runs.generateSampleSheet = jest.fn()
+
+            button = wrapper.find('#generate-sample-sheet-1')
+            button.trigger('click')
+
+            expect(runs.generateSampleSheet).toBeCalledWith("1")
+        })
+    })
 })


### PR DESCRIPTION
Added Generate Sample Sheet button to PacbioRuns table
Button is a link, simply fetching the sample sheet for a run and handling in the browser
Dependent on traction service PR https://github.com/sanger/traction-service/pull/146
Merge after https://github.com/sanger/traction-ui/pull/199
