### PR TITLE
Fix jumpy scrolling when adding wells

### DIFF
--- a/src/components/pacbio/PacbioPoolEdit.vue
+++ b/src/components/pacbio/PacbioPoolEdit.vue
@@ -196,4 +196,16 @@ export default {
 .template-prep-kit-box-barcode {
   width: 120px;
 }
+
+.col {
+  // See https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-anchor/Guide_to_scroll_anchoring
+  // When the DOM content changes, the browser uses a 'scroll-anchor' to try and
+  // prevent the viewport visibly jumping around as the DOM content re-renders.
+  // Under some circumstances, which I haven't been able to reproduce, the
+  // browser appears to use elements in this column as the anchor. This causes
+  // the page to track elements in this column as wells are added to the pool,
+  // making selection tricky. This CSS property *should* stop the browser using
+  // these elements as anchors.
+  overflow-anchor: none;
+}
 </style>


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-anchor/Guide_to_scroll_anchoring
When the DOM content changes, the browser uses a 'scroll-anchor' to try and
prevent the viewport visibly jumping around as the DOM content re-renders.
Under some circumstances, which I haven't been able to reproduce, the
browser appears to use elements in this column as the anchor. This causes
the page to track elements in this column as wells are added to the pool,
making selection tricky. This CSS property *should* stop the browser using
these elements as anchors.
