### PR TITLE
Change Saphyr Samples table to be single select only

### DIFF
--- a/src/views/saphyr/SaphyrSamples.vue
+++ b/src/views/saphyr/SaphyrSamples.vue
@@ -33,7 +33,7 @@
              hover
              @filtered="onFiltered"
              selectable
-             select-mode="multi"
+             select-mode="single"
              @row-selected="onRowSelected">
       <template v-slot:cell(selected)="{ rowSelected }">
         <template v-if="rowSelected">


### PR DESCRIPTION
so multiple libraries cannot be created
as the back end supports only getting the last library

Quick fix - should go back and update rest of code
to support single select

linked to https://github.com/sanger/traction-service/pull/344 
