### PR TITLE
Bug library creation from sample

### DIFF
--- a/src/components/pacbio/PacbioLibraryCreate.vue
+++ b/src/components/pacbio/PacbioLibraryCreate.vue
@@ -70,7 +70,7 @@
         >
           <b-form-input
             id="library-templatePrepKitBoxBarcode"
-            v-model="library.templatePrepKitBoxBarcode"
+            v-model="library.template_prep_kit_box_barcode"
             type="text"
             required
             placeholder="Example: 012345678901234567890"
@@ -85,7 +85,7 @@
         >
           <b-form-input
             id="library-insertSize"
-            v-model="library.insertSize"
+            v-model="library.insert_size"
             type="number"
             required
             step="1"

--- a/src/components/pacbio/PacbioLibraryCreate.vue
+++ b/src/components/pacbio/PacbioLibraryCreate.vue
@@ -156,16 +156,12 @@ export default {
         return
       }
 
-      let response = await this.createLibraryInTraction(this.library)
-      if (response.successful) {
-        let barcodes = response.deserialize.libraries.map((l) => l.barcode)
+      const { success, barcode, errors } = await this.createLibraryInTraction(this.library)
+      if (success) {
         this.hide()
-        this.$emit('alert', 'Created library with barcode ' + barcodes[0], 'success')
+        this.$emit('alert', 'Created library with barcode ' + barcode, 'success')
       } else {
-        this.showAlert(
-          consts.MESSAGE_ERROR_CREATE_LIBRARY_FAILED + response.errors.message,
-          'danger',
-        )
+        this.showAlert(consts.MESSAGE_ERROR_CREATE_LIBRARY_FAILED + errors, 'danger')
       }
     },
     show() {

--- a/src/components/pacbio/PacbioLibraryEdit.vue
+++ b/src/components/pacbio/PacbioLibraryEdit.vue
@@ -61,11 +61,11 @@ export default {
   },
   methods: {
     async update() {
-      try {
-        await this.updateLibrary(this.library)
+      const { success, errors } = await this.updateLibrary(this.library)
+      if (success) {
         this.alert('Library updated', 'success')
-      } catch (err) {
-        this.alert('Failed to update library. ' + err, 'danger')
+      } else {
+        this.alert('Failed to update library. ' + errors, 'danger')
       }
       this.hide()
     },

--- a/src/store/traction/pacbio/libraries/actions.js
+++ b/src/store/traction/pacbio/libraries/actions.js
@@ -14,17 +14,17 @@ const createLibraryInTraction = async ({ rootState, rootGetters }, library) => {
         library_attributes: [
           {
             pacbio_request_id: library.sample.id,
-            template_prep_kit_box_barcode: library.templatePrepKitBoxBarcode,
+            template_prep_kit_box_barcode: library.template_prep_kit_box_barcode,
             tag_id,
             volume: library.volume,
             concentration: library.concentration,
-            insert_size: library.insertSize,
+            insert_size: library.insert_size,
           },
         ],
-        template_prep_kit_box_barcode: library.templatePrepKitBoxBarcode,
+        template_prep_kit_box_barcode: library.template_prep_kit_box_barcode,
         volume: library.volume,
         concentration: library.concentration,
-        insert_size: library.insertSize,
+        insert_size: library.insert_size,
       },
     },
   }
@@ -93,27 +93,41 @@ const updateTag = async ({ getters }, payload) => {
 
 const updateLibrary = async ({ commit, getters }, payload) => {
   let body = {
-    data: {
-      id: payload.id,
-      type: 'libraries',
-      attributes: {
-        volume: payload.volume,
-        concentration: payload.concentration,
-        template_prep_kit_box_barcode: payload.template_prep_kit_box_barcode,
-        insert_size: payload.insert_size,
-      },
+    id: payload.id,
+    type: 'libraries',
+    attributes: {
+      volume: payload.volume,
+      concentration: payload.concentration,
+      template_prep_kit_box_barcode: payload.template_prep_kit_box_barcode,
+      insert_size: payload.insert_size,
     },
   }
+  const req = getters.libraryRequest
+  const promise = req.update({ data: body, include: 'request,tag,tube,pool' })
+  const { success, data: { data = {}, included = [] } = {}, errors } = await handleResponse(promise)
+  const {
+    tubes: [tube = {}] = [],
+    requests: [request = {}] = [],
+    tags: [tag = {}] = [],
+    pools: [pool = {}] = [],
+  } = groupIncludedByResource(included)
 
-  const request = getters.libraryRequest
-  const promise = request.update(body)
-  const response = await handlePromise(promise)
-
-  if (response.successful) {
-    let library = response.deserialize.libraries[0]
-    commit('updateLibrary', library)
+  if (success) {
+    // Formats returned data into correct structure for library store
+    const formattedLibrary = {
+      ...data.attributes,
+      id: data.id,
+      tag_group_id: tag.attributes.group_id,
+      sample_name: request.attributes.sample_name,
+      barcode: tube.attributes.barcode,
+      pool,
+      tag,
+      request,
+      tube,
+    }
+    commit('updateLibrary', formattedLibrary)
   }
-  return response
+  return { success, errors }
 }
 
 const actions = {

--- a/tests/data/tractionPacbioLibrary.json
+++ b/tests/data/tractionPacbioLibrary.json
@@ -6,27 +6,38 @@
         "type": "libraries",
         "attributes": {
           "state": "pending",
-          "barcode": "TRAC-16",
           "volume": 1.0,
           "concentration": 1.0,
           "template_prep_kit_box_barcode": "LK12345",
           "insert_size": 100,
           "created_at": "09/23/2019 11:18",
           "deactivated_at": null,
-          "sample_names": "4616STDY7535900,4616STDY7535900"
+          "source_identifier": "DN1:A1"
         },
         "relationships": {
-          "requests": {
-            "data": [
-              {
-                "type": "request_libraries",
-                "id": "1"
-              },
-              {
-                "type": "request_libraries",
-                "id": "6"
-              }
-            ]
+          "request": {
+            "data": {
+              "type": "requests",
+              "id": "1"
+            }
+          },
+          "pool": {
+            "data": {
+              "type": "pools",
+              "id": "2"
+            }
+          },
+          "tag": {
+            "data": {
+              "type": "tags",
+              "id": "3"
+            }
+          },
+          "tube": {
+            "data": {
+              "type": "tubes",
+              "id": "4"
+            }
           }
         }
       }
@@ -34,24 +45,33 @@
     "included": [
       {
         "id": "1",
-        "type": "request_libraries",
+        "type": "requests",
         "attributes": {
-          "sample_name": "4616STDY7535900",
-          "tag_oligo": "ATGC",
-          "tag_group_id": 1,
-          "tag_set_name": "pacbio",
-          "tag_id": 1
+          "sample_name": "4616STDY7535900"
         }
       },
       {
-        "id": "6",
-        "type": "request_libraries",
+        "id": "2",
+        "type": "pools",
         "attributes": {
-          "sample_name": "4616STDY7535900",
-          "tag_oligo": "CGTA",
-          "tag_group_id": 1,
-          "tag_set_name": "pacbio",
-          "tag_id": 2
+          "volume": 1.0,
+          "concentration": 1.0,
+          "template_prep_kit_box_barcode": "LK12345",
+          "insert_size": 100
+        }
+      },
+      {
+        "id": "3",
+        "type": "tags",
+        "attributes": {
+          "group_id": "1234"
+        }
+      },
+      {
+        "id": "4",
+        "type": "tubes",
+        "attributes": {
+          "sample_name": "TRAC-16"
         }
       }
     ]

--- a/tests/e2e/specs/create_pacbio_library_from_samples_page.js
+++ b/tests/e2e/specs/create_pacbio_library_from_samples_page.js
@@ -6,8 +6,8 @@ describe('Pacbio library creation from sample', () => {
     cy.intercept('/v1/tags', {
       fixture: 'tractionTags.json',
     })
-    cy.intercept('/v1/pacbio/libraries', {
-      fixture: 'tractionPacbioLibraries.json',
+    cy.intercept('/v1/pacbio/pools?include=tube', {
+      fixture: 'tractionPacbioPool.json',
     })
     cy.visit('#/pacbio/samples')
     cy.get('#samples-table').contains('td', '5')
@@ -21,6 +21,6 @@ describe('Pacbio library creation from sample', () => {
     cy.get('#library-templatePrepKitBoxBarcode').type('barcode')
     cy.get('#library-insertSize').type(1)
     cy.get('#create-btn').click()
-    cy.contains('Created library with barcode')
+    cy.contains('Created library with barcode TRAC-2-1465')
   })
 })

--- a/tests/unit/components/pacbio/PacbioLibraryCreate.spec.js
+++ b/tests/unit/components/pacbio/PacbioLibraryCreate.spec.js
@@ -1,6 +1,5 @@
-import { mount, localVue, store, Data } from 'testHelper'
+import { mount, localVue, store } from 'testHelper'
 import PacbioLibraryCreate from '@/components/pacbio/PacbioLibraryCreate'
-import Response from '@/api/Response'
 import * as consts from '@/consts/consts'
 
 describe('PacbioLibraryCreate.vue', () => {
@@ -60,7 +59,7 @@ describe('PacbioLibraryCreate.vue', () => {
 
     it('is successful', async () => {
       wrapper.setData({ library: { tag: { group_id: 1 }, sample: { id: 1 } } })
-      let expectedResponse = new Response(Data.Libraries)
+      let expectedResponse = { success: true, barcode: 'TRAC-1', errors: [] }
       modal.createLibraryInTraction.mockReturnValue(expectedResponse)
 
       await modal.createLibrary()
@@ -82,13 +81,7 @@ describe('PacbioLibraryCreate.vue', () => {
     it('shows a error message on failure', async () => {
       wrapper.setData({ library: { tag: { group_id: 1 }, sample: { id: 1 } } })
 
-      let failedResponse = {
-        status: 422,
-        statusText: 'Unprocessable Entity',
-        data: { errors: { it: ['did not work'] } },
-      }
-      let expectedResponse = new Response(failedResponse)
-
+      let expectedResponse = { success: false, barcode: '', errors: ['it did not work'] }
       modal.createLibraryInTraction.mockReturnValue(expectedResponse)
 
       await modal.createLibrary()

--- a/tests/unit/components/pacbio/PacbioLibraryEdit.spec.js
+++ b/tests/unit/components/pacbio/PacbioLibraryEdit.spec.js
@@ -37,21 +37,16 @@ describe('PacbioLibraryEdit.vue', () => {
     })
 
     it('successful ', async () => {
-      modal.updateLibrary.mockReturnValue(true)
+      modal.updateLibrary.mockReturnValue({ success: true, errors: [] })
       await modal.update()
       expect(modal.alert).toBeCalledWith('Library updated', 'success')
       expect(modal.hide).toBeCalled()
     })
 
     it('unsuccessful ', async () => {
-      modal.updateLibrary.mockImplementation(() => {
-        throw Error('Raise this error')
-      })
+      modal.updateLibrary.mockReturnValue({ success: false, errors: ['Raise this error'] })
       await modal.update()
-      expect(modal.alert).toBeCalledWith(
-        'Failed to update library. Error: Raise this error',
-        'danger',
-      )
+      expect(modal.alert).toBeCalledWith('Failed to update library. Raise this error', 'danger')
       expect(modal.hide).toBeCalled()
     })
   })


### PR DESCRIPTION
Closes #

Changes proposed in this pull request:

* Update library from library page is now working
* Creating a library from samples page now creates a single plexed pool via the pool endpoint instead of going through the library end point


Note: 
Went down a bit of a rabbit hole with this one, but had to call it as this work is not priority.

We need to think about how we deal with single plexed pools:
- if you delete a library from a single plexed pool on the libraries page it will delete the library within the pool and not the pool itself. You then end up with empty pools in the pools tab. You might be able to solve this by adding a conditional to library deletion where if library is only library in pool then delete pool aswell. 
- Similar thing to above with updating a library, if you update a library from a single plexed pool you only update the concentration, volume, insert size and temp...barcode for the library not the pool. This can result in incorrect values down the line.