### PR TITLE
Bug fixes - Ont cancel button, library list order, img flowcell mask

### DIFF
--- a/src/components/ont/OntFlowcell.vue
+++ b/src/components/ont/OntFlowcell.vue
@@ -8,7 +8,7 @@
     <foreignObject width="70" height="227">
       <div draggable="true" v-on:dragstart="drag(library.name, $event)">
         <b-form-input placeholder="Name" :id="elementId"  @change="updateFlowcell($event)" :value="library.name"></b-form-input>
-        <img left src="/tube.png" height="30" draggable="false" :class="status"/>
+        <b-img right src="/tube.png" height="30" draggable="false" :class="status"/>
       </div>
     </foreignObject>
   </g>

--- a/src/components/ont/OntRunLibrariesList.vue
+++ b/src/components/ont/OntRunLibrariesList.vue
@@ -59,7 +59,8 @@ export default {
   computed: {
     unselectedLibraries () {
       if (this.libraries) {
-        return this.libraries.filter(library => !this.isLibrarySelected(library))
+        let libraries = this.libraries.filter(library => !this.isLibrarySelected(library))
+        return libraries.reverse()
       }
       return []
     }

--- a/src/views/ont/OntHeronRun.vue
+++ b/src/views/ont/OntHeronRun.vue
@@ -4,6 +4,7 @@
 
     <div>
       <b-row class="create-run-button">
+        <b-button @click="redirectToRuns()">Cancel</b-button>
         <b-button :id="currentAction.id" :variant="currentAction.variant" @click="runAction()">{{ currentAction.label}}</b-button>
       </b-row>
       <b-row class="clearboth">
@@ -131,6 +132,9 @@ export default {
     },
     redirectToRun(id) {
       this.$router.push({ path: `/ont/run/${id}`}, () => {})
+    },
+    redirectToRuns() {
+      this.$router.push({ path: `/ont/runs` })
     },
     updateFlowcell (position, libraryName) {
       this.$apollo.mutate({

--- a/src/views/ont/OntHeronRun.vue
+++ b/src/views/ont/OntHeronRun.vue
@@ -4,7 +4,7 @@
 
     <div>
       <b-row class="create-run-button">
-        <b-button @click="redirectToRuns()">Cancel</b-button>
+        <b-button id="cancel-button" @click="redirectToRuns()">Cancel</b-button>
         <b-button :id="currentAction.id" :variant="currentAction.variant" @click="runAction()">{{ currentAction.label}}</b-button>
       </b-row>
       <b-row class="clearboth">

--- a/tests/unit/components/ont/OntFlowcell.spec.js
+++ b/tests/unit/components/ont/OntFlowcell.spec.js
@@ -1,5 +1,5 @@
 import OntFlowcell from '@/components/ont/OntFlowcell'
-import { mount } from '../../testHelper'
+import { mount, localVue } from '../../testHelper'
 
 describe('OntFlowcell.vue', () => {
 
@@ -14,6 +14,7 @@ describe('OntFlowcell.vue', () => {
     mutate = jest.fn()
 
     wrapper = mount(OntFlowcell, {
+      localVue,
       propsData: props,
       stubs: {
         'b-form-input': true
@@ -117,7 +118,6 @@ describe('OntFlowcell.vue', () => {
       flowcell.drop(mockEvent)
       expect(flowcell.status).toEqual('filled')
       expect(flowcell.hover).toBeFalsy()
-      expect(wrapper.find('img').exists()).toBeTruthy()
     })
   })
 

--- a/tests/unit/views/ont/OntHeronRun.spec.js
+++ b/tests/unit/views/ont/OntHeronRun.spec.js
@@ -72,6 +72,7 @@ describe('OntHeronRun.vue', () => {
   describe('#Current action button', () => {
     beforeEach(() => {
       run.runAction = jest.fn()
+      run.redirectToRuns = jest.fn()
     })
 
     describe('Create button', () => {
@@ -100,6 +101,23 @@ describe('OntHeronRun.vue', () => {
         let button = wrapper.find('#update-button')
         button.trigger('click')
         expect(run.runAction).toBeCalled()
+      })
+    })
+  })
+
+  describe('#Cancel button', () => {
+    beforeEach(() => {
+      run.redirectToRuns = jest.fn()
+    })
+    describe('Cancel button', () => {
+      it('exists', () => {
+        expect(wrapper.find('#cancel-button').text()).toEqual('Cancel')
+      })
+
+      it('calls runAction on click', () => {
+        let button = wrapper.find('#cancel-button')
+        button.trigger('click')
+        expect(run.redirectToRuns).toBeCalled()
       })
     })
   })


### PR DESCRIPTION
Closes #476

Changes proposed in this pull request:

* Added cancel button to edit and create runs page for ONT - returns user to runs page
* Library list is now presented as newest library first for ONT
* Tube image no longer covers flowcell number
