### PR TITLE
GPL-878-26 BUG - Pool/new page now clears all previous data when loaded

### DIFF
--- a/src/components/InfoFooter.vue
+++ b/src/components/InfoFooter.vue
@@ -32,6 +32,7 @@ export default {
       environment: process.env.NODE_ENV,
       repo: '',
       linkSlice: 51, //length needed for to slice github URL down to release name
+      defaultRelease: 'https://github.com/sanger/traction-ui/releases',
     }
   },
   created() {
@@ -39,25 +40,24 @@ export default {
   },
   methods: {
     getRelease() {
-      if (this.environment != 'development') {
+      if (this.repo != this.defaultRelease) {
         return this.repo.slice(this.linkSlice, this.repo.length)
       } else {
         return 'Releases'
       }
     },
     async provider() {
-      if (this.environment != 'development') {
-        try {
-          await fetch('REPO')
-            .then((response) => response.text())
-            .then((response1) => {
-              this.repo = response1
-            })
-        } catch (err) {
-          console.error(err)
-        }
-      } else {
-        this.repo = 'https://github.com/sanger/traction-ui/releases'
+      try {
+        await fetch('REPO')
+          .then((response) => response.text())
+          .then((response1) => {
+            // Checks returned text contains REPO text as fetch returns index.html if REPO doesn't exist
+            response1.includes('github.com/sanger/traction-ui/releases')
+              ? (this.repo = response1)
+              : (this.repo = this.defaultRelease)
+          })
+      } catch (err) {
+        console.error(err)
       }
     },
   },

--- a/src/store/traction/pacbio/poolCreate/mutations.js
+++ b/src/store/traction/pacbio/poolCreate/mutations.js
@@ -112,12 +112,12 @@ export default {
   },
   // This method clears the editable data in the pool/new page
   clearPoolData: (state) => {
-    ;(state.libraries = {}),
-      (state.pool = {}),
-      (state.tube = {}),
-      (state.selected = {
-        tagSet: {},
-        plates: {},
-      })
+    state.libraries = {}
+    state.pool = {}
+    state.tube = {}
+    state.selected = {
+      tagSet: {},
+      plates: {},
+    }
   },
 }

--- a/src/store/traction/pacbio/poolCreate/mutations.js
+++ b/src/store/traction/pacbio/poolCreate/mutations.js
@@ -110,4 +110,14 @@ export default {
       ...attributes,
     }
   },
+  // This method clears the editable data in the pool/new page
+  clearPoolData: (state) => {
+    ;(state.libraries = {}),
+      (state.pool = {}),
+      (state.tube = {}),
+      (state.selected = {
+        tagSet: {},
+        plates: {},
+      })
+  },
 }

--- a/src/views/pacbio/PacbioPoolCreate.vue
+++ b/src/views/pacbio/PacbioPoolCreate.vue
@@ -45,6 +45,8 @@ export default {
   created() {
     const plates = this.fetchPacbioPlates()
     const tagSets = this.fetchPacbioTagSets()
+    // Needed due to left over pool data from previously edited pools
+    this.$store.commit('traction/pacbio/poolCreate/clearPoolData')
 
     if (this.$route.params.id !== 'new') {
       const libraries = this.populateLibrariesFromPool(this.$route.params.id)

--- a/tests/unit/components/InfoFooter.spec.js
+++ b/tests/unit/components/InfoFooter.spec.js
@@ -29,4 +29,18 @@ describe('InfoFooter.vue', () => {
     wrapper.setData({ repo: 'trac-ui' })
     expect(wrapper.vm.repo).toBe('trac-ui')
   })
+
+  describe('getRelease method', () => {
+    it('returns "Releases" when repo equals default release', () => {
+      let defaultRelease = 'https://github.com/sanger/traction-ui/releases'
+      wrapper.setData({ repo: defaultRelease })
+      expect(wrapper.vm.getRelease()).toEqual('Releases')
+    })
+
+    it('returns a sliced version of repo when repo doesnt equal default release', () => {
+      let exampleRelease = 'https://github.com/sanger/traction-ui/releases/tag/12345'
+      wrapper.setData({ repo: exampleRelease })
+      expect(wrapper.vm.getRelease()).toEqual('12345')
+    })
+  })
 })

--- a/tests/unit/store/traction/pacbio/poolCreate/mutations.spec.js
+++ b/tests/unit/store/traction/pacbio/poolCreate/mutations.spec.js
@@ -16,6 +16,7 @@ describe('mutations.js', () => {
     populateLibraries,
     populatePoolAttributes,
     populateTube,
+    clearPoolData,
   } = mutations
 
   describe('selectPlate', () => {
@@ -273,29 +274,49 @@ describe('mutations.js', () => {
   })
 
   describe('populatePoolAttributes', () => {
-    const state = defaultState()
-    // apply mutation
-    populatePoolAttributes(state, Data.TractionPacbioPool.data.data)
-    expect(state.pool).toEqual(
-      expect.objectContaining({
-        id: '242',
-        volume: 1.0,
-        concentration: 1.0,
-        template_prep_kit_box_barcode: '2424',
-        insert_size: 1,
-        source_identifier: 'DN1:A4',
-      }),
-    )
+    it('sets the pool with the correct data', () => {
+      const state = defaultState()
+      // apply mutation
+      populatePoolAttributes(state, Data.TractionPacbioPool.data.data)
+      expect(state.pool).toEqual(
+        expect.objectContaining({
+          id: '242',
+          volume: 1.0,
+          concentration: 1.0,
+          template_prep_kit_box_barcode: '2424',
+          insert_size: 1,
+          source_identifier: 'DN1:A4',
+        }),
+      )
+    })
   })
 
-  it('populateTube', () => {
-    const tube = { id: 1, attributes: { barcode: 'TRAC-1' } }
-    const state = defaultState()
-    //apply mutation
-    populateTube(state, tube)
-    expect(state.tube).toEqual({
-      id: 1,
-      barcode: 'TRAC-1',
+  describe('populateTube', () => {
+    it('sets the tube with the correct data', () => {
+      const tube = { id: 1, attributes: { barcode: 'TRAC-1' } }
+      const state = defaultState()
+      //apply mutation
+      populateTube(state, tube)
+      expect(state.tube).toEqual({
+        id: 1,
+        barcode: 'TRAC-1',
+      })
+    })
+  })
+
+  describe('clearPoolData', () => {
+    it('clears existing pool data', () => {
+      const state = defaultState()
+      // populates an existing pool into state
+      populatePoolAttributes(state, Data.TractionPacbioPool.data.data)
+      clearPoolData(state)
+      expect(state.selected).toEqual({
+        tagSet: {},
+        plates: {},
+      })
+      expect(state.libraries).toEqual({})
+      expect(state.pool).toEqual({})
+      expect(state.tube).toEqual({})
     })
   })
 })


### PR DESCRIPTION
Closes #658 

Changes proposed in this pull request:

* When navigating to pool/new it clears data from previous pools
* Footer cleaned up and fixed for e2e tests
