### PR TITLE
When a run is created stay on the same page with a success message.

### DIFF
--- a/src/views/ont/OntHeronRun.vue
+++ b/src/views/ont/OntHeronRun.vue
@@ -88,7 +88,7 @@ export default {
         if (response.errors.length > 0) {
           this.showAlert('Failure: ' + response.errors.join(', '), 'danger')
         } else {
-          this.redirectToRuns()
+          this.showAlert('Run successfully created', 'success')
         }
       })
     },
@@ -130,9 +130,6 @@ export default {
       .catch(error => {
         this.showAlert('Failure to build run: ' + error, 'danger')
       })
-    },
-    redirectToRuns() {
-      this.$router.push({ name: 'OntHeronRuns' })
     },
     provider () {
       this.buildRun()

--- a/tests/unit/components/ont/OntHeronRun.spec.js
+++ b/tests/unit/components/ont/OntHeronRun.spec.js
@@ -119,7 +119,7 @@ describe('OntHeronRun.vue', () => {
       run.showAlert = jest.fn()
     })
 
-    it('redirects on success', async () => {
+    it('shows an alert on success', async () => {
       run.redirectToRuns = jest.fn()
 
       let mockResponse = { data: { createOntRun: { run: { id: 1 }, errors: [] } } }
@@ -130,7 +130,7 @@ describe('OntHeronRun.vue', () => {
       await run.runAction()
 
       expect(mutate).toBeCalled()
-      expect(run.redirectToRuns).toBeCalled()
+      expect(run.showAlert).toBeCalledWith(`Run successfully created`, 'success')
     })
 
     it('shows an alert on failure', async () => {
@@ -142,6 +142,7 @@ describe('OntHeronRun.vue', () => {
       await run.runAction()
 
       expect(mutate).toBeCalled()
+
       expect(run.showAlert).toBeCalledWith('Failure: this is an error', 'danger')
     })
   })


### PR DESCRIPTION
Closes #444

Changes proposed in this pull request:

* when a run is created stay on the run page
* Show a success message

TODO:
* when a run is created add it to the cache?
