### PR TITLE
Issue715/dpl 273 allow import of tubes from ss for pacbio pipelines {m}

### DIFF
--- a/src/api/Config.json
+++ b/src/api/Config.json
@@ -108,6 +108,9 @@
     "resources": [
       {
         "name": "plates"
+      },
+      {
+        "name": "labware"
       }
     ]
   }

--- a/src/api/PromiseHelper.js
+++ b/src/api/PromiseHelper.js
@@ -1,5 +1,11 @@
 import Api from '@/api'
 
+/*
+ * Note: Please see handleResponse for updated handling of responses,
+ * this is a little more robust and handling the various server responses,
+ * and is less opinionated about how the returned data is handled.
+ */
+
 // promise - a promise object
 // return - a Api.Response object
 const handlePromise = async (promise) => {

--- a/src/api/ResponseHelper.js
+++ b/src/api/ResponseHelper.js
@@ -38,11 +38,11 @@ const parseErrorArray = (errors) =>
  * @param {Object} data e.g. { data: { id: 1}}
  * @returns { Boolean, {Object}, String} { success, data, errors } e.g. { success: true, data: {id: 1}} or {success: false, errors: 'there was an error'}
  */
-const newResponse = ({ success, data, error }) => ({
+const newResponse = ({ success, data, error, errors }) => ({
   success,
   data,
   // we need to parse the errors into something viewable
-  errors: !success ? parseErrors({ data, error }) : undefined,
+  errors: !success ? parseErrors({ data, error, errors }) : undefined,
 })
 
 /*
@@ -61,6 +61,7 @@ const handleResponse = async (promise) => {
     if (!!+process.env.VUE_APP_LOG) {
       console.error(error)
     }
+
     // 400-500 range will throw an error with a response
     if (error.response) {
       return newResponse({ success: false, ...error.response })

--- a/src/components/Message.vue
+++ b/src/components/Message.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <b-alert :variant="type" :data-type="dataType" dismissible show @dismissed="dismiss()">
+    <b-alert :variant="variant" :data-type="dataType" dismissible show @dismissed="dismiss()">
       {{ message }}
     </b-alert>
   </div>
@@ -24,6 +24,15 @@ export default {
     message: {
       type: String,
       required: true,
+    },
+  },
+  computed: {
+    variant() {
+      return (
+        {
+          error: 'danger',
+        }[this.type] || this.type
+      )
     },
   },
   methods: {

--- a/src/components/pacbio/PacbioPoolList.vue
+++ b/src/components/pacbio/PacbioPoolList.vue
@@ -40,7 +40,7 @@ export default {
 }
 </script>
 
-<style>
+<style scoped>
 .pools {
   border: solid;
   border-width: 1px;

--- a/src/config/PipelinesConfig.json
+++ b/src/config/PipelinesConfig.json
@@ -10,8 +10,8 @@
     "title": "PacBio",
     "description": "A LIMS pipeline to support tracking for PacBio Long-Read Sequencing",
     "routes": [
-      "reception",
-      "plate-reception",
+      "samples-extraction-reception",
+      "sequencescape-reception",
       "plates",
       "samples",
       "libraries",

--- a/src/router.js
+++ b/src/router.js
@@ -1,30 +1,30 @@
 // TODO: routes are not tested so cause errors on start
 import Vue from 'vue'
 import Router from 'vue-router'
-import Dashboard from './views/Dashboard'
-import PageNotFound from './views/PageNotFound'
-import Saphyr from './views/Saphyr'
-import SaphyrReception from './views/saphyr/SaphyrReception'
-import SaphyrSamples from './views/saphyr/SaphyrSamples'
-import SaphyrLibraries from './views/saphyr/SaphyrLibraries'
-import SaphyrRuns from './views/saphyr/SaphyrRuns'
-import SaphyrRun from './views/saphyr/SaphyrRun'
-import Pacbio from './views/Pacbio'
-import PacbioReceptionTube from './views/pacbio/PacbioReceptionTube'
-import PacbioPlateIndex from './views/pacbio/PacbioPlateIndex'
-import PacbioSampleIndex from './views/pacbio/PacbioSampleIndex'
-import PacbioLibraryIndex from './views/pacbio/PacbioLibraryIndex'
-import PacbioPoolIndex from './views/pacbio/PacbioPoolIndex'
-import PacbioRunIndex from './views/pacbio/PacbioRunIndex'
-import PacbioRunShow from './views/pacbio/PacbioRunShow'
-import ONT from './views/ONT'
-import OntReception from './views/ont/OntReception'
-import OntPlates from './views/ont/OntPlates'
-import OntLibraries from './views/ont/OntLibraries'
-import OntHeronRun from './views/ont/OntHeronRun'
-import OntHeronRuns from './views/ont/OntHeronRuns'
-import PacbioReceptionPlate from './views/pacbio/PacbioReceptionPlate'
-import PacbioPoolCreate from './views/pacbio/PacbioPoolCreate'
+import Dashboard from '@/views/Dashboard'
+import PageNotFound from '@/views/PageNotFound'
+import Saphyr from '@/views/Saphyr'
+import SaphyrReception from '@/views/saphyr/SaphyrReception'
+import SaphyrSamples from '@/views/saphyr/SaphyrSamples'
+import SaphyrLibraries from '@/views/saphyr/SaphyrLibraries'
+import SaphyrRuns from '@/views/saphyr/SaphyrRuns'
+import SaphyrRun from '@/views/saphyr/SaphyrRun'
+import Pacbio from '@/views/Pacbio'
+import PacbioReceptionSamplesExtraction from '@/views/pacbio/PacbioReceptionSamplesExtraction'
+import PacbioPlateIndex from '@/views/pacbio/PacbioPlateIndex'
+import PacbioSampleIndex from '@/views/pacbio/PacbioSampleIndex'
+import PacbioLibraryIndex from '@/views/pacbio/PacbioLibraryIndex'
+import PacbioPoolIndex from '@/views/pacbio/PacbioPoolIndex'
+import PacbioRunIndex from '@/views/pacbio/PacbioRunIndex'
+import PacbioRunShow from '@/views/pacbio/PacbioRunShow'
+import ONT from '@/views/ONT'
+import OntReception from '@/views/ont/OntReception'
+import OntPlates from '@/views/ont/OntPlates'
+import OntLibraries from '@/views/ont/OntLibraries'
+import OntHeronRun from '@/views/ont/OntHeronRun'
+import OntHeronRuns from '@/views/ont/OntHeronRuns'
+import PacbioReceptionSequencescape from '@/views/pacbio/PacbioReceptionSequencescape'
+import PacbioPoolCreate from '@/views/pacbio/PacbioPoolCreate'
 
 Vue.use(Router)
 
@@ -83,10 +83,10 @@ export default new Router({
       children: [
         { path: '', redirect: 'reception' },
         {
-          path: 'reception',
-          name: 'PacbioReceptionTube',
-          component: PacbioReceptionTube,
-          meta: { page: 'Tube Reception' },
+          path: 'samples-extraction-reception',
+          name: 'PacbioReceptionSamplesExtraction',
+          component: PacbioReceptionSamplesExtraction,
+          meta: { page: 'Samples Extraction Reception' },
         },
         {
           path: 'samples',
@@ -126,10 +126,10 @@ export default new Router({
           meta: { page: 'Run' },
         },
         {
-          path: 'plate-reception',
-          name: 'PacbioPlateReception',
-          component: PacbioReceptionPlate,
-          meta: { page: 'Plate Reception' },
+          path: 'sequencescape-reception',
+          name: 'PacbioReceptionSequencescape',
+          component: PacbioReceptionSequencescape,
+          meta: { page: 'Sequencescape Reception' },
         },
         {
           path: 'pool/:id',

--- a/src/services/Sequencescape.js
+++ b/src/services/Sequencescape.js
@@ -1,4 +1,6 @@
 import handlePromise from '@/api/PromiseHelper'
+import { handleResponse } from '@/api/ResponseHelper'
+import deserialize from '@/api/JsonApi'
 
 /*
   return a set of plates by their barcodes
@@ -12,12 +14,50 @@ const getPlates = async (request, barcodes) => {
     filter: { barcode: barcodes },
     include: 'wells.aliquots.sample.sample_metadata,wells.aliquots.study',
   })
+
   let response = await handlePromise(promise)
 
   if (response.successful && !response.empty) {
     plates = response.deserialize.plates
   }
   return plates
+}
+
+const extractBarcodes = ({ plates, tubes }) =>
+  [...plates, ...tubes].flatMap((labware) => Object.values(labware.labware_barcode))
+
+/*
+  return a set of labware by their barcodes
+  the request is an executable api call
+  the labware will be converted from json api to nested structure labware: { receptacles: ... }
+  an array will always be returned.
+*/
+const getLabware = async (request, barcodes) => {
+  const promise = request.get({
+    filter: { barcode: barcodes },
+    include: 'receptacles.aliquots.sample.sample_metadata,receptacles.aliquots.study',
+    fields: {
+      plates: 'labware_barcode,receptacles',
+      tubes: 'labware_barcode,receptacles',
+      wells: 'position,aliquots',
+      receptacles: 'aliquots',
+      samples: 'sample_metadata,name,uuid',
+      sample_metadata: 'sample_common_name',
+      studies: 'uuid',
+      aliquots: 'study,library_type,sample',
+    },
+  })
+
+  const { success, data } = await handleResponse(promise)
+
+  if (success) {
+    // If the response contains no plates or tubes, then the corresponding key
+    // will be missing. Here we provide a default of an empty array so that we
+    // may handle it downstream
+    return { plates: [], tubes: [], ...deserialize(data) }
+  } else {
+    return { plates: [], tubes: [] }
+  }
 }
 
 /*
@@ -28,6 +68,9 @@ const getPlates = async (request, barcodes) => {
 const transformPlates = ({ plates = [], sampleType = OntSample, libraryType = null } = {}) =>
   plates.map((plate) => transformPlate({ ...plate, sampleType, libraryType }))
 
+const transformTubes = ({ tubes = [], sampleType, libraryType } = {}) =>
+  tubes.map((tube) => transformTube({ ...tube, sampleType, libraryType }))
+
 /*
   extract the barcode and wells by destructuring
   then transform the wells into the correct format
@@ -35,12 +78,13 @@ const transformPlates = ({ plates = [], sampleType = OntSample, libraryType = nu
 const transformPlate = ({
   labware_barcode: { human_barcode: barcode },
   wells,
+  receptacles,
   sampleType,
   libraryType,
 }) => ({
   barcode,
   //destructure the wells to get the position and the first aliquot
-  wells: wells.map(({ position: { name: position }, aliquots: [aliquot] }) => {
+  wells: (wells || receptacles).map(({ position: { name: position }, aliquots: [aliquot] }) => {
     return {
       position,
       // we only want to transform the aliquot if it has got something in it
@@ -48,6 +92,30 @@ const transformPlate = ({
       samples: aliquot ? [sampleType(aliquot, libraryType)] : undefined,
     }
   }),
+})
+
+/*
+  Convert a tube to a traction request
+*/
+const transformTube = ({
+  labware_barcode: { machine_barcode: barcode },
+  receptacles: [
+    {
+      aliquots: [aliquot],
+    },
+  ],
+  libraryType,
+}) => ({
+  request: {
+    external_study_id: aliquot.study.uuid,
+    library_type: libraryType,
+  },
+  sample: {
+    name: aliquot.sample.name,
+    external_id: aliquot.sample.uuid,
+    species: aliquot.sample.sample_metadata.sample_common_name,
+  },
+  tube: { barcode },
 })
 
 /*
@@ -83,11 +151,22 @@ const PacbioSample = (aliquot, libraryType) => ({
 
 const Sequencescape = {
   transformPlates,
+  transformTubes,
+  getPlates,
+  getLabware,
+  OntSample,
+  PacbioSample,
+  extractBarcodes,
+}
+
+export {
+  transformPlates,
   getPlates,
   OntSample,
   PacbioSample,
+  getLabware,
+  extractBarcodes,
+  transformTubes,
 }
-
-export { transformPlates, getPlates, OntSample, PacbioSample }
 
 export default Sequencescape

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -32,9 +32,7 @@ import { humanise } from '@/lib/stringHumanisation'
 export default {
   name: 'Dashboard',
   computed: {
-    pipelines() {
-      return PipelinesConfig
-    },
+    pipelines: () => PipelinesConfig,
   },
   methods: {
     humanise,

--- a/src/views/pacbio/PacbioReceptionSamplesExtraction.vue
+++ b/src/views/pacbio/PacbioReceptionSamplesExtraction.vue
@@ -43,7 +43,7 @@ import { mapActions, mapState } from 'vuex'
 import LibraryTypeSelect from '@/components/shared/LibraryTypeSelect'
 
 export default {
-  name: 'Reception',
+  name: 'PacbioReceptionSamplesExtraction',
   components: {
     LibraryTypeSelect,
     Spinner,

--- a/src/views/pacbio/PacbioReceptionSequencescape.vue
+++ b/src/views/pacbio/PacbioReceptionSequencescape.vue
@@ -35,7 +35,7 @@
 <script>
 import Spinner from 'vue-simple-spinner'
 import Api from '@/mixins/Api'
-import { createPlates } from '@/services/traction/Pacbio'
+import { createLabware } from '@/services/traction/Pacbio'
 import LibraryTypeSelect from '@/components/shared/LibraryTypeSelect'
 
 export default {
@@ -49,8 +49,6 @@ export default {
     return {
       barcodes: '',
       busy: false,
-      alertMessage: '',
-      status: '',
       libraryType: undefined,
     }
   },
@@ -58,17 +56,14 @@ export default {
     barcodeArray() {
       return this.barcodes.split('\n').filter(Boolean)
     },
-    formattedBarcodes() {
-      return this.barcodeArray.join(',')
-    },
     isDisabled() {
       return this.barcodeArray.length === 0 || this.busy
     },
     sequencescapeRequest() {
-      return this.api.sequencescape.plates
+      return this.api.sequencescape.labware
     },
     tractionRequest() {
-      return this.api.traction.pacbio.plates
+      return this.api.traction.pacbio
     },
     requests() {
       return {
@@ -83,9 +78,9 @@ export default {
   methods: {
     async createTractionPlates() {
       this.busy = true
-      const response = await createPlates({
+      const response = await createLabware({
         requests: this.requests,
-        barcodes: this.formattedBarcodes,
+        barcodes: this.barcodeArray,
         libraryType: this.libraryType,
       })
       this.showAlert(response.message, response.status)

--- a/src/views/pacbio/PacbioReceptionSequencescape.vue
+++ b/src/views/pacbio/PacbioReceptionSequencescape.vue
@@ -39,7 +39,7 @@ import { createPlates } from '@/services/traction/Pacbio'
 import LibraryTypeSelect from '@/components/shared/LibraryTypeSelect'
 
 export default {
-  name: 'Reception',
+  name: 'PacbioReceptionSequencescape',
   components: {
     Spinner,
     LibraryTypeSelect,

--- a/src/views/pacbio/PacbioReceptionSequencescape.vue
+++ b/src/views/pacbio/PacbioReceptionSequencescape.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="reception">
     <b-modal v-model="busy" hide-footer hide-header no-close-on-backdrop>
-      <spinner size="huge" message="Importing plates..."></spinner>
+      <spinner size="huge" message="Importing labware..."></spinner>
     </b-modal>
     <div class="form-group">
       <label for="barcodes">Barcodes:</label>
@@ -25,7 +25,7 @@
           :disabled="isDisabled"
           @click="createTractionPlates"
         >
-          Import {{ plateCount }}
+          Import {{ barcodeCount }}
         </b-button>
       </b-col>
     </b-row>
@@ -76,12 +76,8 @@ export default {
         sequencescape: this.sequencescapeRequest,
       }
     },
-    plateCount() {
-      if (this.barcodeArray.length == 1) {
-        return '1 plate'
-      } else {
-        return `${this.barcodeArray.length} plates`
-      }
+    barcodeCount() {
+      return `${this.barcodeArray.length} labware`
     },
   },
   methods: {

--- a/tests/data/index.js
+++ b/tests/data/index.js
@@ -36,6 +36,7 @@ import PacbioWell from './pacbioWell'
 import PacbioWells from './pacbioWells'
 import PacbioWellLibrary from './pacbioWellLibrary'
 import TractionTags from './tractionTags'
+import SequencescapeLabware from './sequencescapeLabware'
 import SequencescapePlates from './sequencescapePlates'
 import TractionTubeWithContainerMaterials from './tractionTubeWithContainerMaterials'
 import TractionTubesWithPacbioPools from './tractionTubesWithPacbioPools'
@@ -81,6 +82,7 @@ export default {
   PacbioWells,
   PacbioWellLibrary,
   TractionTags,
+  SequencescapeLabware,
   SequencescapePlates,
   TractionTubeWithContainerMaterials,
   TractionTubesWithPacbioPools,

--- a/tests/data/sequencescapeLabware.json
+++ b/tests/data/sequencescapeLabware.json
@@ -1,0 +1,1742 @@
+{
+  "data": {
+    "data": [
+      {
+        "id": "2",
+        "type": "plates",
+        "links": { "self": "http://sequencescape/api/v2/plates/2" },
+        "attributes": {
+          "labware_barcode": {
+            "ean13_barcode": "1229000002657",
+            "machine_barcode": "DN9000002A",
+            "human_barcode": "DN9000002A"
+          }
+        },
+        "relationships": {
+          "receptacles": {
+            "links": {
+              "self": "http://sequencescape/api/v2/plates/2/relationships/receptacles",
+              "related": "http://sequencescape/api/v2/plates/2/receptacles"
+            },
+            "data": [
+              { "type": "wells", "id": "97" },
+              { "type": "wells", "id": "98" },
+              { "type": "wells", "id": "99" },
+              { "type": "wells", "id": "100" },
+              { "type": "wells", "id": "101" },
+              { "type": "wells", "id": "102" },
+              { "type": "wells", "id": "103" },
+              { "type": "wells", "id": "104" },
+              { "type": "wells", "id": "105" },
+              { "type": "wells", "id": "106" },
+              { "type": "wells", "id": "107" },
+              { "type": "wells", "id": "108" },
+              { "type": "wells", "id": "109" },
+              { "type": "wells", "id": "110" },
+              { "type": "wells", "id": "111" },
+              { "type": "wells", "id": "112" },
+              { "type": "wells", "id": "113" },
+              { "type": "wells", "id": "114" },
+              { "type": "wells", "id": "115" },
+              { "type": "wells", "id": "116" },
+              { "type": "wells", "id": "117" },
+              { "type": "wells", "id": "118" },
+              { "type": "wells", "id": "119" },
+              { "type": "wells", "id": "120" },
+              { "type": "wells", "id": "121" },
+              { "type": "wells", "id": "122" },
+              { "type": "wells", "id": "123" },
+              { "type": "wells", "id": "124" },
+              { "type": "wells", "id": "125" },
+              { "type": "wells", "id": "126" },
+              { "type": "wells", "id": "127" },
+              { "type": "wells", "id": "128" },
+              { "type": "wells", "id": "129" },
+              { "type": "wells", "id": "130" },
+              { "type": "wells", "id": "131" },
+              { "type": "wells", "id": "132" },
+              { "type": "wells", "id": "133" },
+              { "type": "wells", "id": "134" },
+              { "type": "wells", "id": "135" },
+              { "type": "wells", "id": "136" },
+              { "type": "wells", "id": "137" },
+              { "type": "wells", "id": "138" },
+              { "type": "wells", "id": "139" },
+              { "type": "wells", "id": "140" },
+              { "type": "wells", "id": "141" },
+              { "type": "wells", "id": "142" },
+              { "type": "wells", "id": "143" },
+              { "type": "wells", "id": "144" },
+              { "type": "wells", "id": "145" },
+              { "type": "wells", "id": "146" },
+              { "type": "wells", "id": "147" },
+              { "type": "wells", "id": "148" },
+              { "type": "wells", "id": "149" },
+              { "type": "wells", "id": "150" },
+              { "type": "wells", "id": "151" },
+              { "type": "wells", "id": "152" },
+              { "type": "wells", "id": "153" },
+              { "type": "wells", "id": "154" },
+              { "type": "wells", "id": "155" },
+              { "type": "wells", "id": "156" },
+              { "type": "wells", "id": "157" },
+              { "type": "wells", "id": "158" },
+              { "type": "wells", "id": "159" },
+              { "type": "wells", "id": "160" },
+              { "type": "wells", "id": "161" },
+              { "type": "wells", "id": "162" },
+              { "type": "wells", "id": "163" },
+              { "type": "wells", "id": "164" },
+              { "type": "wells", "id": "165" },
+              { "type": "wells", "id": "166" },
+              { "type": "wells", "id": "167" },
+              { "type": "wells", "id": "168" },
+              { "type": "wells", "id": "169" },
+              { "type": "wells", "id": "170" },
+              { "type": "wells", "id": "171" },
+              { "type": "wells", "id": "172" },
+              { "type": "wells", "id": "173" },
+              { "type": "wells", "id": "174" },
+              { "type": "wells", "id": "175" },
+              { "type": "wells", "id": "176" },
+              { "type": "wells", "id": "177" },
+              { "type": "wells", "id": "178" },
+              { "type": "wells", "id": "179" },
+              { "type": "wells", "id": "180" },
+              { "type": "wells", "id": "181" },
+              { "type": "wells", "id": "182" },
+              { "type": "wells", "id": "183" },
+              { "type": "wells", "id": "184" },
+              { "type": "wells", "id": "185" },
+              { "type": "wells", "id": "186" },
+              { "type": "wells", "id": "187" },
+              { "type": "wells", "id": "188" },
+              { "type": "wells", "id": "189" },
+              { "type": "wells", "id": "190" },
+              { "type": "wells", "id": "191" },
+              { "type": "wells", "id": "192" }
+            ]
+          }
+        }
+      },
+      {
+        "id": "3",
+        "type": "tubes",
+        "links": { "self": "http://sequencescape/api/v2/tubes/3" },
+        "attributes": {
+          "labware_barcode": {
+            "ean13_barcode": "3980000001795",
+            "machine_barcode": "3980000001795",
+            "human_barcode": "NT1O"
+          }
+        },
+        "relationships": {
+          "receptacles": {
+            "links": {
+              "self": "http://sequencescape/api/v2/tubes/3/relationships/receptacles",
+              "related": "http://sequencescape/api/v2/tubes/3/receptacles"
+            },
+            "data": [{ "type": "receptacles", "id": "193" }]
+          }
+        }
+      }
+    ],
+    "included": [
+      {
+        "id": "97",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/97" },
+        "attributes": { "position": { "name": "A1" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/97/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/97/aliquots"
+            },
+            "data": [{ "type": "aliquots", "id": "97" }]
+          }
+        }
+      },
+      {
+        "id": "98",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/98" },
+        "attributes": { "position": { "name": "B1" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/98/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/98/aliquots"
+            },
+            "data": [{ "type": "aliquots", "id": "98" }]
+          }
+        }
+      },
+      {
+        "id": "99",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/99" },
+        "attributes": { "position": { "name": "C1" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/99/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/99/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "100",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/100" },
+        "attributes": { "position": { "name": "D1" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/100/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/100/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "101",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/101" },
+        "attributes": { "position": { "name": "E1" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/101/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/101/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "102",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/102" },
+        "attributes": { "position": { "name": "F1" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/102/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/102/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "103",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/103" },
+        "attributes": { "position": { "name": "G1" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/103/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/103/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "104",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/104" },
+        "attributes": { "position": { "name": "H1" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/104/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/104/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "105",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/105" },
+        "attributes": { "position": { "name": "A2" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/105/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/105/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "106",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/106" },
+        "attributes": { "position": { "name": "B2" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/106/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/106/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "107",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/107" },
+        "attributes": { "position": { "name": "C2" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/107/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/107/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "108",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/108" },
+        "attributes": { "position": { "name": "D2" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/108/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/108/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "109",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/109" },
+        "attributes": { "position": { "name": "E2" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/109/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/109/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "110",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/110" },
+        "attributes": { "position": { "name": "F2" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/110/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/110/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "111",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/111" },
+        "attributes": { "position": { "name": "G2" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/111/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/111/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "112",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/112" },
+        "attributes": { "position": { "name": "H2" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/112/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/112/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "113",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/113" },
+        "attributes": { "position": { "name": "A3" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/113/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/113/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "114",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/114" },
+        "attributes": { "position": { "name": "B3" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/114/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/114/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "115",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/115" },
+        "attributes": { "position": { "name": "C3" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/115/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/115/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "116",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/116" },
+        "attributes": { "position": { "name": "D3" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/116/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/116/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "117",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/117" },
+        "attributes": { "position": { "name": "E3" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/117/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/117/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "118",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/118" },
+        "attributes": { "position": { "name": "F3" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/118/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/118/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "119",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/119" },
+        "attributes": { "position": { "name": "G3" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/119/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/119/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "120",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/120" },
+        "attributes": { "position": { "name": "H3" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/120/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/120/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "121",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/121" },
+        "attributes": { "position": { "name": "A4" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/121/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/121/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "122",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/122" },
+        "attributes": { "position": { "name": "B4" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/122/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/122/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "123",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/123" },
+        "attributes": { "position": { "name": "C4" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/123/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/123/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "124",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/124" },
+        "attributes": { "position": { "name": "D4" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/124/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/124/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "125",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/125" },
+        "attributes": { "position": { "name": "E4" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/125/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/125/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "126",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/126" },
+        "attributes": { "position": { "name": "F4" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/126/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/126/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "127",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/127" },
+        "attributes": { "position": { "name": "G4" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/127/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/127/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "128",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/128" },
+        "attributes": { "position": { "name": "H4" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/128/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/128/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "129",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/129" },
+        "attributes": { "position": { "name": "A5" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/129/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/129/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "130",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/130" },
+        "attributes": { "position": { "name": "B5" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/130/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/130/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "131",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/131" },
+        "attributes": { "position": { "name": "C5" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/131/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/131/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "132",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/132" },
+        "attributes": { "position": { "name": "D5" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/132/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/132/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "133",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/133" },
+        "attributes": { "position": { "name": "E5" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/133/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/133/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "134",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/134" },
+        "attributes": { "position": { "name": "F5" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/134/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/134/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "135",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/135" },
+        "attributes": { "position": { "name": "G5" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/135/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/135/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "136",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/136" },
+        "attributes": { "position": { "name": "H5" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/136/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/136/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "137",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/137" },
+        "attributes": { "position": { "name": "A6" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/137/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/137/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "138",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/138" },
+        "attributes": { "position": { "name": "B6" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/138/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/138/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "139",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/139" },
+        "attributes": { "position": { "name": "C6" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/139/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/139/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "140",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/140" },
+        "attributes": { "position": { "name": "D6" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/140/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/140/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "141",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/141" },
+        "attributes": { "position": { "name": "E6" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/141/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/141/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "142",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/142" },
+        "attributes": { "position": { "name": "F6" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/142/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/142/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "143",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/143" },
+        "attributes": { "position": { "name": "G6" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/143/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/143/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "144",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/144" },
+        "attributes": { "position": { "name": "H6" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/144/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/144/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "145",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/145" },
+        "attributes": { "position": { "name": "A7" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/145/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/145/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "146",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/146" },
+        "attributes": { "position": { "name": "B7" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/146/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/146/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "147",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/147" },
+        "attributes": { "position": { "name": "C7" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/147/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/147/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "148",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/148" },
+        "attributes": { "position": { "name": "D7" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/148/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/148/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "149",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/149" },
+        "attributes": { "position": { "name": "E7" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/149/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/149/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "150",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/150" },
+        "attributes": { "position": { "name": "F7" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/150/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/150/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "151",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/151" },
+        "attributes": { "position": { "name": "G7" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/151/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/151/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "152",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/152" },
+        "attributes": { "position": { "name": "H7" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/152/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/152/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "153",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/153" },
+        "attributes": { "position": { "name": "A8" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/153/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/153/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "154",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/154" },
+        "attributes": { "position": { "name": "B8" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/154/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/154/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "155",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/155" },
+        "attributes": { "position": { "name": "C8" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/155/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/155/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "156",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/156" },
+        "attributes": { "position": { "name": "D8" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/156/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/156/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "157",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/157" },
+        "attributes": { "position": { "name": "E8" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/157/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/157/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "158",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/158" },
+        "attributes": { "position": { "name": "F8" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/158/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/158/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "159",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/159" },
+        "attributes": { "position": { "name": "G8" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/159/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/159/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "160",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/160" },
+        "attributes": { "position": { "name": "H8" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/160/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/160/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "161",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/161" },
+        "attributes": { "position": { "name": "A9" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/161/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/161/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "162",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/162" },
+        "attributes": { "position": { "name": "B9" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/162/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/162/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "163",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/163" },
+        "attributes": { "position": { "name": "C9" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/163/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/163/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "164",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/164" },
+        "attributes": { "position": { "name": "D9" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/164/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/164/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "165",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/165" },
+        "attributes": { "position": { "name": "E9" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/165/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/165/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "166",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/166" },
+        "attributes": { "position": { "name": "F9" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/166/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/166/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "167",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/167" },
+        "attributes": { "position": { "name": "G9" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/167/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/167/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "168",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/168" },
+        "attributes": { "position": { "name": "H9" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/168/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/168/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "169",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/169" },
+        "attributes": { "position": { "name": "A10" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/169/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/169/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "170",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/170" },
+        "attributes": { "position": { "name": "B10" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/170/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/170/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "171",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/171" },
+        "attributes": { "position": { "name": "C10" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/171/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/171/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "172",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/172" },
+        "attributes": { "position": { "name": "D10" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/172/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/172/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "173",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/173" },
+        "attributes": { "position": { "name": "E10" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/173/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/173/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "174",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/174" },
+        "attributes": { "position": { "name": "F10" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/174/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/174/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "175",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/175" },
+        "attributes": { "position": { "name": "G10" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/175/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/175/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "176",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/176" },
+        "attributes": { "position": { "name": "H10" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/176/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/176/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "177",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/177" },
+        "attributes": { "position": { "name": "A11" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/177/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/177/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "178",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/178" },
+        "attributes": { "position": { "name": "B11" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/178/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/178/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "179",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/179" },
+        "attributes": { "position": { "name": "C11" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/179/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/179/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "180",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/180" },
+        "attributes": { "position": { "name": "D11" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/180/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/180/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "181",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/181" },
+        "attributes": { "position": { "name": "E11" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/181/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/181/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "182",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/182" },
+        "attributes": { "position": { "name": "F11" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/182/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/182/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "183",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/183" },
+        "attributes": { "position": { "name": "G11" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/183/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/183/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "184",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/184" },
+        "attributes": { "position": { "name": "H11" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/184/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/184/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "185",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/185" },
+        "attributes": { "position": { "name": "A12" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/185/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/185/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "186",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/186" },
+        "attributes": { "position": { "name": "B12" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/186/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/186/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "187",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/187" },
+        "attributes": { "position": { "name": "C12" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/187/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/187/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "188",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/188" },
+        "attributes": { "position": { "name": "D12" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/188/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/188/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "189",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/189" },
+        "attributes": { "position": { "name": "E12" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/189/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/189/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "190",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/190" },
+        "attributes": { "position": { "name": "F12" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/190/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/190/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "191",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/191" },
+        "attributes": { "position": { "name": "G12" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/191/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/191/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "192",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/192" },
+        "attributes": { "position": { "name": "H12" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/192/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/192/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "97",
+        "type": "aliquots",
+        "links": { "self": "http://sequencescape/api/v2/aliquots/97" },
+        "attributes": { "library_type": "Pacbio_HiFi" },
+        "relationships": {
+          "study": {
+            "links": {
+              "self": "http://sequencescape/api/v2/aliquots/97/relationships/study",
+              "related": "http://sequencescape/api/v2/aliquots/97/study"
+            },
+            "data": { "type": "studies", "id": "2" }
+          },
+          "sample": {
+            "links": {
+              "self": "http://sequencescape/api/v2/aliquots/97/relationships/sample",
+              "related": "http://sequencescape/api/v2/aliquots/97/sample"
+            },
+            "data": { "type": "samples", "id": "98" }
+          }
+        }
+      },
+      {
+        "id": "98",
+        "type": "aliquots",
+        "links": { "self": "http://sequencescape/api/v2/aliquots/98" },
+        "attributes": { "library_type": "Pacbio_HiFi" },
+        "relationships": {
+          "study": {
+            "links": {
+              "self": "http://sequencescape/api/v2/aliquots/98/relationships/study",
+              "related": "http://sequencescape/api/v2/aliquots/98/study"
+            },
+            "data": { "type": "studies", "id": "2" }
+          },
+          "sample": {
+            "links": {
+              "self": "http://sequencescape/api/v2/aliquots/98/relationships/sample",
+              "related": "http://sequencescape/api/v2/aliquots/98/sample"
+            },
+            "data": { "type": "samples", "id": "99" }
+          }
+        }
+      },
+      {
+        "id": "99",
+        "type": "aliquots",
+        "links": { "self": "http://sequencescape/api/v2/aliquots/99" },
+        "attributes": { "library_type": "Pacbio_IsoSeq" },
+        "relationships": {
+          "study": {
+            "links": {
+              "self": "http://sequencescape/api/v2/aliquots/99/relationships/study",
+              "related": "http://sequencescape/api/v2/aliquots/99/study"
+            },
+            "data": { "type": "studies", "id": "2" }
+          },
+          "sample": {
+            "links": {
+              "self": "http://sequencescape/api/v2/aliquots/99/relationships/sample",
+              "related": "http://sequencescape/api/v2/aliquots/99/sample"
+            },
+            "data": { "type": "samples", "id": "100" }
+          }
+        }
+      },
+      {
+        "id": "2",
+        "type": "studies",
+        "links": { "self": "http://sequencescape/api/v2/studies/2" },
+        "attributes": { "uuid": "5b173660-94c9-11ec-8c89-acde48001122" }
+      },
+      {
+        "id": "98",
+        "type": "samples",
+        "links": { "self": "http://sequencescape/api/v2/samples/98" },
+        "attributes": { "name": "2STDY1", "uuid": "d5008026-94c9-11ec-a9e3-acde48001122" },
+        "relationships": {
+          "sample_metadata": {
+            "links": {
+              "self": "http://sequencescape/api/v2/samples/98/relationships/sample_metadata",
+              "related": "http://sequencescape/api/v2/samples/98/sample_metadata"
+            },
+            "data": { "type": "sample_metadata", "id": "98" }
+          }
+        }
+      },
+      {
+        "id": "99",
+        "type": "samples",
+        "links": { "self": "http://sequencescape/api/v2/samples/99" },
+        "attributes": { "name": "2STDY2", "uuid": "d50bad48-94c9-11ec-a9e3-acde48001122" },
+        "relationships": {
+          "sample_metadata": {
+            "links": {
+              "self": "http://sequencescape/api/v2/samples/99/relationships/sample_metadata",
+              "related": "http://sequencescape/api/v2/samples/99/sample_metadata"
+            },
+            "data": { "type": "sample_metadata", "id": "99" }
+          }
+        }
+      },
+      {
+        "id": "100",
+        "type": "samples",
+        "links": { "self": "http://sequencescape/api/v2/samples/100" },
+        "attributes": { "name": "2STDY97", "uuid": "0db37dd8-94ca-11ec-a9e3-acde48001122" },
+        "relationships": {
+          "sample_metadata": {
+            "links": {
+              "self": "http://sequencescape/api/v2/samples/100/relationships/sample_metadata",
+              "related": "http://sequencescape/api/v2/samples/100/sample_metadata"
+            },
+            "data": { "type": "sample_metadata", "id": "100" }
+          }
+        }
+      },
+      {
+        "id": "98",
+        "type": "sample_metadata",
+        "links": { "self": "http://sequencescape/api/v2/sample_metadata/98" },
+        "attributes": { "sample_common_name": "Dragon" }
+      },
+      {
+        "id": "99",
+        "type": "sample_metadata",
+        "links": { "self": "http://sequencescape/api/v2/sample_metadata/99" },
+        "attributes": { "sample_common_name": "Unicorn" }
+      },
+      {
+        "id": "100",
+        "type": "sample_metadata",
+        "links": { "self": "http://sequencescape/api/v2/sample_metadata/100" },
+        "attributes": { "sample_common_name": "Gryphon" }
+      },
+      {
+        "id": "193",
+        "type": "receptacles",
+        "links": { "self": "http://sequencescape/api/v2/receptacles/193" },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/receptacles/193/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/receptacles/193/aliquots"
+            },
+            "data": [{ "type": "aliquots", "id": "99" }]
+          }
+        }
+      }
+    ],
+    "links": {
+      "first": "http://sequencescape/api/v2/labware?fields%5Baliquots%5D=study%2Clibrary_type%2Csample&fields%5Bplates%5D=labware_barcode%2Creceptacles&fields%5Breceptacles%5D=aliquots&fields%5Bsample_metadata%5D=sample_common_name&fields%5Bsamples%5D=sample_metadata%2Cname%2Cuuid&fields%5Bstudies%5D=uuid&fields%5Btubes%5D=labware_barcode%2Creceptacles&fields%5Bwells%5D=position%2Caliquots&filter%5Bbarcode%5D=DN9000002A%2CNT1O&include=receptacles.aliquots.sample.sample_metadata%2Creceptacles.aliquots.study&page%5Bnumber%5D=1&page%5Bsize%5D=100",
+      "last": "http://sequencescape/api/v2/labware?fields%5Baliquots%5D=study%2Clibrary_type%2Csample&fields%5Bplates%5D=labware_barcode%2Creceptacles&fields%5Breceptacles%5D=aliquots&fields%5Bsample_metadata%5D=sample_common_name&fields%5Bsamples%5D=sample_metadata%2Cname%2Cuuid&fields%5Bstudies%5D=uuid&fields%5Btubes%5D=labware_barcode%2Creceptacles&fields%5Bwells%5D=position%2Caliquots&filter%5Bbarcode%5D=DN9000002A%2CNT1O&include=receptacles.aliquots.sample.sample_metadata%2Creceptacles.aliquots.study&page%5Bnumber%5D=1&page%5Bsize%5D=100"
+    }
+  },
+  "status": 200,
+  "statusText": "Success"
+}

--- a/tests/e2e/fixtures/sequencescapeLabware.json
+++ b/tests/e2e/fixtures/sequencescapeLabware.json
@@ -1,0 +1,1738 @@
+{
+  "data": [
+    {
+      "id": "2",
+      "type": "plates",
+      "links": { "self": "http://sequencescape/api/v2/plates/2" },
+      "attributes": {
+        "labware_barcode": {
+          "ean13_barcode": "1229000002657",
+          "machine_barcode": "DN9000002A",
+          "human_barcode": "DN9000002A"
+        }
+      },
+      "relationships": {
+        "receptacles": {
+          "links": {
+            "self": "http://sequencescape/api/v2/plates/2/relationships/receptacles",
+            "related": "http://sequencescape/api/v2/plates/2/receptacles"
+          },
+          "data": [
+            { "type": "wells", "id": "97" },
+            { "type": "wells", "id": "98" },
+            { "type": "wells", "id": "99" },
+            { "type": "wells", "id": "100" },
+            { "type": "wells", "id": "101" },
+            { "type": "wells", "id": "102" },
+            { "type": "wells", "id": "103" },
+            { "type": "wells", "id": "104" },
+            { "type": "wells", "id": "105" },
+            { "type": "wells", "id": "106" },
+            { "type": "wells", "id": "107" },
+            { "type": "wells", "id": "108" },
+            { "type": "wells", "id": "109" },
+            { "type": "wells", "id": "110" },
+            { "type": "wells", "id": "111" },
+            { "type": "wells", "id": "112" },
+            { "type": "wells", "id": "113" },
+            { "type": "wells", "id": "114" },
+            { "type": "wells", "id": "115" },
+            { "type": "wells", "id": "116" },
+            { "type": "wells", "id": "117" },
+            { "type": "wells", "id": "118" },
+            { "type": "wells", "id": "119" },
+            { "type": "wells", "id": "120" },
+            { "type": "wells", "id": "121" },
+            { "type": "wells", "id": "122" },
+            { "type": "wells", "id": "123" },
+            { "type": "wells", "id": "124" },
+            { "type": "wells", "id": "125" },
+            { "type": "wells", "id": "126" },
+            { "type": "wells", "id": "127" },
+            { "type": "wells", "id": "128" },
+            { "type": "wells", "id": "129" },
+            { "type": "wells", "id": "130" },
+            { "type": "wells", "id": "131" },
+            { "type": "wells", "id": "132" },
+            { "type": "wells", "id": "133" },
+            { "type": "wells", "id": "134" },
+            { "type": "wells", "id": "135" },
+            { "type": "wells", "id": "136" },
+            { "type": "wells", "id": "137" },
+            { "type": "wells", "id": "138" },
+            { "type": "wells", "id": "139" },
+            { "type": "wells", "id": "140" },
+            { "type": "wells", "id": "141" },
+            { "type": "wells", "id": "142" },
+            { "type": "wells", "id": "143" },
+            { "type": "wells", "id": "144" },
+            { "type": "wells", "id": "145" },
+            { "type": "wells", "id": "146" },
+            { "type": "wells", "id": "147" },
+            { "type": "wells", "id": "148" },
+            { "type": "wells", "id": "149" },
+            { "type": "wells", "id": "150" },
+            { "type": "wells", "id": "151" },
+            { "type": "wells", "id": "152" },
+            { "type": "wells", "id": "153" },
+            { "type": "wells", "id": "154" },
+            { "type": "wells", "id": "155" },
+            { "type": "wells", "id": "156" },
+            { "type": "wells", "id": "157" },
+            { "type": "wells", "id": "158" },
+            { "type": "wells", "id": "159" },
+            { "type": "wells", "id": "160" },
+            { "type": "wells", "id": "161" },
+            { "type": "wells", "id": "162" },
+            { "type": "wells", "id": "163" },
+            { "type": "wells", "id": "164" },
+            { "type": "wells", "id": "165" },
+            { "type": "wells", "id": "166" },
+            { "type": "wells", "id": "167" },
+            { "type": "wells", "id": "168" },
+            { "type": "wells", "id": "169" },
+            { "type": "wells", "id": "170" },
+            { "type": "wells", "id": "171" },
+            { "type": "wells", "id": "172" },
+            { "type": "wells", "id": "173" },
+            { "type": "wells", "id": "174" },
+            { "type": "wells", "id": "175" },
+            { "type": "wells", "id": "176" },
+            { "type": "wells", "id": "177" },
+            { "type": "wells", "id": "178" },
+            { "type": "wells", "id": "179" },
+            { "type": "wells", "id": "180" },
+            { "type": "wells", "id": "181" },
+            { "type": "wells", "id": "182" },
+            { "type": "wells", "id": "183" },
+            { "type": "wells", "id": "184" },
+            { "type": "wells", "id": "185" },
+            { "type": "wells", "id": "186" },
+            { "type": "wells", "id": "187" },
+            { "type": "wells", "id": "188" },
+            { "type": "wells", "id": "189" },
+            { "type": "wells", "id": "190" },
+            { "type": "wells", "id": "191" },
+            { "type": "wells", "id": "192" }
+          ]
+        }
+      }
+    },
+    {
+      "id": "3",
+      "type": "tubes",
+      "links": { "self": "http://sequencescape/api/v2/tubes/3" },
+      "attributes": {
+        "labware_barcode": {
+          "ean13_barcode": "3980000001795",
+          "machine_barcode": "3980000001795",
+          "human_barcode": "NT1O"
+        }
+      },
+      "relationships": {
+        "receptacles": {
+          "links": {
+            "self": "http://sequencescape/api/v2/tubes/3/relationships/receptacles",
+            "related": "http://sequencescape/api/v2/tubes/3/receptacles"
+          },
+          "data": [{ "type": "receptacles", "id": "193" }]
+        }
+      }
+    }
+  ],
+  "included": [
+    {
+      "id": "97",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/97" },
+      "attributes": { "position": { "name": "A1" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/97/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/97/aliquots"
+          },
+          "data": [{ "type": "aliquots", "id": "97" }]
+        }
+      }
+    },
+    {
+      "id": "98",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/98" },
+      "attributes": { "position": { "name": "B1" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/98/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/98/aliquots"
+          },
+          "data": [{ "type": "aliquots", "id": "98" }]
+        }
+      }
+    },
+    {
+      "id": "99",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/99" },
+      "attributes": { "position": { "name": "C1" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/99/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/99/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "100",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/100" },
+      "attributes": { "position": { "name": "D1" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/100/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/100/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "101",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/101" },
+      "attributes": { "position": { "name": "E1" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/101/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/101/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "102",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/102" },
+      "attributes": { "position": { "name": "F1" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/102/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/102/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "103",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/103" },
+      "attributes": { "position": { "name": "G1" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/103/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/103/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "104",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/104" },
+      "attributes": { "position": { "name": "H1" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/104/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/104/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "105",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/105" },
+      "attributes": { "position": { "name": "A2" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/105/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/105/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "106",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/106" },
+      "attributes": { "position": { "name": "B2" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/106/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/106/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "107",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/107" },
+      "attributes": { "position": { "name": "C2" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/107/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/107/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "108",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/108" },
+      "attributes": { "position": { "name": "D2" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/108/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/108/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "109",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/109" },
+      "attributes": { "position": { "name": "E2" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/109/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/109/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "110",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/110" },
+      "attributes": { "position": { "name": "F2" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/110/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/110/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "111",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/111" },
+      "attributes": { "position": { "name": "G2" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/111/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/111/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "112",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/112" },
+      "attributes": { "position": { "name": "H2" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/112/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/112/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "113",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/113" },
+      "attributes": { "position": { "name": "A3" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/113/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/113/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "114",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/114" },
+      "attributes": { "position": { "name": "B3" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/114/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/114/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "115",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/115" },
+      "attributes": { "position": { "name": "C3" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/115/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/115/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "116",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/116" },
+      "attributes": { "position": { "name": "D3" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/116/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/116/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "117",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/117" },
+      "attributes": { "position": { "name": "E3" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/117/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/117/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "118",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/118" },
+      "attributes": { "position": { "name": "F3" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/118/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/118/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "119",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/119" },
+      "attributes": { "position": { "name": "G3" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/119/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/119/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "120",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/120" },
+      "attributes": { "position": { "name": "H3" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/120/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/120/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "121",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/121" },
+      "attributes": { "position": { "name": "A4" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/121/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/121/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "122",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/122" },
+      "attributes": { "position": { "name": "B4" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/122/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/122/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "123",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/123" },
+      "attributes": { "position": { "name": "C4" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/123/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/123/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "124",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/124" },
+      "attributes": { "position": { "name": "D4" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/124/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/124/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "125",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/125" },
+      "attributes": { "position": { "name": "E4" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/125/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/125/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "126",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/126" },
+      "attributes": { "position": { "name": "F4" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/126/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/126/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "127",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/127" },
+      "attributes": { "position": { "name": "G4" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/127/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/127/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "128",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/128" },
+      "attributes": { "position": { "name": "H4" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/128/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/128/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "129",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/129" },
+      "attributes": { "position": { "name": "A5" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/129/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/129/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "130",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/130" },
+      "attributes": { "position": { "name": "B5" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/130/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/130/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "131",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/131" },
+      "attributes": { "position": { "name": "C5" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/131/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/131/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "132",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/132" },
+      "attributes": { "position": { "name": "D5" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/132/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/132/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "133",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/133" },
+      "attributes": { "position": { "name": "E5" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/133/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/133/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "134",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/134" },
+      "attributes": { "position": { "name": "F5" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/134/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/134/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "135",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/135" },
+      "attributes": { "position": { "name": "G5" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/135/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/135/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "136",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/136" },
+      "attributes": { "position": { "name": "H5" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/136/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/136/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "137",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/137" },
+      "attributes": { "position": { "name": "A6" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/137/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/137/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "138",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/138" },
+      "attributes": { "position": { "name": "B6" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/138/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/138/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "139",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/139" },
+      "attributes": { "position": { "name": "C6" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/139/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/139/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "140",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/140" },
+      "attributes": { "position": { "name": "D6" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/140/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/140/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "141",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/141" },
+      "attributes": { "position": { "name": "E6" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/141/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/141/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "142",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/142" },
+      "attributes": { "position": { "name": "F6" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/142/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/142/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "143",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/143" },
+      "attributes": { "position": { "name": "G6" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/143/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/143/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "144",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/144" },
+      "attributes": { "position": { "name": "H6" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/144/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/144/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "145",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/145" },
+      "attributes": { "position": { "name": "A7" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/145/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/145/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "146",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/146" },
+      "attributes": { "position": { "name": "B7" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/146/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/146/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "147",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/147" },
+      "attributes": { "position": { "name": "C7" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/147/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/147/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "148",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/148" },
+      "attributes": { "position": { "name": "D7" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/148/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/148/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "149",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/149" },
+      "attributes": { "position": { "name": "E7" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/149/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/149/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "150",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/150" },
+      "attributes": { "position": { "name": "F7" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/150/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/150/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "151",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/151" },
+      "attributes": { "position": { "name": "G7" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/151/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/151/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "152",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/152" },
+      "attributes": { "position": { "name": "H7" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/152/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/152/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "153",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/153" },
+      "attributes": { "position": { "name": "A8" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/153/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/153/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "154",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/154" },
+      "attributes": { "position": { "name": "B8" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/154/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/154/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "155",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/155" },
+      "attributes": { "position": { "name": "C8" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/155/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/155/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "156",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/156" },
+      "attributes": { "position": { "name": "D8" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/156/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/156/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "157",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/157" },
+      "attributes": { "position": { "name": "E8" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/157/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/157/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "158",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/158" },
+      "attributes": { "position": { "name": "F8" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/158/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/158/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "159",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/159" },
+      "attributes": { "position": { "name": "G8" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/159/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/159/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "160",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/160" },
+      "attributes": { "position": { "name": "H8" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/160/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/160/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "161",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/161" },
+      "attributes": { "position": { "name": "A9" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/161/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/161/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "162",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/162" },
+      "attributes": { "position": { "name": "B9" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/162/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/162/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "163",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/163" },
+      "attributes": { "position": { "name": "C9" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/163/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/163/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "164",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/164" },
+      "attributes": { "position": { "name": "D9" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/164/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/164/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "165",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/165" },
+      "attributes": { "position": { "name": "E9" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/165/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/165/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "166",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/166" },
+      "attributes": { "position": { "name": "F9" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/166/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/166/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "167",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/167" },
+      "attributes": { "position": { "name": "G9" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/167/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/167/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "168",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/168" },
+      "attributes": { "position": { "name": "H9" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/168/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/168/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "169",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/169" },
+      "attributes": { "position": { "name": "A10" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/169/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/169/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "170",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/170" },
+      "attributes": { "position": { "name": "B10" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/170/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/170/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "171",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/171" },
+      "attributes": { "position": { "name": "C10" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/171/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/171/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "172",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/172" },
+      "attributes": { "position": { "name": "D10" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/172/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/172/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "173",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/173" },
+      "attributes": { "position": { "name": "E10" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/173/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/173/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "174",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/174" },
+      "attributes": { "position": { "name": "F10" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/174/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/174/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "175",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/175" },
+      "attributes": { "position": { "name": "G10" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/175/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/175/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "176",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/176" },
+      "attributes": { "position": { "name": "H10" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/176/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/176/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "177",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/177" },
+      "attributes": { "position": { "name": "A11" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/177/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/177/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "178",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/178" },
+      "attributes": { "position": { "name": "B11" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/178/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/178/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "179",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/179" },
+      "attributes": { "position": { "name": "C11" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/179/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/179/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "180",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/180" },
+      "attributes": { "position": { "name": "D11" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/180/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/180/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "181",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/181" },
+      "attributes": { "position": { "name": "E11" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/181/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/181/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "182",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/182" },
+      "attributes": { "position": { "name": "F11" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/182/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/182/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "183",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/183" },
+      "attributes": { "position": { "name": "G11" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/183/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/183/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "184",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/184" },
+      "attributes": { "position": { "name": "H11" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/184/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/184/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "185",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/185" },
+      "attributes": { "position": { "name": "A12" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/185/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/185/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "186",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/186" },
+      "attributes": { "position": { "name": "B12" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/186/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/186/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "187",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/187" },
+      "attributes": { "position": { "name": "C12" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/187/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/187/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "188",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/188" },
+      "attributes": { "position": { "name": "D12" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/188/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/188/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "189",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/189" },
+      "attributes": { "position": { "name": "E12" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/189/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/189/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "190",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/190" },
+      "attributes": { "position": { "name": "F12" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/190/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/190/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "191",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/191" },
+      "attributes": { "position": { "name": "G12" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/191/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/191/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "192",
+      "type": "wells",
+      "links": { "self": "http://sequencescape/api/v2/wells/192" },
+      "attributes": { "position": { "name": "H12" } },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/wells/192/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/wells/192/aliquots"
+          },
+          "data": []
+        }
+      }
+    },
+    {
+      "id": "97",
+      "type": "aliquots",
+      "links": { "self": "http://sequencescape/api/v2/aliquots/97" },
+      "attributes": { "library_type": "Pacbio_HiFi" },
+      "relationships": {
+        "study": {
+          "links": {
+            "self": "http://sequencescape/api/v2/aliquots/97/relationships/study",
+            "related": "http://sequencescape/api/v2/aliquots/97/study"
+          },
+          "data": { "type": "studies", "id": "2" }
+        },
+        "sample": {
+          "links": {
+            "self": "http://sequencescape/api/v2/aliquots/97/relationships/sample",
+            "related": "http://sequencescape/api/v2/aliquots/97/sample"
+          },
+          "data": { "type": "samples", "id": "98" }
+        }
+      }
+    },
+    {
+      "id": "98",
+      "type": "aliquots",
+      "links": { "self": "http://sequencescape/api/v2/aliquots/98" },
+      "attributes": { "library_type": "Pacbio_HiFi" },
+      "relationships": {
+        "study": {
+          "links": {
+            "self": "http://sequencescape/api/v2/aliquots/98/relationships/study",
+            "related": "http://sequencescape/api/v2/aliquots/98/study"
+          },
+          "data": { "type": "studies", "id": "2" }
+        },
+        "sample": {
+          "links": {
+            "self": "http://sequencescape/api/v2/aliquots/98/relationships/sample",
+            "related": "http://sequencescape/api/v2/aliquots/98/sample"
+          },
+          "data": { "type": "samples", "id": "99" }
+        }
+      }
+    },
+    {
+      "id": "99",
+      "type": "aliquots",
+      "links": { "self": "http://sequencescape/api/v2/aliquots/99" },
+      "attributes": { "library_type": "Pacbio_IsoSeq" },
+      "relationships": {
+        "study": {
+          "links": {
+            "self": "http://sequencescape/api/v2/aliquots/99/relationships/study",
+            "related": "http://sequencescape/api/v2/aliquots/99/study"
+          },
+          "data": { "type": "studies", "id": "2" }
+        },
+        "sample": {
+          "links": {
+            "self": "http://sequencescape/api/v2/aliquots/99/relationships/sample",
+            "related": "http://sequencescape/api/v2/aliquots/99/sample"
+          },
+          "data": { "type": "samples", "id": "100" }
+        }
+      }
+    },
+    {
+      "id": "2",
+      "type": "studies",
+      "links": { "self": "http://sequencescape/api/v2/studies/2" },
+      "attributes": { "uuid": "5b173660-94c9-11ec-8c89-acde48001122" }
+    },
+    {
+      "id": "98",
+      "type": "samples",
+      "links": { "self": "http://sequencescape/api/v2/samples/98" },
+      "attributes": { "name": "2STDY1", "uuid": "d5008026-94c9-11ec-a9e3-acde48001122" },
+      "relationships": {
+        "sample_metadata": {
+          "links": {
+            "self": "http://sequencescape/api/v2/samples/98/relationships/sample_metadata",
+            "related": "http://sequencescape/api/v2/samples/98/sample_metadata"
+          },
+          "data": { "type": "sample_metadata", "id": "98" }
+        }
+      }
+    },
+    {
+      "id": "99",
+      "type": "samples",
+      "links": { "self": "http://sequencescape/api/v2/samples/99" },
+      "attributes": { "name": "2STDY2", "uuid": "d50bad48-94c9-11ec-a9e3-acde48001122" },
+      "relationships": {
+        "sample_metadata": {
+          "links": {
+            "self": "http://sequencescape/api/v2/samples/99/relationships/sample_metadata",
+            "related": "http://sequencescape/api/v2/samples/99/sample_metadata"
+          },
+          "data": { "type": "sample_metadata", "id": "99" }
+        }
+      }
+    },
+    {
+      "id": "100",
+      "type": "samples",
+      "links": { "self": "http://sequencescape/api/v2/samples/100" },
+      "attributes": { "name": "2STDY97", "uuid": "0db37dd8-94ca-11ec-a9e3-acde48001122" },
+      "relationships": {
+        "sample_metadata": {
+          "links": {
+            "self": "http://sequencescape/api/v2/samples/100/relationships/sample_metadata",
+            "related": "http://sequencescape/api/v2/samples/100/sample_metadata"
+          },
+          "data": { "type": "sample_metadata", "id": "100" }
+        }
+      }
+    },
+    {
+      "id": "98",
+      "type": "sample_metadata",
+      "links": { "self": "http://sequencescape/api/v2/sample_metadata/98" },
+      "attributes": { "sample_common_name": "Dragon" }
+    },
+    {
+      "id": "99",
+      "type": "sample_metadata",
+      "links": { "self": "http://sequencescape/api/v2/sample_metadata/99" },
+      "attributes": { "sample_common_name": "Unicorn" }
+    },
+    {
+      "id": "100",
+      "type": "sample_metadata",
+      "links": { "self": "http://sequencescape/api/v2/sample_metadata/100" },
+      "attributes": { "sample_common_name": "Gryphon" }
+    },
+    {
+      "id": "193",
+      "type": "receptacles",
+      "links": { "self": "http://sequencescape/api/v2/receptacles/193" },
+      "relationships": {
+        "aliquots": {
+          "links": {
+            "self": "http://sequencescape/api/v2/receptacles/193/relationships/aliquots",
+            "related": "http://sequencescape/api/v2/receptacles/193/aliquots"
+          },
+          "data": [{ "type": "aliquots", "id": "99" }]
+        }
+      }
+    }
+  ],
+  "links": {
+    "first": "http://sequencescape/api/v2/labware?fields%5Baliquots%5D=study%2Clibrary_type%2Csample&fields%5Bplates%5D=labware_barcode%2Creceptacles&fields%5Breceptacles%5D=aliquots&fields%5Bsample_metadata%5D=sample_common_name&fields%5Bsamples%5D=sample_metadata%2Cname%2Cuuid&fields%5Bstudies%5D=uuid&fields%5Btubes%5D=labware_barcode%2Creceptacles&fields%5Bwells%5D=position%2Caliquots&filter%5Bbarcode%5D=DN9000002A%2CNT1O&include=receptacles.aliquots.sample.sample_metadata%2Creceptacles.aliquots.study&page%5Bnumber%5D=1&page%5Bsize%5D=100",
+    "last": "http://sequencescape/api/v2/labware?fields%5Baliquots%5D=study%2Clibrary_type%2Csample&fields%5Bplates%5D=labware_barcode%2Creceptacles&fields%5Breceptacles%5D=aliquots&fields%5Bsample_metadata%5D=sample_common_name&fields%5Bsamples%5D=sample_metadata%2Cname%2Cuuid&fields%5Bstudies%5D=uuid&fields%5Btubes%5D=labware_barcode%2Creceptacles&fields%5Bwells%5D=position%2Caliquots&filter%5Bbarcode%5D=DN9000002A%2CNT1O&include=receptacles.aliquots.sample.sample_metadata%2Creceptacles.aliquots.study&page%5Bnumber%5D=1&page%5Bsize%5D=100"
+  }
+}

--- a/tests/e2e/fixtures/tractionPacbioPlateCreate.json
+++ b/tests/e2e/fixtures/tractionPacbioPlateCreate.json
@@ -4,16 +4,16 @@
       "attributes": {
         "plates": [
           {
-            "barcode": "DN804974W",
+            "barcode": "DN9000002A",
             "wells": [
               {
                 "position": "A1",
                 "samples": [
                   {
-                    "external_id": "d5bbd9f8-adba-11eb-ac23-fa163eac3af7",
-                    "name": "DTOL10239359",
-                    "external_study_id": "cf04ea86-ac82-11e9-8998-68b599768938",
-                    "species": "Apamea scolopacina",
+                    "external_id": "d5008026-94c9-11ec-a9e3-acde48001122",
+                    "name": "2STDY1",
+                    "external_study_id": "5b173660-94c9-11ec-8c89-acde48001122",
+                    "species": "Dragon",
                     "library_type": null
                   }
                 ]
@@ -22,350 +22,296 @@
                 "position": "B1",
                 "samples": [
                   {
-                    "external_id": "d5c6414a-adba-11eb-ac23-fa163eac3af7",
-                    "name": "DTOL10239360",
-                    "external_study_id": "cf04ea86-ac82-11e9-8998-68b599768938",
-                    "species": "Attelabus nitens",
+                    "external_id": "d50bad48-94c9-11ec-a9e3-acde48001122",
+                    "name": "2STDY2",
+                    "external_study_id": "5b173660-94c9-11ec-8c89-acde48001122",
+                    "species": "Unicorn",
                     "library_type": null
                   }
                 ]
               },
               {
-                "position": "C1",
-                "samples": [
-                  {
-                    "external_id": "d5cd7ea6-adba-11eb-ac23-fa163eac3af7",
-                    "name": "DTOL10239361",
-                    "external_study_id": "cf04ea86-ac82-11e9-8998-68b599768938",
-                    "species": "Linnaemya tessellans",
-                    "library_type": null
-                  }
-                ]
+                "position": "C1"
               },
               {
-                "position": "D1",
-                "samples": [
-                  {
-                    "external_id": "d5d4f49c-adba-11eb-ac23-fa163eac3af7",
-                    "name": "DTOL10239362",
-                    "external_study_id": "cf04ea86-ac82-11e9-8998-68b599768938",
-                    "species": "Physocephala rufipes",
-                    "library_type": null
-                  }
-                ]
+                "position": "D1"
               },
               {
-                "position": "E1",
-                "samples": [
-                  {
-                    "external_id": "d5dc5e3a-adba-11eb-ac23-fa163eac3af7",
-                    "name": "DTOL10239363",
-                    "external_study_id": "cf04ea86-ac82-11e9-8998-68b599768938",
-                    "species": "Pollenia angustigena",
-                    "library_type": null
-                  }
-                ]
+                "position": "E1"
               },
               {
-                "position": "F1",
-                "samples": [
-                  {
-                    "external_id": "d5e3641e-adba-11eb-ac23-fa163eac3af7",
-                    "name": "DTOL10239364",
-                    "external_study_id": "cf04ea86-ac82-11e9-8998-68b599768938",
-                    "species": "Sarcophaga rosellei",
-                    "library_type": null
-                  }
-                ]
+                "position": "F1"
               },
               {
-                "position": "G1",
-                "samples": [
-                  {
-                    "external_id": "d5eab85e-adba-11eb-ac23-fa163eac3af7",
-                    "name": "DTOL10239365",
-                    "external_study_id": "cf04ea86-ac82-11e9-8998-68b599768938",
-                    "species": "Spilarctia lutea",
-                    "library_type": null
-                  }
-                ]
+                "position": "G1"
               },
               {
-                "position": "H1",
-                "samples": [
-                  {
-                    "external_id": "d5f2448e-adba-11eb-ac23-fa163eac3af7",
-                    "name": "DTOL10239366",
-                    "external_study_id": "cf04ea86-ac82-11e9-8998-68b599768938",
-                    "species": "Dolichovespula sylvestris",
-                    "library_type": null
-                  }
-                ]
+                "position": "H1"
               },
               {
-                "position": "A2",
-                "samples": [
-                  {
-                    "external_id": "d5f977fe-adba-11eb-ac23-fa163eac3af7",
-                    "name": "DTOL10239367",
-                    "external_study_id": "cf04ea86-ac82-11e9-8998-68b599768938",
-                    "species": "Macropis europaea",
-                    "library_type": null
-                  }
-                ]
+                "position": "A2"
               },
               {
-                "position": "B2",
-                "samples": [
-                  {
-                    "external_id": "d6011b76-adba-11eb-ac23-fa163eac3af7",
-                    "name": "DTOL10239368",
-                    "external_study_id": "cf04ea86-ac82-11e9-8998-68b599768938",
-                    "species": "Tenthredo notha",
-                    "library_type": null
-                  }
-                ]
+                "position": "B2"
               },
               {
-                "position": "C2",
-                "samples": [
-                  {
-                    "external_id": "d6084e46-adba-11eb-ac23-fa163eac3af7",
-                    "name": "DTOL10239369",
-                    "external_study_id": "cf04ea86-ac82-11e9-8998-68b599768938",
-                    "species": "Anatis ocellata",
-                    "library_type": null
-                  }
-                ]
+                "position": "C2"
               },
               {
-                "position": "D2",
-                "samples": [
-                  {
-                    "external_id": "d60f95b6-adba-11eb-ac23-fa163eac3af7",
-                    "name": "DTOL10239370",
-                    "external_study_id": "cf04ea86-ac82-11e9-8998-68b599768938",
-                    "species": "Dolomedes fimbriatus",
-                    "library_type": null
-                  }
-                ]
+                "position": "D2"
               },
               {
-                "position": "E2",
-                "samples": [
-                  {
-                    "external_id": "d619a01a-adba-11eb-ac23-fa163eac3af7",
-                    "name": "DTOL10239371",
-                    "external_study_id": "cf04ea86-ac82-11e9-8998-68b599768938",
-                    "species": "Zoropsis spinimana",
-                    "library_type": null
-                  }
-                ]
+                "position": "E2"
               },
               {
-                "position": "F2",
-                "samples": [
-                  {
-                    "external_id": "d62391f6-adba-11eb-ac23-fa163eac3af7",
-                    "name": "DTOL10239372",
-                    "external_study_id": "cf04ea86-ac82-11e9-8998-68b599768938",
-                    "species": "Alitta virens",
-                    "library_type": null
-                  }
-                ]
+                "position": "F2"
               },
               {
-                "position": "G2",
-                "samples": [
-                  {
-                    "external_id": "d62b59ae-adba-11eb-ac23-fa163eac3af7",
-                    "name": "DTOL10239373",
-                    "external_study_id": "cf04ea86-ac82-11e9-8998-68b599768938",
-                    "species": "Cornu aspersum",
-                    "library_type": null
-                  }
-                ]
+                "position": "G2"
               },
               {
-                "position": "H2",
-                "samples": [
-                  {
-                    "external_id": "d636b92a-adba-11eb-ac23-fa163eac3af7",
-                    "name": "DTOL10239374",
-                    "external_study_id": "cf04ea86-ac82-11e9-8998-68b599768938",
-                    "species": "Nemurella pictetii",
-                    "library_type": null
-                  }
-                ]
+                "position": "H2"
               },
               {
-                "position": "A3",
-                "samples": [
-                  {
-                    "external_id": "d63e83c6-adba-11eb-ac23-fa163eac3af7",
-                    "name": "DTOL10239375",
-                    "external_study_id": "cf04ea86-ac82-11e9-8998-68b599768938",
-                    "species": "Mimachlamys varia",
-                    "library_type": null
-                  }
-                ]
+                "position": "A3"
               },
               {
-                "position": "B3",
-                "samples": [
-                  {
-                    "external_id": "d645ea44-adba-11eb-ac23-fa163eac3af7",
-                    "name": "DTOL10239376",
-                    "external_study_id": "cf04ea86-ac82-11e9-8998-68b599768938",
-                    "species": "Xeroplexa intersecta",
-                    "library_type": null
-                  }
-                ]
+                "position": "B3"
               },
               {
-                "position": "C3",
-                "samples": [
-                  {
-                    "external_id": "d658326c-adba-11eb-ac23-fa163eac3af7",
-                    "name": "DTOL10239377",
-                    "external_study_id": "cf04ea86-ac82-11e9-8998-68b599768938",
-                    "species": "Epistrophe grossulariae",
-                    "library_type": null
-                  }
-                ]
+                "position": "C3"
               },
               {
-                "position": "D3",
-                "samples": [
-                  {
-                    "external_id": "d667e91e-adba-11eb-ac23-fa163eac3af7",
-                    "name": "DTOL10239378",
-                    "external_study_id": "cf04ea86-ac82-11e9-8998-68b599768938",
-                    "species": "Helina quadrum",
-                    "library_type": null
-                  }
-                ]
+                "position": "D3"
               },
               {
-                "position": "E3",
-                "samples": [
-                  {
-                    "external_id": "d6782842-adba-11eb-ac23-fa163eac3af7",
-                    "name": "DTOL10239379",
-                    "external_study_id": "cf04ea86-ac82-11e9-8998-68b599768938",
-                    "species": "Hylemya vagans",
-                    "library_type": null
-                  }
-                ]
+                "position": "E3"
               },
               {
-                "position": "F3",
-                "samples": [
-                  {
-                    "external_id": "d68017c8-adba-11eb-ac23-fa163eac3af7",
-                    "name": "DTOL10239380",
-                    "external_study_id": "cf04ea86-ac82-11e9-8998-68b599768938",
-                    "species": "Lucilia richardsi",
-                    "library_type": null
-                  }
-                ]
+                "position": "F3"
               },
               {
-                "position": "G3",
-                "samples": [
-                  {
-                    "external_id": "d6900bce-adba-11eb-ac23-fa163eac3af7",
-                    "name": "DTOL10239381",
-                    "external_study_id": "cf04ea86-ac82-11e9-8998-68b599768938",
-                    "species": "Agrochola circellaris",
-                    "library_type": null
-                  }
-                ]
+                "position": "G3"
               },
               {
-                "position": "H3",
-                "samples": [
-                  {
-                    "external_id": "d69ac6e0-adba-11eb-ac23-fa163eac3af7",
-                    "name": "DTOL10239382",
-                    "external_study_id": "cf04ea86-ac82-11e9-8998-68b599768938",
-                    "species": "Agriphila tristella",
-                    "library_type": null
-                  }
-                ]
+                "position": "H3"
               },
-              { "position": "A4" },
-              { "position": "B4" },
-              { "position": "C4" },
-              { "position": "D4" },
-              { "position": "E4" },
-              { "position": "F4" },
-              { "position": "G4" },
-              { "position": "H4" },
-              { "position": "A5" },
-              { "position": "B5" },
-              { "position": "C5" },
-              { "position": "D5" },
-              { "position": "E5" },
-              { "position": "F5" },
-              { "position": "G5" },
-              { "position": "H5" },
-              { "position": "A6" },
-              { "position": "B6" },
-              { "position": "C6" },
-              { "position": "D6" },
-              { "position": "E6" },
-              { "position": "F6" },
-              { "position": "G6" },
-              { "position": "H6" },
-              { "position": "A7" },
-              { "position": "B7" },
-              { "position": "C7" },
-              { "position": "D7" },
-              { "position": "E7" },
-              { "position": "F7" },
-              { "position": "G7" },
-              { "position": "H7" },
-              { "position": "A8" },
-              { "position": "B8" },
-              { "position": "C8" },
-              { "position": "D8" },
-              { "position": "E8" },
-              { "position": "F8" },
-              { "position": "G8" },
-              { "position": "H8" },
-              { "position": "A9" },
-              { "position": "B9" },
-              { "position": "C9" },
-              { "position": "D9" },
-              { "position": "E9" },
-              { "position": "F9" },
-              { "position": "G9" },
-              { "position": "H9" },
-              { "position": "A10" },
-              { "position": "B10" },
-              { "position": "C10" },
-              { "position": "D10" },
-              { "position": "E10" },
-              { "position": "F10" },
-              { "position": "G10" },
-              { "position": "H10" },
-              { "position": "A11" },
-              { "position": "B11" },
-              { "position": "C11" },
-              { "position": "D11" },
-              { "position": "E11" },
-              { "position": "F11" },
-              { "position": "G11" },
-              { "position": "H11" },
-              { "position": "A12" },
-              { "position": "B12" },
-              { "position": "C12" },
-              { "position": "D12" },
-              { "position": "E12" },
-              { "position": "F12" },
-              { "position": "G12" },
-              { "position": "H12" }
+              {
+                "position": "A4"
+              },
+              {
+                "position": "B4"
+              },
+              {
+                "position": "C4"
+              },
+              {
+                "position": "D4"
+              },
+              {
+                "position": "E4"
+              },
+              {
+                "position": "F4"
+              },
+              {
+                "position": "G4"
+              },
+              {
+                "position": "H4"
+              },
+              {
+                "position": "A5"
+              },
+              {
+                "position": "B5"
+              },
+              {
+                "position": "C5"
+              },
+              {
+                "position": "D5"
+              },
+              {
+                "position": "E5"
+              },
+              {
+                "position": "F5"
+              },
+              {
+                "position": "G5"
+              },
+              {
+                "position": "H5"
+              },
+              {
+                "position": "A6"
+              },
+              {
+                "position": "B6"
+              },
+              {
+                "position": "C6"
+              },
+              {
+                "position": "D6"
+              },
+              {
+                "position": "E6"
+              },
+              {
+                "position": "F6"
+              },
+              {
+                "position": "G6"
+              },
+              {
+                "position": "H6"
+              },
+              {
+                "position": "A7"
+              },
+              {
+                "position": "B7"
+              },
+              {
+                "position": "C7"
+              },
+              {
+                "position": "D7"
+              },
+              {
+                "position": "E7"
+              },
+              {
+                "position": "F7"
+              },
+              {
+                "position": "G7"
+              },
+              {
+                "position": "H7"
+              },
+              {
+                "position": "A8"
+              },
+              {
+                "position": "B8"
+              },
+              {
+                "position": "C8"
+              },
+              {
+                "position": "D8"
+              },
+              {
+                "position": "E8"
+              },
+              {
+                "position": "F8"
+              },
+              {
+                "position": "G8"
+              },
+              {
+                "position": "H8"
+              },
+              {
+                "position": "A9"
+              },
+              {
+                "position": "B9"
+              },
+              {
+                "position": "C9"
+              },
+              {
+                "position": "D9"
+              },
+              {
+                "position": "E9"
+              },
+              {
+                "position": "F9"
+              },
+              {
+                "position": "G9"
+              },
+              {
+                "position": "H9"
+              },
+              {
+                "position": "A10"
+              },
+              {
+                "position": "B10"
+              },
+              {
+                "position": "C10"
+              },
+              {
+                "position": "D10"
+              },
+              {
+                "position": "E10"
+              },
+              {
+                "position": "F10"
+              },
+              {
+                "position": "G10"
+              },
+              {
+                "position": "H10"
+              },
+              {
+                "position": "A11"
+              },
+              {
+                "position": "B11"
+              },
+              {
+                "position": "C11"
+              },
+              {
+                "position": "D11"
+              },
+              {
+                "position": "E11"
+              },
+              {
+                "position": "F11"
+              },
+              {
+                "position": "G11"
+              },
+              {
+                "position": "H11"
+              },
+              {
+                "position": "A12"
+              },
+              {
+                "position": "B12"
+              },
+              {
+                "position": "C12"
+              },
+              {
+                "position": "D12"
+              },
+              {
+                "position": "E12"
+              },
+              {
+                "position": "F12"
+              },
+              {
+                "position": "G12"
+              },
+              {
+                "position": "H12"
+              }
             ]
           }
         ]

--- a/tests/e2e/fixtures/tractionPacbioRequest.json
+++ b/tests/e2e/fixtures/tractionPacbioRequest.json
@@ -1,0 +1,35 @@
+{
+  "data": [
+    {
+      "id": "264",
+      "type": "requests",
+      "links": { "self": "/v1/pacbio/requests/264" },
+      "attributes": {
+        "library_type": null,
+        "estimate_of_gb_required": null,
+        "number_of_smrt_cells": null,
+        "cost_code": "S4773",
+        "external_study_id": "5b173660-94c9-11ec-8c89-acde48001122",
+        "sample_name": "2STDY97",
+        "barcode": null,
+        "sample_species": "Gryphon",
+        "created_at": "2022/02/25 16:49",
+        "source_identifier": null
+      },
+      "relationships": {
+        "well": {
+          "links": {
+            "self": "/v1/pacbio/requests/264/relationships/well",
+            "related": "/v1/pacbio/requests/264/well"
+          }
+        },
+        "plate": {
+          "links": {
+            "self": "/v1/pacbio/requests/264/relationships/plate",
+            "related": "/v1/pacbio/requests/264/plate"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/e2e/specs/import_samples_from_samples_extraction.js
+++ b/tests/e2e/specs/import_samples_from_samples_extraction.js
@@ -2,7 +2,7 @@
 
 describe('Import samples from Samples extraction', () => {
   it('Successfully', () => {
-    cy.visit('#/pacbio/reception')
+    cy.visit('#/pacbio/samples-extraction-reception')
     cy.contains('Barcodes:')
     cy.get('#barcodes').type('SE108532I')
     cy.intercept('/api/v1/assets?filter[barcode]=SE108532I', {
@@ -14,7 +14,7 @@ describe('Import samples from Samples extraction', () => {
   })
 
   it('Unsuccessfully', () => {
-    cy.visit('#/pacbio/reception')
+    cy.visit('#/pacbio/samples-extraction-reception')
     cy.contains('Barcodes:')
     cy.get('#barcodes').type('SE108532I')
     cy.intercept('/api/v1/assets?filter[barcode]=SE108532I', {

--- a/tests/e2e/specs/import_samples_from_sequencescape.js
+++ b/tests/e2e/specs/import_samples_from_sequencescape.js
@@ -1,6 +1,6 @@
 describe('Import samples from Sequencescape', () => {
   it('Successfully', () => {
-    cy.visit('#/pacbio/plate-reception')
+    cy.visit('#/pacbio/sequencescape-reception')
     cy.contains('Barcodes:')
     cy.get('#barcodes').type('DN804974W')
     cy.intercept(
@@ -20,7 +20,7 @@ describe('Import samples from Sequencescape', () => {
   })
 
   it('Unsuccessfully - when the plates do not exist', () => {
-    cy.visit('#/pacbio/plate-reception')
+    cy.visit('#/pacbio/sequencescape-reception')
     cy.contains('Barcodes:')
     cy.get('#barcodes').type('DN804974W')
     cy.intercept(
@@ -35,7 +35,7 @@ describe('Import samples from Sequencescape', () => {
   })
 
   it('Unsuccessfully - when there is an error from traction', () => {
-    cy.visit('#/pacbio/plate-reception')
+    cy.visit('#/pacbio/sequencescape-reception')
     cy.contains('Barcodes:')
     cy.get('#barcodes').type('DN804974W')
     cy.intercept(

--- a/tests/unit/components/Message.spec.js
+++ b/tests/unit/components/Message.spec.js
@@ -37,6 +37,14 @@ describe('Message.vue', () => {
     expect(wrapper.find('.alert-success').element).toBeTruthy()
   })
 
+  it('converts types to boottrap styles', () => {
+    wrapper = mount(Message, {
+      localVue,
+      propsData: { ...requiredProps, type: 'error' },
+    })
+    expect(wrapper.find('.alert-danger').element).toBeTruthy()
+  })
+
   describe('data-attribute', () => {
     it('default', () => {
       const wrapper = mount(Message, { localVue, propsData: requiredProps })

--- a/tests/unit/services/Sequencescape.spec.js
+++ b/tests/unit/services/Sequencescape.spec.js
@@ -1,132 +1,12 @@
-import { getPlates, transformPlates, OntSample, PacbioSample } from '@/services/Sequencescape'
+import {
+  getPlates,
+  transformPlates,
+  OntSample,
+  PacbioSample,
+  labwareForImport,
+} from '@/services/Sequencescape'
 import { Data } from 'testHelper'
 import Response from '@/api/Response'
-
-const plates = [
-  {
-    id: '27210587',
-    type: 'plates',
-    uuid: '7747e988-a73a-11eb-b642-fa163eea3084',
-    name: 'Plate DN803958S',
-    labware_barcode: {
-      ean13_barcode: '1220803958837',
-      machine_barcode: 'DN803958S',
-      human_barcode: 'DN803958S',
-    },
-    state: 'pending',
-    number_of_rows: 8,
-    number_of_columns: 12,
-    size: 96,
-    created_at: '2021-04-27T10:25:11+01:00',
-    updated_at: '2021-04-30T13:41:38+01:00',
-    wells: [
-      {
-        type: 'wells',
-        id: '41656842',
-        uuid: '77f9e3e0-a73a-11eb-a305-fa163e8a206d',
-        name: 'DN803958S:A1',
-        position: { name: 'A1' },
-        state: 'unknown',
-        pcr_cycles: null,
-        submit_for_sequencing: null,
-        sub_pool: null,
-        coverage: null,
-        diluent_volume: null,
-        aliquots: [
-          {
-            type: 'aliquots',
-            id: '38486117',
-            tag_oligo: 'GGGATCCT',
-            tag_index: 1,
-            tag2_oligo: 'CCATCCAA',
-            tag2_index: 1,
-            suboptimal: false,
-            study: {
-              type: 'studies',
-              id: '5901',
-              name: 'DTOL_Darwin Tree of Life',
-              uuid: 'cf04ea86-ac82-11e9-8998-68b599768938',
-            },
-            sample: {
-              type: 'samples',
-              id: '5709173',
-              name: 'DTOL10233354',
-              sanger_sample_id: 'DTOL10233354',
-              uuid: '64e065a4-a9b0-11eb-991b-fa163eac3af7',
-              control: false,
-              control_type: null,
-              sample_metadata: {
-                type: 'sample_metadata',
-                id: '5707375',
-                sample_common_name: 'Orgyia antiqua',
-                supplier_name: 'FD21636035',
-              },
-            },
-          },
-        ],
-      },
-      {
-        type: 'wells',
-        id: '41656845',
-        uuid: '780088b2-a73a-11eb-a305-fa163e8a206d',
-        name: 'DN803958S:D1',
-        position: { name: 'D1' },
-        state: 'unknown',
-        pcr_cycles: null,
-        submit_for_sequencing: null,
-        sub_pool: null,
-        coverage: null,
-        diluent_volume: null,
-        aliquots: [
-          {
-            type: 'aliquots',
-            id: '38486120',
-            tag_oligo: 'GGGATCCT',
-            tag_index: 1,
-            tag2_oligo: 'CCATCCAA',
-            tag2_index: 1,
-            suboptimal: false,
-            study: {
-              type: 'studies',
-              id: '5901',
-              name: 'DTOL_Darwin Tree of Life',
-              uuid: 'cf04ea86-ac82-11e9-8998-68b599768938',
-            },
-            sample: {
-              type: 'samples',
-              id: '5709176',
-              name: 'DTOL10233357',
-              sanger_sample_id: 'DTOL10233357',
-              uuid: '64f86c9e-a9b0-11eb-991b-fa163eac3af7',
-              control: false,
-              control_type: null,
-              sample_metadata: {
-                type: 'sample_metadata',
-                id: '5707378',
-                sample_common_name: 'Ilex aquifolium',
-                supplier_name: 'FD21635705',
-              },
-            },
-          },
-        ],
-      },
-      {
-        type: 'wells',
-        id: '41656871',
-        uuid: '7836d336-a73a-11eb-a305-fa163e8a206d',
-        name: 'DN803958S:F4',
-        position: { name: 'F4' },
-        state: 'unknown',
-        pcr_cycles: null,
-        submit_for_sequencing: null,
-        sub_pool: null,
-        coverage: null,
-        diluent_volume: null,
-        aliquots: [],
-      },
-    ],
-  },
-]
 
 describe('SequencescapePlates', () => {
   describe('#getPlates', () => {
@@ -137,11 +17,15 @@ describe('SequencescapePlates', () => {
       barcodes = 'DN1234567'
 
       emptyResponse = { data: { data: [] }, status: 200, statusText: 'Success' }
-      failedResponse = { data: { data: [] }, status: 500, statusText: 'Internal Server Error' }
+      failedResponse = {
+        data: { errors: [{ title: 'error1', detail: 'There was an error.' }] },
+        status: 500,
+        statusText: 'Internal Server Error',
+      }
     })
 
     it('successfully', async () => {
-      request.get.mockReturnValue(Data.SequencescapePlates)
+      request.get.mockResolvedValue(Data.SequencescapePlates)
 
       expectedResponse = new Response(Data.SequencescapePlates)
       let expectedPlates = expectedResponse.deserialize.plates
@@ -155,7 +39,7 @@ describe('SequencescapePlates', () => {
     })
 
     it('unsuccessfully', async () => {
-      request.get.mockReturnValue(failedResponse)
+      request.get.mockRejectedValue(failedResponse)
 
       plates = await getPlates(request, barcodes)
 
@@ -164,12 +48,129 @@ describe('SequencescapePlates', () => {
     })
 
     it('when no plates exist', async () => {
-      request.get.mockReturnValue(emptyResponse)
+      request.get.mockResolvedValue(emptyResponse)
 
       plates = await getPlates(request, barcodes)
 
       expect(request.get).toHaveBeenCalled()
       expect(plates).toEqual([])
+    })
+  })
+
+  describe('#labwareForImport', () => {
+    const barcodes = ['DN1234567']
+    const emptyResponse = { data: { data: [] }, status: 200, statusText: 'Success' }
+    const failedResponse = {
+      data: { errors: [{ title: 'error1', detail: 'There was an error.' }] },
+      status: 500,
+      statusText: 'Internal Server Error',
+    }
+    let request
+
+    beforeEach(() => {
+      request = { get: jest.fn() }
+    })
+
+    it('successfully', async () => {
+      request.get.mockResolvedValue(Data.SequencescapeLabware)
+
+      const expectedPlates = [
+        {
+          barcode: 'DN9000002A',
+          wells: expect.arrayContaining([
+            {
+              position: 'A1',
+              samples: [
+                {
+                  external_id: 'd5008026-94c9-11ec-a9e3-acde48001122',
+                  name: '2STDY1',
+                  external_study_id: '5b173660-94c9-11ec-8c89-acde48001122',
+                  species: 'Dragon',
+                  library_type: 'Example',
+                },
+              ],
+            },
+            {
+              position: 'B1',
+              samples: [
+                {
+                  external_id: 'd50bad48-94c9-11ec-a9e3-acde48001122',
+                  name: '2STDY2',
+                  external_study_id: '5b173660-94c9-11ec-8c89-acde48001122',
+                  species: 'Unicorn',
+                  library_type: 'Example',
+                },
+              ],
+            },
+          ]),
+        },
+      ]
+      const expectedTubes = [
+        {
+          request: {
+            external_study_id: '5b173660-94c9-11ec-8c89-acde48001122',
+            library_type: 'Example',
+          },
+          sample: {
+            name: '2STDY97',
+            external_id: '0db37dd8-94ca-11ec-a9e3-acde48001122',
+            species: 'Gryphon',
+          },
+          tube: { barcode: '3980000001795' },
+        },
+      ]
+      let { plates, tubes, foundBarcodes } = await labwareForImport({
+        request,
+        barcodes,
+        sampleType: PacbioSample,
+        libraryType: 'Example',
+      })
+
+      expect(request.get).toHaveBeenCalledWith({
+        filter: { barcode: barcodes[0] },
+        include: 'receptacles.aliquots.sample.sample_metadata,receptacles.aliquots.study',
+        fields: {
+          aliquots: 'study,library_type,sample',
+          plates: 'labware_barcode,receptacles',
+          receptacles: 'aliquots',
+          sample_metadata: 'sample_common_name',
+          samples: 'sample_metadata,name,uuid',
+          studies: 'uuid',
+          tubes: 'labware_barcode,receptacles',
+          wells: 'position,aliquots',
+        },
+      })
+
+      expect(plates).toEqual(expectedPlates)
+      expect(tubes).toEqual(expectedTubes)
+      expect(foundBarcodes).toEqual([
+        '1229000002657',
+        'DN9000002A',
+        'DN9000002A',
+        '3980000001795',
+        '3980000001795',
+        'NT1O',
+      ])
+    })
+
+    it('unsuccessfully', async () => {
+      request.get.mockRejectedValue(failedResponse)
+
+      const { plates, tubes } = await labwareForImport({ request, barcodes })
+
+      expect(request.get).toHaveBeenCalled()
+      expect(plates).toEqual([])
+      expect(tubes).toEqual([])
+    })
+
+    it('when no plates exist', async () => {
+      request.get.mockResolvedValue(emptyResponse)
+
+      const { plates, tubes } = await labwareForImport({ request, barcodes })
+
+      expect(request.get).toHaveBeenCalled()
+      expect(plates).toEqual([])
+      expect(tubes).toEqual([])
     })
   })
 
@@ -203,6 +204,131 @@ describe('SequencescapePlates', () => {
   })
 
   describe('#transformPlates', () => {
+    const plates = [
+      {
+        id: '27210587',
+        type: 'plates',
+        uuid: '7747e988-a73a-11eb-b642-fa163eea3084',
+        name: 'Plate DN803958S',
+        labware_barcode: {
+          ean13_barcode: '1220803958837',
+          machine_barcode: 'DN803958S',
+          human_barcode: 'DN803958S',
+        },
+        state: 'pending',
+        number_of_rows: 8,
+        number_of_columns: 12,
+        size: 96,
+        created_at: '2021-04-27T10:25:11+01:00',
+        updated_at: '2021-04-30T13:41:38+01:00',
+        wells: [
+          {
+            type: 'wells',
+            id: '41656842',
+            uuid: '77f9e3e0-a73a-11eb-a305-fa163e8a206d',
+            name: 'DN803958S:A1',
+            position: { name: 'A1' },
+            state: 'unknown',
+            pcr_cycles: null,
+            submit_for_sequencing: null,
+            sub_pool: null,
+            coverage: null,
+            diluent_volume: null,
+            aliquots: [
+              {
+                type: 'aliquots',
+                id: '38486117',
+                tag_oligo: 'GGGATCCT',
+                tag_index: 1,
+                tag2_oligo: 'CCATCCAA',
+                tag2_index: 1,
+                suboptimal: false,
+                study: {
+                  type: 'studies',
+                  id: '5901',
+                  name: 'DTOL_Darwin Tree of Life',
+                  uuid: 'cf04ea86-ac82-11e9-8998-68b599768938',
+                },
+                sample: {
+                  type: 'samples',
+                  id: '5709173',
+                  name: 'DTOL10233354',
+                  sanger_sample_id: 'DTOL10233354',
+                  uuid: '64e065a4-a9b0-11eb-991b-fa163eac3af7',
+                  control: false,
+                  control_type: null,
+                  sample_metadata: {
+                    type: 'sample_metadata',
+                    id: '5707375',
+                    sample_common_name: 'Orgyia antiqua',
+                    supplier_name: 'FD21636035',
+                  },
+                },
+              },
+            ],
+          },
+          {
+            type: 'wells',
+            id: '41656845',
+            uuid: '780088b2-a73a-11eb-a305-fa163e8a206d',
+            name: 'DN803958S:D1',
+            position: { name: 'D1' },
+            state: 'unknown',
+            pcr_cycles: null,
+            submit_for_sequencing: null,
+            sub_pool: null,
+            coverage: null,
+            diluent_volume: null,
+            aliquots: [
+              {
+                type: 'aliquots',
+                id: '38486120',
+                tag_oligo: 'GGGATCCT',
+                tag_index: 1,
+                tag2_oligo: 'CCATCCAA',
+                tag2_index: 1,
+                suboptimal: false,
+                study: {
+                  type: 'studies',
+                  id: '5901',
+                  name: 'DTOL_Darwin Tree of Life',
+                  uuid: 'cf04ea86-ac82-11e9-8998-68b599768938',
+                },
+                sample: {
+                  type: 'samples',
+                  id: '5709176',
+                  name: 'DTOL10233357',
+                  sanger_sample_id: 'DTOL10233357',
+                  uuid: '64f86c9e-a9b0-11eb-991b-fa163eac3af7',
+                  control: false,
+                  control_type: null,
+                  sample_metadata: {
+                    type: 'sample_metadata',
+                    id: '5707378',
+                    sample_common_name: 'Ilex aquifolium',
+                    supplier_name: 'FD21635705',
+                  },
+                },
+              },
+            ],
+          },
+          {
+            type: 'wells',
+            id: '41656871',
+            uuid: '7836d336-a73a-11eb-a305-fa163e8a206d',
+            name: 'DN803958S:F4',
+            position: { name: 'F4' },
+            state: 'unknown',
+            pcr_cycles: null,
+            submit_for_sequencing: null,
+            sub_pool: null,
+            coverage: null,
+            diluent_volume: null,
+            aliquots: [],
+          },
+        ],
+      },
+    ]
     let transformedPlates, transformedPlate
 
     describe('for any type of plate', () => {

--- a/tests/unit/services/traction/Pacbio.spec.js
+++ b/tests/unit/services/traction/Pacbio.spec.js
@@ -1,58 +1,88 @@
-import { createPlates } from '@/services/traction/Pacbio'
+import { createLabware } from '@/services/traction/Pacbio'
 import { Data } from 'testHelper'
 
 const failedResponse = {
   status: 422,
   statusText: 'Record not found',
-  data: { errors: { error1: ['There was an error.'] } },
+  data: {
+    errors: [{ title: 'error1', detail: 'There was an error.' }],
+  },
 }
 
-const createdResponse = {
+const createdPlateResponse = {
   status: 201,
   statusText: 'created',
   data: Data.TractionPlates,
 }
 
+const createdRequestResponse = {
+  status: 201,
+  statusText: 'created',
+  data: {},
+}
+
 describe('Pacbio', () => {
-  describe('#createPlates', () => {
+  describe('#createLabware', () => {
+    const fetchLabware = jest.fn()
+    const createPlate = jest.fn()
+    const createTube = jest.fn()
+
     afterEach(() => {
-      requests.sequencescape.get.mockRestore()
-      requests.traction.create.mockRestore()
+      fetchLabware.mockRestore()
+      createPlate.mockRestore()
+      createTube.mockRestore()
     })
 
     // would it be better to mock the Sequencescape function??
-    const requests = { sequencescape: { get: jest.fn() }, traction: { create: jest.fn() } }
+    const requests = {
+      sequencescape: { get: fetchLabware },
+      traction: {
+        plates: { create: createPlate },
+        requests: { create: createTube },
+      },
+    }
 
     it('successfully', async () => {
-      requests.sequencescape.get.mockReturnValue(Data.SequencescapePlates)
-      requests.traction.create.mockReturnValue(createdResponse)
+      fetchLabware.mockResolvedValue(Data.SequencescapeLabware)
+      createPlate.mockResolvedValue(createdPlateResponse)
+      createTube.mockResolvedValue(createdRequestResponse)
 
-      const response = await createPlates({ requests, barcodes: ['DN1', 'DN2'] })
+      const response = await createLabware({
+        requests,
+        barcodes: ['DN9000002A', 'NT1O'],
+      })
+
       expect(response.status).toEqual('success')
-      expect(response.message).toEqual('Plates created with barcodes DN1,DN2')
+      expect(response.message).toEqual('Labware created with barcodes DN9000002A,NT1O')
     })
 
-    it('generates a valid payload', async () => {
-      requests.sequencescape.get.mockReturnValue(Data.SequencescapePlates)
-      requests.traction.create.mockReturnValue(createdResponse)
-      await createPlates({ requests, barcodes: ['DN1', 'DN2'], libraryType: 'Example' })
+    it('generates a valid plate payload', async () => {
+      fetchLabware.mockResolvedValue(Data.SequencescapeLabware)
+      createPlate.mockResolvedValue(createdPlateResponse)
+      createTube.mockResolvedValue(createdRequestResponse)
 
-      expect(requests.traction.create).toHaveBeenCalledWith({
+      await createLabware({
+        requests,
+        barcodes: ['DN9000002A', 'NT1O'],
+        libraryType: 'Example',
+      })
+
+      expect(createPlate).toHaveBeenCalledWith({
         data: {
           data: {
             attributes: {
               plates: [
                 expect.objectContaining({
-                  barcode: 'DN803958S',
+                  barcode: 'DN9000002A',
                   wells: expect.arrayContaining([
                     {
                       position: 'A1',
                       samples: [
                         {
-                          external_id: '64e065a4-a9b0-11eb-991b-fa163eac3af7',
-                          external_study_id: 'cf04ea86-ac82-11e9-8998-68b599768938',
-                          name: 'DTOL10233354',
-                          species: 'Orgyia antiqua',
+                          external_id: 'd5008026-94c9-11ec-a9e3-acde48001122',
+                          external_study_id: '5b173660-94c9-11ec-8c89-acde48001122',
+                          name: '2STDY1',
+                          species: 'Dragon',
                           library_type: 'Example',
                         },
                       ],
@@ -61,17 +91,52 @@ describe('Pacbio', () => {
                       position: 'B1',
                       samples: [
                         {
-                          external_id: '64e8f43a-a9b0-11eb-991b-fa163eac3af7',
-                          external_study_id: 'cf04ea86-ac82-11e9-8998-68b599768938',
-                          name: 'DTOL10233355',
-                          species: 'Chelidonium majus',
+                          external_id: 'd50bad48-94c9-11ec-a9e3-acde48001122',
+                          external_study_id: '5b173660-94c9-11ec-8c89-acde48001122',
+                          name: '2STDY2',
+                          species: 'Unicorn',
                           library_type: 'Example',
                         },
                       ],
                     },
                   ]),
                 }),
-                expect.objectContaining({ barcode: 'DN804974W' }),
+              ],
+            },
+          },
+        },
+      })
+    })
+
+    it('generates a valid tube payload', async () => {
+      fetchLabware.mockResolvedValue(Data.SequencescapeLabware)
+      createPlate.mockResolvedValue(createdPlateResponse)
+      createTube.mockResolvedValue(createdRequestResponse)
+
+      await createLabware({
+        requests,
+        barcodes: ['DN9000002A', 'NT1O'],
+        libraryType: 'Example',
+      })
+
+      expect(createTube).toHaveBeenCalledWith({
+        data: {
+          data: {
+            type: 'requests',
+            attributes: {
+              requests: [
+                {
+                  sample: {
+                    name: '2STDY97',
+                    species: 'Gryphon',
+                    external_id: '0db37dd8-94ca-11ec-a9e3-acde48001122',
+                  },
+                  request: {
+                    external_study_id: '5b173660-94c9-11ec-8c89-acde48001122',
+                    library_type: 'Example',
+                  },
+                  tube: { barcode: '3980000001795' },
+                },
               ],
             },
           },
@@ -80,18 +145,41 @@ describe('Pacbio', () => {
     })
 
     describe('unsuccessfully', () => {
-      it('when the plates could not be retrievied', async () => {
-        requests.sequencescape.get.mockReturnValue(failedResponse)
-        const response = await createPlates({ requests, barcodes: ['DN1', 'DN2'] })
+      it('when the labware could not be retrievied', async () => {
+        fetchLabware.mockRejectedValue({ response: failedResponse })
+
+        const response = await createLabware({
+          requests,
+          barcodes: ['DN9000002A', 'NT1O'],
+        })
         expect(response.status).toEqual('error')
-        expect(response.message).toEqual('Plates could not be retrieved from Sequencescape')
+        expect(response.message).toEqual(
+          'Labware could not be retrieved from Sequencescape: DN9000002A,NT1O',
+        )
       })
 
-      it('when the plates could not be created', async () => {
-        requests.sequencescape.get.mockReturnValue(Data.SequencescapePlates)
-        requests.traction.create.mockReturnValue(failedResponse)
+      it('when the plate could not be created', async () => {
+        fetchLabware.mockResolvedValue(Data.SequencescapeLabware)
+        createPlate.mockRejectedValue({ response: failedResponse })
+        createTube.mockResolvedValue(createdRequestResponse)
 
-        const response = await createPlates({ requests, barcodes: ['DN1', 'DN2'] })
+        const response = await createLabware({
+          requests,
+          barcodes: ['DN9000002A', 'NT1O'],
+        })
+        expect(response.status).toEqual('error')
+        expect(response.message).toEqual('error1 There was an error.')
+      })
+
+      it('when the tube could not be created', async () => {
+        fetchLabware.mockResolvedValue(Data.SequencescapeLabware)
+        createPlate.mockResolvedValue(createdPlateResponse)
+        createTube.mockRejectedValue({ response: failedResponse })
+
+        const response = await createLabware({
+          requests,
+          barcodes: ['DN9000002A', 'NT1O'],
+        })
         expect(response.status).toEqual('error')
         expect(response.message).toEqual('error1 There was an error.')
       })

--- a/tests/unit/views/Dashboard.spec.js
+++ b/tests/unit/views/Dashboard.spec.js
@@ -91,15 +91,15 @@ describe('Dashboard.vue', () => {
     describe('route buttons', () => {
       it('will have a reception button', () => {
         let receptionButton = box.findAll('button').at(0)
-        expect(receptionButton.text()).toEqual('Reception')
+        expect(receptionButton.text()).toEqual('Samples extraction reception')
         receptionButton.trigger('click')
-        expect(wrapper.vm.$route.path).toBe('/pacbio/reception')
+        expect(wrapper.vm.$route.path).toBe('/pacbio/samples-extraction-reception')
       })
       it('will have a plate reception button', () => {
         let receptionButton = box.findAll('button').at(1)
-        expect(receptionButton.text()).toEqual('Plate reception')
+        expect(receptionButton.text()).toEqual('Sequencescape reception')
         receptionButton.trigger('click')
-        expect(wrapper.vm.$route.path).toBe('/pacbio/plate-reception')
+        expect(wrapper.vm.$route.path).toBe('/pacbio/sequencescape-reception')
       })
       it('will have a plates button', () => {
         let platesButton = box.findAll('button').at(2)

--- a/tests/unit/views/pacbio/PacbioReceptionSamplesExtraction.spec.js
+++ b/tests/unit/views/pacbio/PacbioReceptionSamplesExtraction.spec.js
@@ -1,8 +1,8 @@
-import Reception from '@/views/pacbio/PacbioReceptionTube'
+import Reception from '@/views/pacbio/PacbioReceptionSamplesExtraction'
 import { mount, localVue, store, Data, router } from 'testHelper'
 import Response from '@/api/Response'
 
-describe('Reception', () => {
+describe('PacbioReceptionSamplesExtraction', () => {
   let wrapper, reception, barcodes, barcode, input
 
   beforeEach(() => {

--- a/tests/unit/views/pacbio/PacbioReceptionSequencescape.spec.js
+++ b/tests/unit/views/pacbio/PacbioReceptionSequencescape.spec.js
@@ -27,14 +27,14 @@ describe('PacbioReceptionSequencescape', () => {
       input = wrapper.find('textarea')
       await input.setValue(barcode)
       expect(reception.barcodes).toEqual(barcode)
-      expect(wrapper.find('#createTractionPlates').text()).toEqual('Import 1 plate')
+      expect(wrapper.find('#createTractionPlates').text()).toEqual('Import 1 labware')
     })
 
     it('multiple barcodes', async () => {
       input = wrapper.find('textarea')
       await input.setValue(barcodes)
       expect(reception.barcodes).toEqual(barcodes)
-      expect(wrapper.find('#createTractionPlates').text()).toEqual('Import 5 plates')
+      expect(wrapper.find('#createTractionPlates').text()).toEqual('Import 5 labware')
     })
   })
 

--- a/tests/unit/views/pacbio/PacbioReceptionSequencescape.spec.js
+++ b/tests/unit/views/pacbio/PacbioReceptionSequencescape.spec.js
@@ -1,8 +1,8 @@
-import Reception from '@/views/pacbio/PacbioReceptionPlate'
+import Reception from '@/views/pacbio/PacbioReceptionSequencescape'
 import { mount, localVue, store, router } from 'testHelper'
 import * as pacbio from '@/services/traction/Pacbio'
 
-describe('Reception', () => {
+describe('PacbioReceptionSequencescape', () => {
   let wrapper, reception, barcodes, barcode, input
 
   beforeEach(() => {

--- a/tests/unit/views/pacbio/PacbioReceptionSequencescape.spec.js
+++ b/tests/unit/views/pacbio/PacbioReceptionSequencescape.spec.js
@@ -61,22 +61,22 @@ describe('PacbioReceptionSequencescape', () => {
       wrapper.setData({ barcodes: 'DN1\nDN2' })
     })
 
-    it('reports success when createPlates works', async () => {
-      const mockedcreatePlates = jest.spyOn(pacbio, 'createPlates').mockImplementation(() => {})
+    it('reports success when createLabware works', async () => {
+      const mockedcreateLabware = jest.spyOn(pacbio, 'createLabware').mockImplementation(() => {})
 
-      mockedcreatePlates.mockResolvedValue({
+      mockedcreateLabware.mockResolvedValue({
         status: 'success',
         message: 'Samples have been created with barcodes: DN1, DN2',
       })
 
       await reception.createTractionPlates()
 
-      expect(mockedcreatePlates).toBeCalledWith({
+      expect(mockedcreateLabware).toBeCalledWith({
         requests: expect.objectContaining({
           sequencescape: expect.anything(),
           traction: expect.anything(),
         }),
-        barcodes: 'DN1,DN2',
+        barcodes: ['DN1', 'DN2'],
         libraryType: undefined,
       })
       expect(reception.showAlert).toBeCalledWith(
@@ -86,9 +86,9 @@ describe('PacbioReceptionSequencescape', () => {
     })
 
     it('passes library type when selected', async () => {
-      const mockedcreatePlates = jest.spyOn(pacbio, 'createPlates').mockImplementation(() => {})
+      const mockedcreateLabware = jest.spyOn(pacbio, 'createLabware').mockImplementation(() => {})
 
-      mockedcreatePlates.mockResolvedValue({
+      mockedcreateLabware.mockResolvedValue({
         status: 'success',
         message: 'Samples have been created with barcodes: DN1, DN2',
       })
@@ -96,27 +96,27 @@ describe('PacbioReceptionSequencescape', () => {
       await wrapper.setData({ libraryType: 'Example' })
       await reception.createTractionPlates()
 
-      expect(mockedcreatePlates).toBeCalledWith({
+      expect(mockedcreateLabware).toBeCalledWith({
         requests: expect.objectContaining({
           sequencescape: expect.anything(),
           traction: expect.anything(),
         }),
-        barcodes: 'DN1,DN2',
+        barcodes: ['DN1', 'DN2'],
         libraryType: 'Example',
       })
     })
 
     it('is unsuccessful when getSampleExtractionPlatesForBarcodes fails', async () => {
-      const mockedcreatePlates = jest.spyOn(pacbio, 'createPlates').mockImplementation(() => {})
+      const mockedcreateLabware = jest.spyOn(pacbio, 'createLabware').mockImplementation(() => {})
 
-      mockedcreatePlates.mockResolvedValue({
+      mockedcreateLabware.mockResolvedValue({
         status: 'danger',
         message: 'Failed to create samples: title Plate could not be found.',
       })
 
       await reception.createTractionPlates()
 
-      expect(mockedcreatePlates).toBeCalled()
+      expect(mockedcreateLabware).toBeCalled()
 
       expect(reception.showAlert).toBeCalledWith(
         'Failed to create samples: title Plate could not be found.',


### PR DESCRIPTION
Closes #715 

See companion PR in Sequencescape and traction-service.
https://github.com/sanger/sequencescape/pull/3545
https://github.com/sanger/traction-service/pull/727

Changes proposed in this pull request:

* Add import of tubes from Sequencescape
* Begin refactor of reception in anticipation of ONT and external user requirements

