### PR TITLE
Fix library update in Saphyr Run

### DIFF
--- a/src/components/saphyr/SaphyrFlowcell.vue
+++ b/src/components/saphyr/SaphyrFlowcell.vue
@@ -26,11 +26,11 @@ export default {
   methods: {
     async setBarcode(barcode) {
       let isValid = await this.isLibraryBarcodeValid(barcode)
-
+      
       if (isValid) {
         let libraryTube = await this.getTubeForBarcode(barcode)
-        let library = libraryTube.materials[0]
-        let payload = { library: library, flowcellIndex: this.index}
+        let container_material = libraryTube.materials[0]
+        let payload = { library: { id: container_material.material_id, barcode: container_material.barcode }, flowcellIndex: this.index }
 
         this.setLibraryBarcode(payload)
       } else {

--- a/tests/data/tubeWithLibrary.json
+++ b/tests/data/tubeWithLibrary.json
@@ -37,7 +37,8 @@
                     "barcode": "TRAC-2-21",
                     "created_at": "2020/05/04 13:26",
                     "sample_name": "Sample1",
-                    "material_type": "library"
+                    "material_type": "library",
+                    "material_id": "1"
                 }
             }
          

--- a/tests/unit/components/saphyr/SaphyrFlowcell.spec.js
+++ b/tests/unit/components/saphyr/SaphyrFlowcell.spec.js
@@ -86,8 +86,14 @@ describe('Flowcell', () => {
       flowcell.getTubeForBarcode.mockReturnValue(tube)
 
       await flowcell.setBarcode(newBarcode)
-
-      expect(flowcell.setLibraryBarcode).toBeCalled()
+      let expected = {
+        flowcellIndex: 0,
+        library:  {
+          barcode: "TRAC-2-21",
+          id: "1",
+        }
+      }
+      expect(flowcell.setLibraryBarcode).toBeCalledWith(expected)
       expect(flowcell.alert).not.toBeCalled()
     })
 


### PR DESCRIPTION
Subpart of #413 
Coupled with https://github.com/sanger/traction-service/pull/443
container_material was being return as the tubes material
rather than the library
So the wrong library id was being used on update
