### PR TITLE
GPL-878-21 Adding binding kit box barcode to well 

### DIFF
--- a/src/api/PacbioRun.js
+++ b/src/api/PacbioRun.js
@@ -19,6 +19,7 @@ const buildWell = (
   on_plate_loading_concentration: '',
   generate_hifi,
   ccs_analysis_output,
+  binding_kit_box_barcode: '',
   // TODO remove
   libraries: [],
   pools: [],
@@ -29,7 +30,6 @@ const build = (object) => {
   return (
     object || {
       id: 'new',
-      binding_kit_box_barcode: '',
       sequencing_kit_box_barcode: '',
       dna_control_complex_box_barcode: '',
       comments: '',
@@ -119,7 +119,6 @@ const createRunPayload = (run) => {
     data: {
       type: 'runs',
       attributes: {
-        binding_kit_box_barcode: run.binding_kit_box_barcode,
         sequencing_kit_box_barcode: run.sequencing_kit_box_barcode,
         dna_control_complex_box_barcode: run.dna_control_complex_box_barcode,
         system_name: run.system_name,
@@ -155,6 +154,7 @@ const createWellsPayload = (wells, plateId) => {
       generate_hifi: well.generate_hifi,
       ccs_analysis_output: well.ccs_analysis_output,
       pre_extension_time: well.pre_extension_time,
+      binding_kit_box_barcode: well.binding_kit_box_barcode,
       relationships: {
         plate: {
           data: {
@@ -186,7 +186,6 @@ const updateRunPayload = (run) => {
       id: run.id,
       type: 'runs',
       attributes: {
-        binding_kit_box_barcode: run.binding_kit_box_barcode,
         sequencing_kit_box_barcode: run.sequencing_kit_box_barcode,
         dna_control_complex_box_barcode: run.dna_control_complex_box_barcode,
         system_name: run.system_name,
@@ -214,6 +213,7 @@ const updateWellPayload = (well) => {
         generate_hifi: well.generate_hifi,
         ccs_analysis_output: well.ccs_analysis_output,
         pre_extension_time: well.pre_extension_time,
+        binding_kit_box_barcode: well.binding_kit_box_barcode,
       },
       relationships: {
         pools: {

--- a/src/api/PacbioRun.js
+++ b/src/api/PacbioRun.js
@@ -8,6 +8,7 @@ const buildWell = (
   row,
   column,
   generate_hifi = '',
+  binding_kit_box_barcode = '',
   pre_extension_time = PRE_EXTENSION_TIME_DEFAULT,
   ccs_analysis_output = CCS_ANALYSIS_OUTPUT_DEFAULT,
 ) => ({
@@ -19,7 +20,7 @@ const buildWell = (
   on_plate_loading_concentration: '',
   generate_hifi,
   ccs_analysis_output,
-  binding_kit_box_barcode: '',
+  binding_kit_box_barcode,
   // TODO remove
   libraries: [],
   pools: [],

--- a/src/components/pacbio/PacbioRunInfoEdit.vue
+++ b/src/components/pacbio/PacbioRunInfoEdit.vue
@@ -79,6 +79,9 @@
           title="Default Binding Kit Box Barcode for new wells"
           @change="setDefaultBindingKitBoxBarcode"
         />
+        <p style="float: left; font-size:12px;">
+          * Non-submitted field, used for providing new wells with a default binding kit box barcode
+        </p>
       </b-col>
     </b-row>
   </div>
@@ -112,7 +115,7 @@ export default {
       defaultBindingKitBoxBarcode: (state) => state.currentRun.default_binding_kit_box_barcode,
       /* 
         Default binding kit box barcode is not a run attribute and it is not sent on update/create
-        It exists as a default value when creating wells to autofill the well binding kit box barcode
+        It exists to provide a default value when creating wells to autofill the well binding kit box barcode
       */
     }),
   },

--- a/src/components/pacbio/PacbioRunInfoEdit.vue
+++ b/src/components/pacbio/PacbioRunInfoEdit.vue
@@ -13,18 +13,6 @@
           readonly
         />
       </b-col>
-      <b-col>
-        <b-form-input
-          id="binding-kit-box-barcode"
-          v-b-tooltip.hover
-          :value="bindingKitBoxBarcode"
-          placeholder="Binding Kit Box Barcode"
-          type="text"
-          width="48"
-          title="Binding Kit Box Barcode"
-          @change="setBindingKitBoxBarcode"
-        />
-      </b-col>
     </b-row>
 
     <b-row>
@@ -102,7 +90,6 @@ export default {
     ...mapGetters(['currentRun']),
     ...mapState({
       runName: (state) => state.currentRun.name,
-      bindingKitBoxBarcode: (state) => state.currentRun.binding_kit_box_barcode,
       sequencingKitBoxBarcode: (state) => state.currentRun.sequencing_kit_box_barcode,
       dnaControlComplexBoxBarcode: (state) => state.currentRun.dna_control_complex_box_barcode,
       comments: (state) => state.currentRun.comments,
@@ -112,7 +99,6 @@ export default {
   },
   methods: {
     ...mapMutations([
-      'setBindingKitBoxBarcode',
       'setSequencingKitBoxBarcode',
       'setDNAControlComplexBoxBarcode',
       'setComments',

--- a/src/components/pacbio/PacbioRunInfoEdit.vue
+++ b/src/components/pacbio/PacbioRunInfoEdit.vue
@@ -67,6 +67,20 @@
         />
       </b-col>
     </b-row>
+    <b-row>
+      <b-col>
+        <b-form-input
+          id="default-binding-kit-box-barcode"
+          v-b-tooltip.hover
+          style="max-width: 50%;"
+          :value="defaultBindingKitBoxBarcode"
+          placeholder="Default Binding Kit Box Barcode for new wells"
+          type="text"
+          title="Default Binding Kit Box Barcode for new wells"
+          @change="setDefaultBindingKitBoxBarcode"
+        />
+      </b-col>
+    </b-row>
   </div>
 </template>
 
@@ -95,6 +109,11 @@ export default {
       comments: (state) => state.currentRun.comments,
       uuid: (state) => state.currentRun.uuid,
       systemName: (state) => state.currentRun.system_name,
+      defaultBindingKitBoxBarcode: (state) => state.currentRun.default_binding_kit_box_barcode,
+      /* 
+        Default binding kit box barcode is not a run attribute and it is not sent on update/create
+        It exists as a default value when creating wells to autofill the well binding kit box barcode
+      */
     }),
   },
   methods: {
@@ -104,6 +123,7 @@ export default {
       'setComments',
       'setUuid',
       'setSystemName',
+      'setDefaultBindingKitBoxBarcode',
     ]),
   },
 }

--- a/src/components/pacbio/PacbioRunWellEdit.vue
+++ b/src/components/pacbio/PacbioRunWellEdit.vue
@@ -83,6 +83,21 @@
         >
         </b-form-input>
       </b-form-group>
+
+      <b-form-group
+        id="bindingKitBoxBarcode-group"
+        label="Binding Kit Box Barcode: "
+        label-for="bindingKitBoxBarcode"
+      >
+        <b-form-input
+          id="bindingKitBoxBarcode"
+          ref="bindingKitBoxBarcode"
+          :value="bindingKitBoxBarcode"
+          placeholder="Binding Kit Box Barcode"
+          @change="updateBindingKitBoxBarcode"
+        >
+        </b-form-input>
+      </b-form-group>
     </b-form>
 
     <b-table id="wellPools" stacked :items="wellPools" :fields="wellPoolsFields">
@@ -173,6 +188,9 @@ export default {
       ccsAnalysisOutput() {
         return this.well(this.position) ? this.well(this.position).ccs_analysis_output : ''
       },
+      bindingKitBoxBarcode() {
+        return this.well(this.position) ? this.well(this.position).binding_kit_box_barcode : ''
+      },
     }),
   },
   methods: {
@@ -227,6 +245,13 @@ export default {
         position: this.position,
         property: 'ccs_analysis_output',
         with: ccsAnalysisOutput,
+      })
+    },
+    updateBindingKitBoxBarcode(bindingKitBoxBarcode) {
+      this.mutateWell({
+        position: this.position,
+        property: 'binding_kit_box_barcode',
+        with: bindingKitBoxBarcode,
       })
     },
     async updatePoolBarcode(row, barcode) {

--- a/src/components/pacbio/PacbioRunWellItem.vue
+++ b/src/components/pacbio/PacbioRunWellItem.vue
@@ -64,7 +64,12 @@ export default {
       default() {
         // Below doesn't include 'generate_hifi', 'pre_extension_time' or 'ccs_analysis_output'
         // as they have default values
-        return ['movie_time', 'insert_size', 'on_plate_loading_concentration']
+        return [
+          'movie_time',
+          'insert_size',
+          'on_plate_loading_concentration',
+          'binding_kit_box_barcode',
+        ]
       },
     },
   },

--- a/src/components/pacbio/PacbioRunWellItem.vue
+++ b/src/components/pacbio/PacbioRunWellItem.vue
@@ -62,13 +62,14 @@ export default {
     required_metadata_fields: {
       type: Array,
       default() {
-        // Below doesn't include 'generate_hifi', 'pre_extension_time' or 'ccs_analysis_output'
+        // Below doesn't include 'pre_extension_time' or 'ccs_analysis_output'
         // as they have default values
         return [
           'movie_time',
           'insert_size',
           'on_plate_loading_concentration',
           'binding_kit_box_barcode',
+          'generate_hifi',
         ]
       },
     },

--- a/src/store/traction/pacbio/runs/mutations.js
+++ b/src/store/traction/pacbio/runs/mutations.js
@@ -20,7 +20,12 @@ const getCurrentWell = (state, position) => {
   if (!currentWell) {
     // Duplication of createWell mutation below
     let generateHiFiDefault = getGenerateHiFiDefault(state.currentRun.system_name)
-    currentWell = PacbioRun.buildWell(...splitPosition(position), generateHiFiDefault)
+    let defaultBindingKitBoxBarcode = state.currentRun.default_binding_kit_box_barcode
+    currentWell = PacbioRun.buildWell(
+      ...splitPosition(position),
+      generateHiFiDefault,
+      defaultBindingKitBoxBarcode,
+    )
     state.currentRun.plate.wells.push(currentWell)
   }
 
@@ -44,10 +49,16 @@ const mutations = {
   setDNAControlComplexBoxBarcode: mutateRun('dna_control_complex_box_barcode'),
   setComments: mutateRun('comments'),
   setSystemName: mutateRun('system_name'),
+  setDefaultBindingKitBoxBarcode: mutateRun('default_binding_kit_box_barcode'),
 
   createWell(state, position) {
+    let defaultBindingKitBoxBarcode = state.currentRun.default_binding_kit_box_barcode
     let generateHiFiDefault = getGenerateHiFiDefault(state.currentRun.system_name)
-    let currentWell = PacbioRun.buildWell(...splitPosition(position), generateHiFiDefault)
+    let currentWell = PacbioRun.buildWell(
+      ...splitPosition(position),
+      generateHiFiDefault,
+      defaultBindingKitBoxBarcode,
+    )
     state.currentRun.plate.wells.push(currentWell)
   },
   mutateWell(state, payload) {

--- a/src/store/traction/pacbio/runs/mutations.js
+++ b/src/store/traction/pacbio/runs/mutations.js
@@ -40,7 +40,6 @@ const getGenerateHiFiDefault = (systemName) => {
 const mutations = {
   setRuns: mutate('runs'),
   setCurrentRun: mutate('currentRun'),
-  setBindingKitBoxBarcode: mutateRun('binding_kit_box_barcode'),
   setSequencingKitBoxBarcode: mutateRun('sequencing_kit_box_barcode'),
   setDNAControlComplexBoxBarcode: mutateRun('dna_control_complex_box_barcode'),
   setComments: mutateRun('comments'),

--- a/src/views/pacbio/PacbioRunIndex.vue
+++ b/src/views/pacbio/PacbioRunIndex.vue
@@ -131,12 +131,6 @@ export default {
         { key: 'name', label: 'Name', sortable: true, tdClass: 'name' },
         { key: 'state', label: 'State', sortable: true, tdClass: 'state' },
         {
-          key: 'binding_kit_box_barcode',
-          label: 'Binding Kit BB',
-          sortable: true,
-          tdClass: 'binding-kit-box-barcode',
-        },
-        {
           key: 'sequencing_kit_box_barcode',
           label: 'Sequencing Kit BB',
           sortable: true,

--- a/tests/data/pacbioRun.json
+++ b/tests/data/pacbioRun.json
@@ -8,7 +8,6 @@
       },
       "attributes": {
         "name": "aname",
-        "binding_kit_box_barcode": "DM11171008622001117",
         "sequencing_kit_box_barcode": "DM000110086180012312",
         "dna_control_complex_box_barcode": "Lxxxxx10171760012319",
         "system_name": "Sequel II",

--- a/tests/data/pacbioRuns.json
+++ b/tests/data/pacbioRuns.json
@@ -10,7 +10,6 @@
         "attributes": {
           "name": "aname",
           "state": "pending",
-          "binding_kit_box_barcode": "DM11171008622001111",
           "sequencing_kit_box_barcode": "DM000110086180012311",
           "dna_control_complex_box_barcode": "Lxxxxx10171760012311",
           "system_name": "Sequel I",
@@ -27,7 +26,6 @@
         "attributes": {
           "name": "anothername",
           "state": "started",
-          "binding_kit_box_barcode": "DM11171008622001112",
           "sequencing_kit_box_barcode": "DM000110086180012312",
           "dna_control_complex_box_barcode": "Lxxxxx10171760012312",
           "system_name": "Sequel II",
@@ -44,7 +42,6 @@
         "attributes": {
           "name": "anothername1",
           "state": "completed",
-          "binding_kit_box_barcode": "DM11171008622001112",
           "sequencing_kit_box_barcode": "DM000110086180012312",
           "dna_control_complex_box_barcode": "Lxxxxx10171760012312",
           "system_name": "Sequel II",
@@ -60,7 +57,6 @@
         "attributes": {
           "name": "anothername2",
           "state": "cancelled",
-          "binding_kit_box_barcode": "DM11171008622001112",
           "sequencing_kit_box_barcode": "DM000110086180012312",
           "dna_control_complex_box_barcode": "Lxxxxx10171760012312",
           "system_name": "Sequel II",
@@ -77,7 +73,6 @@
         "attributes": {
           "name": "anothername3",
           "state": "completed",
-          "binding_kit_box_barcode": "DM11171008622001112",
           "sequencing_kit_box_barcode": "DM000110086180012312",
           "dna_control_complex_box_barcode": "Lxxxxx10171760012312",
           "system_name": "Sequel II",
@@ -94,7 +89,6 @@
         "attributes": {
           "name": "anothername4",
           "state": "started",
-          "binding_kit_box_barcode": "DM11171008622001112",
           "sequencing_kit_box_barcode": "DM000110086180012312",
           "dna_control_complex_box_barcode": "Lxxxxx10171760012312",
           "system_name": "Sequel II",

--- a/tests/data/pacbioWell.json
+++ b/tests/data/pacbioWell.json
@@ -16,7 +16,8 @@
         "comment": null,
         "generate_hifi": "In SMRT Link",
         "ccs_analysis_output": "",
-        "pre_extension_time": "2"
+        "pre_extension_time": "2",
+        "bindng_kit_box_barcode": "BKB1"
       }
     }
   },

--- a/tests/data/pacbioWells.json
+++ b/tests/data/pacbioWells.json
@@ -18,7 +18,8 @@
           "generate_hifi": "In SMRT Link",
           "pre_extension_time": "2",
           "position": "A1",
-          "ccs_analysis_output": "No"
+          "ccs_analysis_output": "No",
+          "bindng_kit_box_barcode": "BKB1"
         },
         "relationships": {
           "pools": {
@@ -46,7 +47,8 @@
           "generate_hifi": "In SMRT Link",
           "pre_extension_time": "2",
           "position": "A1",
-          "ccs_analysis_output": "No"
+          "ccs_analysis_output": "No",
+          "bindng_kit_box_barcode": "BKB1"
         },
         "relationships": {
           "pools": {

--- a/tests/data/updateRun.json
+++ b/tests/data/updateRun.json
@@ -8,7 +8,6 @@
       },
       "attributes": {
         "name": "Run0",
-        "binding_kit_box_barcode": "BKB0",
         "sequencing_kit_box_barcode": "SKB0",
         "dna_control_complex_box_barcode": "DCCB0",
         "system_name": "Sequel II",

--- a/tests/e2e/fixtures/tractionPacbioRun.json
+++ b/tests/e2e/fixtures/tractionPacbioRun.json
@@ -7,7 +7,6 @@
     },
     "attributes": {
       "name": "run1",
-      "binding_kit_box_barcode": "DM11171008622001117",
       "sequencing_kit_box_barcode": "DM000110086180012312",
       "dna_control_complex_box_barcode": "Lxxxxx10171760012319",
       "system_name": "Sequel II",

--- a/tests/e2e/fixtures/tractionPacbioRuns.json
+++ b/tests/e2e/fixtures/tractionPacbioRuns.json
@@ -8,7 +8,6 @@
       },
       "attributes": {
         "name": "Run1",
-        "binding_kit_box_barcode": "BKB1",
         "sequencing_kit_box_barcode": "SKB1",
         "dna_control_complex_box_barcode": "DCCB1",
         "system_name": "Sequel II",
@@ -34,7 +33,6 @@
       },
       "attributes": {
         "name": "Run2",
-        "binding_kit_box_barcode": "BKB2",
         "sequencing_kit_box_barcode": "SKB2",
         "dna_control_complex_box_barcode": "DCCB2",
         "system_name": "Sequel II",
@@ -60,7 +58,6 @@
       },
       "attributes": {
         "name": "Run3",
-        "binding_kit_box_barcode": "BKB3",
         "sequencing_kit_box_barcode": "SKB3",
         "dna_control_complex_box_barcode": "DCCB3",
         "system_name": "Sequel II",
@@ -86,7 +83,6 @@
       },
       "attributes": {
         "name": "Run4",
-        "binding_kit_box_barcode": "BKB4",
         "sequencing_kit_box_barcode": "SKB4",
         "dna_control_complex_box_barcode": "DCCB4",
         "system_name": "Sequel II",
@@ -112,7 +108,6 @@
       },
       "attributes": {
         "name": "Run5",
-        "binding_kit_box_barcode": "BKB5",
         "sequencing_kit_box_barcode": "SKB5",
         "dna_control_complex_box_barcode": "DCCB5",
         "system_name": "Sequel II",

--- a/tests/e2e/specs/pacbio_run_create.js
+++ b/tests/e2e/specs/pacbio_run_create.js
@@ -15,7 +15,6 @@ describe('Pacbio Run Create view', () => {
     cy.get('button')
       .contains('New Run')
       .click()
-    cy.get('#binding-kit-box-barcode').type('Lxxxxx101789500123199')
     cy.get('#sequencing-kit-box-barcode').type('Lxxxxx101826100123199')
     cy.get('#dna-control-complex-box-barcode').type('Lxxxxx101717600123199')
     cy.get('#system-name').select('Sequel IIe')

--- a/tests/e2e/specs/pacbio_run_create.js
+++ b/tests/e2e/specs/pacbio_run_create.js
@@ -37,6 +37,8 @@ describe('Pacbio Run Create view', () => {
       .type('10')
       .get('#generateHiFi')
       .select('Do Not Generate')
+      .get('#bindingKitBoxBarcode')
+      .type('12345')
       .get('button')
       .contains('Update')
       .click()

--- a/tests/e2e/specs/pacbio_runs_view.js
+++ b/tests/e2e/specs/pacbio_runs_view.js
@@ -16,7 +16,6 @@ describe('Pacbio Runs view', () => {
         cy.get('.run-id').should('have.length.greaterThan', 0)
         cy.get('.name').should('have.length.greaterThan', 0)
         cy.get('.state').should('have.length.greaterThan', 0)
-        cy.get('.binding-kit-box-barcode').should('have.length.greaterThan', 0)
         cy.get('.sequencing-kit-box-barcode').should('have.length.greaterThan', 0)
         cy.get('.dna-control-complex-box-barcode').should('have.length.greaterThan', 0)
         cy.get('.system-name').should('have.length.greaterThan', 0)

--- a/tests/unit/api/PacbioRun.spec.js
+++ b/tests/unit/api/PacbioRun.spec.js
@@ -85,7 +85,7 @@ describe('Run', () => {
     let well
 
     beforeEach(() => {
-      well = Run.buildWell('A', 1, 'In SMRT Link')
+      well = Run.buildWell('A', 1, 'In SMRT Link', '12345')
     })
 
     it('will have the correct data', () => {
@@ -100,12 +100,13 @@ describe('Run', () => {
       expect(well.generate_hifi).toEqual('In SMRT Link')
       expect(well.pre_extension_time).toEqual(2)
       expect(well.ccs_analysis_output).toEqual('Yes')
-      expect(well.binding_kit_box_barcode).toEqual('')
+      expect(well.binding_kit_box_barcode).toEqual('12345')
     })
 
     it('will have the correct data when passed values', () => {
-      well = Run.buildWell('A', 1, 'In SMRT Link', 1, 'No')
+      well = Run.buildWell('A', 1, 'In SMRT Link', '12345', 1, 'No')
       expect(well.generate_hifi).toEqual('In SMRT Link')
+      expect(well.binding_kit_box_barcode).toEqual('12345')
       expect(well.pre_extension_time).toEqual(1)
       expect(well.ccs_analysis_output).toEqual('No')
     })

--- a/tests/unit/api/PacbioRun.spec.js
+++ b/tests/unit/api/PacbioRun.spec.js
@@ -42,10 +42,6 @@ describe('Run', () => {
         expect(run.id).toEqual('new')
       })
 
-      it('will have an binding_kit_box_barcode', () => {
-        expect(run.binding_kit_box_barcode).toBeDefined()
-      })
-
       it('will have an sequencing_kit_box_barcode', () => {
         expect(run.sequencing_kit_box_barcode).toBeDefined()
       })
@@ -104,6 +100,7 @@ describe('Run', () => {
       expect(well.generate_hifi).toEqual('In SMRT Link')
       expect(well.pre_extension_time).toEqual(2)
       expect(well.ccs_analysis_output).toEqual('Yes')
+      expect(well.binding_kit_box_barcode).toEqual('')
     })
 
     it('will have the correct data when passed values', () => {
@@ -267,7 +264,6 @@ describe('Run', () => {
       let result = Run.createRunPayload(run)
 
       expect(result.data.type).toEqual('runs')
-      expect(result.data.attributes.binding_kit_box_barcode).toEqual(run.binding_kit_box_barcode)
       expect(result.data.attributes.sequencing_kit_box_barcode).toEqual(
         run.sequencing_kit_box_barcode,
       )
@@ -320,6 +316,9 @@ describe('Run', () => {
       )
       expect(result.data.attributes.wells[0].ccs_analysis_output).toEqual(
         wells[0].ccs_analysis_output,
+      )
+      expect(result.data.attributes.wells[0].binding_kit_box_barcode).toEqual(
+        wells[0].binding_kit_box_barcode,
       )
       expect(result.data.attributes.wells[0].relationships.plate.data.type).toEqual('plates')
       expect(result.data.attributes.wells[0].relationships.plate.data.id).toEqual(plateID)
@@ -459,7 +458,6 @@ describe('Run', () => {
 
       expect(result.data.id).toEqual(run.id)
       expect(result.data.type).toEqual('runs')
-      expect(result.data.attributes.binding_kit_box_barcode).toEqual(run.binding_kit_box_barcode)
       expect(result.data.attributes.sequencing_kit_box_barcode).toEqual(
         run.sequencing_kit_box_barcode,
       )
@@ -494,7 +492,7 @@ describe('Run', () => {
       expect(result.data.attributes.generate_hifi).toEqual(well.generate_hifi)
       expect(result.data.attributes.ccs_analysis_output).toEqual(well.ccs_analysis_output)
       expect(result.data.attributes.pre_extension_time).toEqual(well.pre_extension_time)
-      expect(result.data.attributes.ccs_analysis_output).toEqual(well.ccs_analysis_output)
+      expect(result.data.attributes.binding_kit_box_barcode).toEqual(well.binding_kit_box_barcode)
       expect(result.data.relationships.pools.data[0].type).toEqual('pools')
       expect(result.data.relationships.pools.data[0].id).toEqual(well.pools[0].id)
     })

--- a/tests/unit/components/pacbio/PacbioRunInfoEdit.spec.js
+++ b/tests/unit/components/pacbio/PacbioRunInfoEdit.spec.js
@@ -57,6 +57,9 @@ describe('PacbioRunInfoEdit', () => {
     it('has a Comments input', () => {
       expect(wrapper.find('#comments')).toBeDefined()
     })
+    it('has a Default Binding Kit Box Barcode input', () => {
+      expect(wrapper.find('#default-binding-kit-box-barcode')).toBeDefined()
+    })
   })
 
   afterEach(() => {

--- a/tests/unit/components/pacbio/PacbioRunInfoEdit.spec.js
+++ b/tests/unit/components/pacbio/PacbioRunInfoEdit.spec.js
@@ -21,7 +21,6 @@ describe('PacbioRunInfoEdit', () => {
   })
 
   it('can have mapState', () => {
-    expect(runInfo.bindingKitBoxBarcode).toBeDefined()
     expect(runInfo.sequencingKitBoxBarcode).toBeDefined()
     expect(runInfo.dnaControlComplexBoxBarcode).toBeDefined()
     expect(runInfo.comments).toBeDefined()
@@ -45,9 +44,6 @@ describe('PacbioRunInfoEdit', () => {
     it('Run name should be read only', () => {
       let input = wrapper.find('#run-name')
       expect(input.attributes('readonly')).toBeTruthy()
-    })
-    it('has a Binding Kit Box Barcode input', () => {
-      expect(wrapper.find('#binding-kit-box-barcode')).toBeDefined()
     })
     it('has a Sequencing Kit Box Barcode input', () => {
       expect(wrapper.find('#sequencing-kit-box-barcode')).toBeDefined()

--- a/tests/unit/components/pacbio/PacbioRunWellEdit.spec.js
+++ b/tests/unit/components/pacbio/PacbioRunWellEdit.spec.js
@@ -70,6 +70,7 @@ describe('PacbioWellModal', () => {
     expect(modal.ccsAnalysisOutput).toBeDefined()
     expect(modal.preExtensionTime).toBeDefined()
     expect(modal.ccsAnalysisOutput).toBeDefined()
+    expect(modal.bindingKitBoxBarcode).toBeDefined()
   })
 
   it('can have getters', () => {
@@ -102,8 +103,8 @@ describe('PacbioWellModal', () => {
     it('has a pre-extension time input', () => {
       expect(wrapper.find('.preExtensionTime')).toBeDefined()
     })
-    it('has a ccsAnalysisOutput', () => {
-      expect(wrapper.find('.ccsAnalysisOutput')).toBeDefined()
+    it('has a bindingKitBoxBarcode', () => {
+      expect(wrapper.find('.bindingKitBoxBarcode')).toBeDefined()
     })
   })
 
@@ -191,6 +192,15 @@ describe('PacbioWellModal', () => {
         position: props.position,
         property: 'pre_extension_time',
         with: '2',
+      })
+    })
+
+    it('updateBindingKitBoxBarcode', () => {
+      modal.updateBindingKitBoxBarcode('12345')
+      expect(modal.mutateWell).toBeCalledWith({
+        position: props.position,
+        property: 'binding_kit_box_barcode',
+        with: '12345',
       })
     })
 

--- a/tests/unit/components/pacbio/PacbioRunWellItem.spec.js
+++ b/tests/unit/components/pacbio/PacbioRunWellItem.spec.js
@@ -24,6 +24,7 @@ describe('Well.vue', () => {
     storeWell.insert_size = 123
     storeWell.on_plate_loading_concentration = 234
     storeWell.generate_hifi = 'In SMRT Link'
+    storeWell.binding_kit_box_barcode = '12345'
 
     run = Run.build()
     run.plate.wells[0] = storeWell
@@ -79,6 +80,7 @@ describe('Well.vue', () => {
       'movie_time',
       'insert_size',
       'on_plate_loading_concentration',
+      'binding_kit_box_barcode',
     ])
   })
 
@@ -146,6 +148,7 @@ describe('Well.vue', () => {
       storeWell.on_plate_loading_concentration = ''
       storeWell.insert_size = ''
       storeWell.pre_extension_time = ''
+      storeWell.binding_kit_box_barcode = ''
 
       wrapper = mount(Well, {
         localVue,

--- a/tests/unit/components/pacbio/PacbioRunWellItem.spec.js
+++ b/tests/unit/components/pacbio/PacbioRunWellItem.spec.js
@@ -81,6 +81,7 @@ describe('Well.vue', () => {
       'insert_size',
       'on_plate_loading_concentration',
       'binding_kit_box_barcode',
+      'generate_hifi',
     ])
   })
 

--- a/tests/unit/store/traction/pacbio/runs/mutations.spec.js
+++ b/tests/unit/store/traction/pacbio/runs/mutations.spec.js
@@ -39,6 +39,7 @@ describe('createWell', () => {
     run = Run.build()
     run.plate.wells = []
     run.system_name = 'Sequel I'
+    run.default_binding_kit_box_barcode = 'default'
     state = { currentRun: run }
   })
 
@@ -51,6 +52,19 @@ describe('createWell', () => {
       expect(well).toBeDefined()
       expect(well.position).toEqual(position)
       expect(well.generate_hifi).toEqual('In SMRT Link')
+      expect(well.binding_kit_box_barcode).toEqual('default')
+    })
+  })
+
+  describe('well binding kit box barcode is defaulted as "" when no value is passed', () => {
+    it('creates the well', () => {
+      position = 'A10'
+      delete state.currentRun.default_binding_kit_box_barcode
+      Mutations.createWell(state, position)
+
+      let well = state.currentRun.plate.wells.find((well) => well.position === position)
+      expect(well).toBeDefined()
+      expect(well.binding_kit_box_barcode).toEqual('')
     })
   })
 })

--- a/tests/unit/views/pacbio/PacbioRunShow.spec.js
+++ b/tests/unit/views/pacbio/PacbioRunShow.spec.js
@@ -8,7 +8,6 @@ describe('Run.vue', () => {
     mockRun = {
       id: '1',
       name: '',
-      binding_kit_box_barcode: '',
       sequencing_kit_box_barcode: '',
       dna_control_complex_box_barcode: '',
       comments: '',


### PR DESCRIPTION
Closes #

Changes proposed in this pull request:

* removed binding kit box barcode from run views and added to well edit
* add field at top of pacbio run to set a default binding kit box barcode for wells

