### PR TITLE
Reload library page

### DIFF
--- a/src/views/ont/OntLibraries.vue
+++ b/src/views/ont/OntLibraries.vue
@@ -89,6 +89,7 @@ export default {
           this.showAlert(`Failure deleting library '${libraryName}': ` + data.data.deleteOntLibrary.errors.join(', '), 'danger')
         } else {
           this.showAlert(`Library '${libraryName}' was successully deleted`, 'success')
+          this.refetchLibraries()
         }
       })
     },

--- a/src/views/ont/OntLibraries.vue
+++ b/src/views/ont/OntLibraries.vue
@@ -77,17 +77,18 @@ export default {
   },
   methods: {
     handleLibraryDelete() {
+      const libraryName = this.selected[0].name
       this.$apollo.mutate({
         mutation: DELETE_ONT_LIBRARY,
         variables: {
-          libraryName: this.selected[0].name
+          libraryName
         }
       }).then(data => {
         let response = data.data.deleteOntLibrary
         if (response.errors.length > 0) {
-          this.showAlert('Failure: ' + data.data.deleteOntLibrary.errors.join(', '), 'danger')
+          this.showAlert(`Failure deleting library '${libraryName}': ` + data.data.deleteOntLibrary.errors.join(', '), 'danger')
         } else {
-          this.showAlert('Library was successully deleted', 'success')
+          this.showAlert(`Library '${libraryName}' was successully deleted`, 'success')
         }
       })
     },

--- a/tests/unit/views/ont/OntLibraries.spec.js
+++ b/tests/unit/views/ont/OntLibraries.spec.js
@@ -3,10 +3,11 @@ import { mount, localVue } from '../../testHelper'
 import PrinterModal from '@/components/PrinterModal'
 
 describe('OntLibraries.vue', () => {
-  let wrapper, libraries, librariesData, mutate
+  let wrapper, libraries, librariesData, mutate, refetchLibraries
 
   beforeEach(() => {
     mutate = jest.fn()
+    refetchLibraries = jest.fn()
 
     librariesData = [
       { id: 1, tube_barcode: 'TRAC-2-1', plate_barcode: 'TRAC-1-1', poolSize: 1, wellRange: 'A1-H3', tag_set: 24 },
@@ -33,7 +34,7 @@ describe('OntLibraries.vue', () => {
         }
       },
       methods: {
-        refetchLibraries() { return }
+        refetchLibraries: refetchLibraries
       }
     })
     libraries = wrapper.vm
@@ -97,6 +98,21 @@ describe('OntLibraries.vue', () => {
 
       expect(mutate).toBeCalled()
       expect(libraries.showAlert).toBeCalledWith(`Library '${libraryName}' was successully deleted`, 'success')
+    })
+
+    it('refetches libraries on success', async () => {
+      refetchLibraries.mockClear()
+      let mockResponse = { data: { deleteOntLibrary: { success: true, errors: [] } } }
+
+      let promise = new Promise((resolve) => {
+        resolve(mockResponse)
+      })
+
+      mutate.mockReturnValue(promise)
+
+      await button.trigger('click')
+
+      expect(refetchLibraries).toBeCalled()
     })
 
     it('shows an alert on failure', async () => {

--- a/tests/unit/views/ont/OntLibraries.spec.js
+++ b/tests/unit/views/ont/OntLibraries.spec.js
@@ -72,11 +72,12 @@ describe('OntLibraries.vue', () => {
 
   describe('Delete button', () => {
     let button
+    const libraryName = 'aLibraryName'
 
     beforeEach(() => {
       button = wrapper.find('#deleteLibrary-btn')
       libraries.showAlert = jest.fn()
-      libraries.selected = [{ name: 'aLibraryName' }]
+      libraries.selected = [{ name: libraryName }]
     })
 
     it('is shows button', () => {
@@ -95,7 +96,7 @@ describe('OntLibraries.vue', () => {
       await button.trigger('click')
 
       expect(mutate).toBeCalled()
-      expect(libraries.showAlert).toBeCalledWith('Library was successully deleted', 'success')
+      expect(libraries.showAlert).toBeCalledWith(`Library '${libraryName}' was successully deleted`, 'success')
     })
 
     it('shows an alert on failure', async () => {
@@ -110,7 +111,7 @@ describe('OntLibraries.vue', () => {
       await button.trigger('click')
 
       expect(mutate).toBeCalled()
-      expect(libraries.showAlert).toBeCalledWith('Failure: this is an error', 'danger')
+      expect(libraries.showAlert).toBeCalledWith(`Failure deleting library '${libraryName}': this is an error`, 'danger')
     })
   })
 })


### PR DESCRIPTION
Closes #442 

Changes proposed in this pull request:

* Update the messages shown when deleting a library to include the library name
* Refetch libraries after successful deletion to reload the libraries table
