### PR TITLE
Pacbio runs reset button 

### DIFF
--- a/src/views/pacbio/PacbioRun.vue
+++ b/src/views/pacbio/PacbioRun.vue
@@ -6,6 +6,7 @@
       <b-button id="backToRunsButton" class="float-right">Back</b-button>
     </router-link>
 
+    <b-button v-if="currentAction.id == 'create'" variant="primary" class="float-right" @click="resetRun()" id="reset">Reset</b-button>
     <b-button class="float-right" :id="currentAction.id" :variant="currentAction.variant" @click="runAction">{{ currentAction.label}}</b-button>
 
     <br>
@@ -78,6 +79,9 @@ export default {
       } else {
         this.showAlert(consts.MESSAGE_ERROR_CREATE_RUN_FAILED + responses, 'danger')
       }
+    },
+    resetRun() {
+      this.newRun()
     },
     ...mapActions([
       'createRun',

--- a/src/views/pacbio/PacbioRun.vue
+++ b/src/views/pacbio/PacbioRun.vue
@@ -6,7 +6,7 @@
       <b-button id="backToRunsButton" class="float-right">Back</b-button>
     </router-link>
 
-    <b-button v-if="currentAction.id == 'create'" variant="primary" class="float-right" @click="resetRun()" id="reset">Reset</b-button>
+    <b-button v-if="this.newRecord" variant="primary" class="float-right" @click="resetRun()" id="reset">Reset</b-button>
     <b-button class="float-right" :id="currentAction.id" :variant="currentAction.variant" @click="runAction">{{ currentAction.label}}</b-button>
 
     <br>

--- a/src/views/pacbio/PacbioRun.vue
+++ b/src/views/pacbio/PacbioRun.vue
@@ -82,6 +82,7 @@ export default {
     },
     resetRun() {
       this.newRun()
+      this.showAlert("Run has been reset", 'success')
     },
     ...mapActions([
       'createRun',

--- a/tests/unit/views/pacbio/PacbioRun.spec.js
+++ b/tests/unit/views/pacbio/PacbioRun.spec.js
@@ -123,9 +123,14 @@ describe('Run.vue', () => {
         })
 
         describe('Reset button', () => {
-            it('will only show if the record is new', () => {
+            it('will show if the record is new', () => {
                 wrapper.setData({ newRecord: true })
                 expect(wrapper.find('#reset').exists()).toBeTruthy()
+            })
+
+            it('will not show if the record is existing', () => {
+                wrapper.setData({ newRecord: false })
+                expect(wrapper.find('#reset').exists()).toBeFalsy()
             })
         })
     })
@@ -219,6 +224,7 @@ describe('Run.vue', () => {
             pacbioRun.newRun.mockReturnValue([])
             pacbioRun.resetRun()
             expect(pacbioRun.newRun).toBeCalled()
+            expect(pacbioRun.showAlert).toBeCalledWith("Run has been reset", 'success')
         })
     })
 })

--- a/tests/unit/views/pacbio/PacbioRun.spec.js
+++ b/tests/unit/views/pacbio/PacbioRun.spec.js
@@ -121,6 +121,13 @@ describe('Run.vue', () => {
                 expect(wrapper.find('#update').exists()).toBeTruthy()
             })
         })
+
+        describe('Reset button', () => {
+            it('will only show if the record is new', () => {
+                wrapper.setData({ newRecord: true })
+                expect(wrapper.find('#reset').exists()).toBeTruthy()
+            })
+        })
     })
 
     describe('#create', () => {
@@ -201,4 +208,30 @@ describe('Run.vue', () => {
         })
     })
 
+    describe('#reset', () => {
+
+        beforeEach(() => {
+            wrapper = shallowMount(PacbioRun, {
+            store, 
+            router,
+            localVue,
+            propsData: { id: 1},
+            methods: {
+               provider() { return }
+            }
+        })
+        pacbioRun = wrapper.vm
+
+            pacbioRun.showAlert = jest.fn()
+            pacbioRun.newRun = jest.fn()
+            pacbioRun.redirectToRuns = jest.fn()
+        })
+
+        it('calls newRun', async () => {
+            pacbioRun.newRun.mockReturnValue([])
+
+            pacbioRun.resetRun()
+            expect(pacbioRun.newRun).toBeCalled()
+        })
+    })
 })

--- a/tests/unit/views/pacbio/PacbioRun.spec.js
+++ b/tests/unit/views/pacbio/PacbioRun.spec.js
@@ -211,25 +211,12 @@ describe('Run.vue', () => {
     describe('#reset', () => {
 
         beforeEach(() => {
-            wrapper = shallowMount(PacbioRun, {
-            store, 
-            router,
-            localVue,
-            propsData: { id: 1},
-            methods: {
-               provider() { return }
-            }
-        })
-        pacbioRun = wrapper.vm
-
             pacbioRun.showAlert = jest.fn()
             pacbioRun.newRun = jest.fn()
-            pacbioRun.redirectToRuns = jest.fn()
         })
 
         it('calls newRun', async () => {
             pacbioRun.newRun.mockReturnValue([])
-
             pacbioRun.resetRun()
             expect(pacbioRun.newRun).toBeCalled()
         })

--- a/tests/unit/views/pacbio/PacbioRun.spec.js
+++ b/tests/unit/views/pacbio/PacbioRun.spec.js
@@ -1,6 +1,6 @@
 import PacbioRun from '@/views/pacbio/PacbioRun'    
 import PacbioRuns from '@/views/pacbio/PacbioRuns'
-import { shallowMount, localVue, Vuex } from '../../testHelper'
+import { mount, localVue, Vuex } from '../../testHelper'
 import VueRouter from 'vue-router'
 import Alert from '@/components/Alert'
 import PacbioRunInfo from '@/components/pacbio/PacbioRunInfo'
@@ -62,10 +62,15 @@ describe('Run.vue', () => {
             }
         })
 
-        wrapper = shallowMount(PacbioRun, {
+        wrapper = mount(PacbioRun, {
             store, 
             router,
             localVue,
+            stubs: {
+                Plate: true,
+                PacbioLibrariesList: true,
+                PacbioRunInfo: true,
+            },
             methods: {
                provider() { return }
             }
@@ -171,11 +176,16 @@ describe('Run.vue', () => {
     describe('#update', () => {
 
         beforeEach(() => {
-             wrapper = shallowMount(PacbioRun, {
+            wrapper = mount(PacbioRun, {
             store, 
             router,
             localVue,
             propsData: { id: 1},
+            stubs: {
+                Plate: true,
+                PacbioLibrariesList: true,
+                PacbioRunInfo: true,
+            },
             methods: {
                provider() { return }
                


### PR DESCRIPTION
Closes #475

Changes proposed in this pull request:

*Reset button added to pacbio new run page. Removes all current data and presents a blank plate and plate info.

