### PR TITLE
Issue716/dpl 298 add ability to add tubes to a pacbio pool {c v 4}

### DIFF
--- a/src/components/pacbio/PacbioLabwareFind.vue
+++ b/src/components/pacbio/PacbioLabwareFind.vue
@@ -1,7 +1,7 @@
 <template>
   <b-col>
     <b-form @submit.prevent="handleSubmit()">
-      <h3>Find plates</h3>
+      <h3>Find Labware</h3>
       <b-form-input
         v-model="enteredLabware"
         data-input="labware-find"
@@ -27,7 +27,9 @@
 
 <script>
 import { createNamespacedHelpers } from 'vuex'
-const { mapMutations, mapActions } = createNamespacedHelpers('traction/pacbio/poolCreate')
+const { mapMutations, mapActions, mapGetters } = createNamespacedHelpers(
+  'traction/pacbio/poolCreate',
+)
 
 export default {
   name: 'PacbioLabwareFind',
@@ -40,9 +42,7 @@ export default {
     getFilteredList() {
       return this.labwareList.filter((labware) => labware.barcode.includes(this.enteredLabware))
     },
-    labwareList() {
-      return this.$store.getters['traction/pacbio/poolCreate/labwareList']
-    },
+    ...mapGetters(['labwareList']),
   },
   methods: {
     handleSubmit() {
@@ -50,7 +50,7 @@ export default {
       labware
         ? this.toggleSelected(labware)
         : this.showAlert(
-            'Unable to find a plate with the barcode: ' + this.enteredLabware,
+            `Unable to find labware with the barcode: ${this.enteredLabware}`,
             'danger',
           )
       this.enteredLabware = ''
@@ -72,7 +72,7 @@ export default {
 @import 'src/styles/components.scss';
 .find-list-group {
   max-height: 150px;
-  overflow: scroll;
+  overflow-y: auto;
 }
 
 .list-group-item {

--- a/src/components/pacbio/PacbioLabwareSelectedList.vue
+++ b/src/components/pacbio/PacbioLabwareSelectedList.vue
@@ -5,6 +5,7 @@
       :container="$el"
       :selectableTargets="['ellipse.filled']"
       :continueSelect="true"
+      :keyContainer="$el"
       hitRate="20"
       @select="onSelect"
     />

--- a/src/components/pacbio/PacbioPlateFind.vue
+++ b/src/components/pacbio/PacbioPlateFind.vue
@@ -1,0 +1,82 @@
+<template>
+  <b-col>
+    <b-form @submit.prevent="handleSubmit()">
+      <h3>Find Plate</h3>
+      <b-form-input
+        v-model="enteredLabware"
+        data-input="plate-find"
+        autocomplete="off"
+        placeholder="Search or scan for plate by barcode"
+        class="mb-2"
+      >
+      </b-form-input>
+      <b-list-group data-type="plate-list" class="find-list-group">
+        <b-list-group-item
+          v-for="item in getFilteredList"
+          :key="item.id"
+          button
+          :active="item.selected"
+          data-action="select-plate"
+          @click="toggleSelected(item)"
+        >
+          Plate: {{ item.barcode }}
+        </b-list-group-item>
+      </b-list-group>
+    </b-form>
+  </b-col>
+</template>
+
+<script>
+import { createNamespacedHelpers } from 'vuex'
+const { mapMutations, mapActions, mapGetters } = createNamespacedHelpers(
+  'traction/pacbio/poolCreate',
+)
+
+export default {
+  name: 'PacbioLabwareFind',
+  data() {
+    return {
+      enteredLabware: '',
+    }
+  },
+  computed: {
+    getFilteredList() {
+      return this.plateList.filter((labware) => labware.barcode.includes(this.enteredLabware))
+    },
+    ...mapGetters(['plateList']),
+  },
+  methods: {
+    handleSubmit() {
+      let labware = this.plateList.find((labware) => labware.barcode === this.enteredLabware)
+      labware
+        ? this.toggleSelected(labware)
+        : this.showAlert(
+            `Unable to find labware with the barcode: ${this.enteredLabware}`,
+            'danger',
+          )
+      this.enteredLabware = ''
+    },
+    toggleSelected({ id, selected }) {
+      if (selected) {
+        this.deselectPlateAndContents(id)
+      } else {
+        this.selectPlate({ id })
+      }
+    },
+    ...mapMutations(['selectPlate']),
+    ...mapActions(['deselectPlateAndContents']),
+  },
+}
+</script>
+
+<style scoped lang="scss">
+@import 'src/styles/components.scss';
+.find-list-group {
+  max-height: 150px;
+  overflow-y: auto;
+}
+
+.list-group-item {
+  margin: 0;
+}
+</style>

--- a/src/components/pacbio/PacbioPlateSelectedList.vue
+++ b/src/components/pacbio/PacbioPlateSelectedList.vue
@@ -104,7 +104,7 @@ export default {
 <style scoped lang="scss">
 @import 'src/styles/components.scss';
 .wrapper {
-  overflow: scroll;
+  overflow: auto;
   display: flex;
   flex-wrap: wrap;
 }

--- a/src/components/pacbio/PacbioPoolEdit.vue
+++ b/src/components/pacbio/PacbioPoolEdit.vue
@@ -1,9 +1,9 @@
 <template>
-  <b-col data-type="pool">
+  <div data-type="pool">
     <h3>
       Pooled Samples <b-badge data-attribute="pool-type">{{ poolType }}</b-badge>
     </h3>
-    <b-row>
+    <b-row class="mb-1">
       <b-col>
         <b-form-checkbox v-model="autoTag" name="check-button" switch data-attribute="auto-tagging">
           Autotagging
@@ -95,7 +95,7 @@
         <b-spinner v-show="busy" small></b-spinner>
       </b-button>
     </div>
-  </b-col>
+  </div>
 </template>
 
 <script>

--- a/src/components/pacbio/PacbioTagSetItem.vue
+++ b/src/components/pacbio/PacbioTagSetItem.vue
@@ -1,20 +1,22 @@
 <template>
-  <b-col class="tag-set-item">
-    <div data-attribute="tag-set-name" class="tag-set-name">
-      <h3>{{ tagSetName }}</h3>
-    </div>
-    <div v-if="!isEmpty" data-type="tag-set-item" class="wrapper flex-wrap">
+  <details v-if="selectedTagSet.id" class="tag-set-item">
+    <summary data-attribute="tag-set-name" class="tag-set-name">
+      {{ tagSetName }} <b-badge>{{ tagCount }} tags</b-badge>
+    </summary>
+    <div data-type="tag-set-item" class="wrapper flex-wrap">
       <div
         v-for="tag in selectedTagSet.tags"
         :key="tag.id"
         data-attribute="group-id"
         class="border rounded"
-        @click="setSelected(tag.id)"
       >
         {{ tag.group_id }}
       </div>
     </div>
-  </b-col>
+  </details>
+  <div v-else class="tag-set-item">
+    <div class="tag-set-name">No tag set selected</div>
+  </div>
 </template>
 
 <script>
@@ -24,27 +26,15 @@ const { mapGetters } = createNamespacedHelpers('traction/pacbio/poolCreate')
 export default {
   name: 'PacbioTagSetShow',
   data() {
-    return {
-      selected: [],
-    }
+    return {}
   },
   computed: {
     ...mapGetters(['selectedTagSet']),
-    isEmpty() {
-      return this.selectedTagSet.tags.length === 0
-    },
     tagSetName() {
-      return this.selectedTagSet.name || 'No tag set selected'
+      return this.selectedTagSet.name
     },
-  },
-  methods: {
-    setSelected(id) {
-      const index = this.selected.indexOf(id)
-      if (index === -1) {
-        this.selected.push(id)
-      } else {
-        this.selected.splice(index, 1)
-      }
+    tagCount() {
+      return this.selectedTagSet.tags.length
     },
   },
 }
@@ -64,6 +54,7 @@ export default {
 }
 .tag-set-item {
   padding-bottom: 10px;
+  padding-top: 10px;
 }
 .tag-set-name {
   text-align: left;

--- a/src/components/pacbio/PacbioTagSetItem.vue
+++ b/src/components/pacbio/PacbioTagSetItem.vue
@@ -15,7 +15,7 @@
     </div>
   </details>
   <div v-else class="tag-set-item">
-    <div class="tag-set-name">No tag set selected</div>
+    <div data-attribute="tag-set-name-placeholder" class="tag-set-name">No tag set selected</div>
   </div>
 </template>
 

--- a/src/components/pacbio/PacbioTagSetList.vue
+++ b/src/components/pacbio/PacbioTagSetList.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-col class="tag-set-list">
+  <div class="tag-set-list">
     <h3>Select tag set</h3>
     <b-form-select
       v-if="!isEmpty"
@@ -8,7 +8,7 @@
       :options="options"
       @change="updateSelected"
     ></b-form-select>
-  </b-col>
+  </div>
 </template>
 
 <script>

--- a/src/components/pacbio/PacbioTubeFind.vue
+++ b/src/components/pacbio/PacbioTubeFind.vue
@@ -1,24 +1,25 @@
 <template>
   <b-col>
     <b-form @submit.prevent="handleSubmit()">
-      <h3>Find Labware</h3>
+      <h3>Find Tube</h3>
       <b-form-input
         v-model="enteredLabware"
-        data-input="labware-find"
+        data-input="tube-find"
         autocomplete="off"
-        placeholder="Search or scan for labware by barcode"
+        placeholder="Search or scan for tube by barcode"
+        class="mb-2"
       >
       </b-form-input>
-      <b-list-group data-type="labware-list" class="find-list-group">
+      <b-list-group data-type="tube-list" class="find-list-group">
         <b-list-group-item
           v-for="item in getFilteredList"
           :key="item.id"
           button
           :active="item.selected"
-          data-action="select-labware"
+          data-action="select-tube"
           @click="toggleSelected(item)"
         >
-          Plate: {{ item.barcode }}
+          Tube: {{ item.barcode }}
         </b-list-group-item>
       </b-list-group>
     </b-form>
@@ -27,9 +28,7 @@
 
 <script>
 import { createNamespacedHelpers } from 'vuex'
-const { mapMutations, mapActions, mapGetters } = createNamespacedHelpers(
-  'traction/pacbio/poolCreate',
-)
+const { mapActions, mapGetters } = createNamespacedHelpers('traction/pacbio/poolCreate')
 
 export default {
   name: 'PacbioLabwareFind',
@@ -40,13 +39,13 @@ export default {
   },
   computed: {
     getFilteredList() {
-      return this.labwareList.filter((labware) => labware.barcode.includes(this.enteredLabware))
+      return this.tubeList.filter((labware) => labware.barcode.includes(this.enteredLabware))
     },
-    ...mapGetters(['labwareList']),
+    ...mapGetters(['tubeList']),
   },
   methods: {
     handleSubmit() {
-      let labware = this.labwareList.find((labware) => labware.barcode === this.enteredLabware)
+      let labware = this.tubeList.find((labware) => labware.barcode === this.enteredLabware)
       labware
         ? this.toggleSelected(labware)
         : this.showAlert(
@@ -57,13 +56,12 @@ export default {
     },
     toggleSelected({ id, selected }) {
       if (selected) {
-        this.deselectPlateAndContents(id)
+        this.deselectTubeAndContents(id)
       } else {
-        this.selectPlate({ id })
+        this.selectTubeAndContents(id)
       }
     },
-    ...mapMutations(['selectPlate']),
-    ...mapActions(['deselectPlateAndContents']),
+    ...mapActions(['deselectTubeAndContents', 'selectTubeAndContents']),
   },
 }
 </script>

--- a/src/components/pacbio/PacbioTubeSelectedList.vue
+++ b/src/components/pacbio/PacbioTubeSelectedList.vue
@@ -1,0 +1,81 @@
+<template>
+  <b-col data-type="selected-tube-list" class="selected-tube-list">
+    <h3>Selected Tube Requests</h3>
+    <b-list-group class="selected-list-group">
+      <b-table
+        :items="selectedTubeRequests"
+        show-empty
+        small
+        :fields="requestFields"
+        :tbody-tr-class="rowClass"
+        empty-text="No tubes selected"
+        @row-clicked="requestClicked"
+      ></b-table>
+    </b-list-group>
+  </b-col>
+</template>
+
+<script>
+import { createNamespacedHelpers } from 'vuex'
+
+const { mapGetters, mapMutations, mapActions } = createNamespacedHelpers(
+  'traction/pacbio/poolCreate',
+)
+
+export default {
+  name: 'PacbioLabwareSelectedList',
+  data() {
+    return {
+      requestFields: [
+        'source_identifier',
+        'sample_species',
+        'library_type',
+        'number_of_smrt_cells',
+        'estimate_of_gb_required',
+      ],
+    }
+  },
+  computed: {
+    ...mapGetters(['selectedTubes', 'wellList', 'requestList']),
+    selectedTubeRequests() {
+      // Not really sure this belongs here, and I'd prefer to see this handled
+      // in the getters.
+      return this.selectedTubes.flatMap((tube) => {
+        return this.requestList(tube.requests || [])
+      })
+    },
+  },
+  methods: {
+    ...mapMutations(['selectTube', 'selectRequest']),
+    ...mapActions(['selectWellRequests']),
+    requestClicked({ id, selected }) {
+      this.selectRequest({ id, selected: !selected })
+    },
+    rowClass(item) {
+      if (item && item.selected) {
+        return 'table-primary'
+      }
+    },
+    onSelect(e) {
+      e.added.forEach((el) => {
+        this.selectWellRequests(el.__vue__.$attrs.id)
+      })
+      e.removed.forEach((el) => {
+        this.selectWellRequests(el.__vue__.$attrs.id)
+      })
+    },
+  },
+}
+</script>
+
+<style scoped lang="scss">
+@import 'src/styles/components.scss';
+.wrapper {
+  overflow: auto;
+  display: flex;
+  flex-wrap: wrap;
+}
+.wrapper > div {
+  width: 50%;
+}
+</style>

--- a/src/services/traction/Pacbio.js
+++ b/src/services/traction/Pacbio.js
@@ -4,6 +4,16 @@ import { PacbioSample, labwareForImport } from '@/services/Sequencescape'
 const checkBarcodes = (barcodes, foundBarcodes) =>
   barcodes.filter((barcode) => !foundBarcodes.includes(barcode))
 
+const makePlateRequest = (request, plates) =>
+  plates.length > 0
+    ? request.create({ data: { data: { attributes: { plates } } } })
+    : { success: true, data: [] }
+
+const makeTubeRequest = (request, tubes) =>
+  tubes.length > 0
+    ? request.create({ data: { data: { attributes: { requests: tubes }, type: 'requests' } } })
+    : { success: true, data: [] }
+
 /*
   retrieve the plates from Sequencescape.
   if that is successful transform the plates into the correct format.
@@ -27,26 +37,8 @@ const createLabware = async ({ requests, barcodes, libraryType }) => {
     }
   }
 
-  const plateRequest = requests.traction.plates.create({
-    data: {
-      data: {
-        attributes: {
-          plates,
-        },
-      },
-    },
-  })
-
-  const tubeRequest = requests.traction.requests.create({
-    data: {
-      data: {
-        attributes: {
-          requests: tubes,
-        },
-        type: 'requests',
-      },
-    },
-  })
+  const plateRequest = makePlateRequest(requests.traction.plates, plates)
+  const tubeRequest = makeTubeRequest(requests.traction.requests, tubes)
 
   const plateResponse = await handleResponse(plateRequest)
   const tubeResponse = await handleResponse(tubeRequest)

--- a/src/store/traction/pacbio/poolCreate/actions.js
+++ b/src/store/traction/pacbio/poolCreate/actions.js
@@ -278,7 +278,7 @@ export default {
    * - Do not apply tags that appear earlier on the plate
    * - Do not apply tags to request originating from other plates
    * - Offset tags based on well position, ignoring occupancy. For example
-   *   if tag 2 was applied to A1, then C1 would receive tag 4 regardless of
+   *   if tag 2 was applied to A1, then C1 would receive tag 4 regardless
    *   the state of B1.
    */
   applyTags: ({ state, commit, getters }, { library, autoTag }) => {

--- a/src/store/traction/pacbio/poolCreate/actions.js
+++ b/src/store/traction/pacbio/poolCreate/actions.js
@@ -85,6 +85,29 @@ export default {
       }
     }
   },
+  /**
+   * When a tube is deselected, we need to also remove all its requests
+   */
+  deselectTubeAndContents: ({ commit, state }, tubeId) => {
+    commit('selectTube', { id: tubeId, selected: false })
+    const { requests } = state.resources.tubes[tubeId]
+
+    for (let requestId of requests) {
+      commit('selectRequest', { id: requestId, selected: false })
+    }
+  },
+  /**
+   * When a tube is deselected, we need to also remove all its requests
+   */
+  selectTubeAndContents: ({ commit, state }, tubeId) => {
+    commit('selectTube', { id: tubeId, selected: true })
+
+    const { requests } = state.resources.tubes[tubeId]
+
+    for (let requestId of requests) {
+      commit('selectRequest', { id: requestId, selected: true })
+    }
+  },
 
   /*
    * Creates a pool from the libraries

--- a/src/store/traction/pacbio/poolCreate/actions.js
+++ b/src/store/traction/pacbio/poolCreate/actions.js
@@ -26,16 +26,17 @@ export default {
    */
   fetchPacbioRequests: async ({ commit, rootState }) => {
     const request = rootState.api.traction.pacbio.requests
-    const promise = request.get({ include: 'well.plate' })
+    const promise = request.get({ include: 'well.plate,tube' })
     const response = await handleResponse(promise)
 
     const { success, data: { data, included = [] } = {}, errors = [] } = response
 
     if (success) {
-      const { wells, plates } = groupIncludedByResource(included)
+      const { wells, plates, tubes } = groupIncludedByResource(included)
       commit('populateRequests', data)
       commit('populatePlates', plates)
       commit('populateWells', wells)
+      commit('populateTubes', tubes)
     }
 
     return { success, errors }

--- a/src/store/traction/pacbio/poolCreate/actions.js
+++ b/src/store/traction/pacbio/poolCreate/actions.js
@@ -20,18 +20,24 @@ const csvLogger = (commit, info, level) => (message) =>
 // the store context
 // see https://vuex.vuejs.org/guide/actions.html
 export default {
-  fetchPacbioPlates: async ({ commit, rootState }) => {
-    const request = rootState.api.traction.pacbio.plates
-    const promise = request.get({ include: 'wells.requests' })
+  /**
+   * Retrieves a list of pacbio request from traction-service and populates the store
+   * with associated plates, wells and tubes
+   * @param rootState the vuex rootState object. Provides access to current state
+   * @param commit the vuex commit object. Provides access to mutations
+   */
+  fetchPacbioRequests: async ({ commit, rootState }) => {
+    const request = rootState.api.traction.pacbio.requests
+    const promise = request.get({ include: 'well.plate' })
     const response = await handleResponse(promise)
 
     const { success, data: { data, included = [] } = {}, errors = [] } = response
 
     if (success) {
-      const { wells, requests } = groupIncludedByResource(included)
-      commit('populatePlates', data)
+      const { wells, plates } = groupIncludedByResource(included)
+      commit('populateRequests', data)
+      commit('populatePlates', plates)
       commit('populateWells', wells)
-      commit('populateRequests', requests)
     }
 
     return { success, errors }

--- a/src/store/traction/pacbio/poolCreate/actions.js
+++ b/src/store/traction/pacbio/poolCreate/actions.js
@@ -177,7 +177,7 @@ export default {
   /*
    * Given a tag change to library_a, will automatically apply tags to the remaining wells
    * on the plate with the following  rules:
-   * - Only apply additional tags is autoTag is true
+   * - Only apply additional tags if autoTag is true
    * - Tags applied in column order based on the source well
    * - Do not apply tags that appear earlier on the plate
    * - Do not apply tags to request originating from other plates

--- a/src/store/traction/pacbio/poolCreate/actions.js
+++ b/src/store/traction/pacbio/poolCreate/actions.js
@@ -16,8 +16,6 @@ const csvLogger = (commit, info, level) => (message) =>
   )
 
 // Actions handle asynchronous update of state, via mutations.
-// Note: The { commit } in the given example is destucturing
-// the store context
 // see https://vuex.vuejs.org/guide/actions.html
 export default {
   /**

--- a/src/store/traction/pacbio/poolCreate/getters.js
+++ b/src/store/traction/pacbio/poolCreate/getters.js
@@ -4,7 +4,7 @@ import { wellToIndex } from './wellHelpers'
 /**
  * Merge together two representations of the same object.
  * The parent object will be mapped over, and equivalent items from the
- * child object will be merged in. keyFuntion allwos for cases where there
+ * child object will be merged in. keyFunction allows for cases where there
  * is not a 1:1 mapping between ids.
  * @param {Object} parent the parent object, only resources in here will be present in the output.
  * @param {Object} child resources with a matching id will be merged into the parent
@@ -40,10 +40,10 @@ const sortRequestByLabware = (resources) => (a, b) => {
 
 export default {
   /**
-   * Returns a list of all fetched labware
+   * Returns a list of all fetched plates
    * @param {Object} state The Vuex state object
    */
-  labwareList: ({ selected, resources }) => {
+  plateList: ({ selected, resources }) => {
     return mergeRepresentations(resources.plates, selected.plates)
   },
   /**

--- a/src/store/traction/pacbio/poolCreate/getters.js
+++ b/src/store/traction/pacbio/poolCreate/getters.js
@@ -31,6 +31,13 @@ export default {
     return mergeRepresentations(resources.plates, selected.plates)
   },
   /**
+   * Returns a list of all fetched tubes
+   * @param {Object} state The Vuex state object
+   */
+  tubeList: ({ selected, resources }) => {
+    return mergeRepresentations(resources.tubes, selected.tubes)
+  },
+  /**
    * Returns a list of all fetched tagSet
    * @param {Object} state The Vuex state object
    */
@@ -69,6 +76,12 @@ export default {
    */
   selectedPlates: ({ selected, resources }) =>
     mergeRepresentations(selected.plates, resources.plates),
+
+  /**
+   * Returns a list of selected tubes
+   * @param {Object} state The Vuex state object
+   */
+  selectedTubes: ({ selected, resources }) => mergeRepresentations(selected.tubes, resources.tubes),
 
   /**
    * Returns a list of selected requests

--- a/src/store/traction/pacbio/poolCreate/getters.js
+++ b/src/store/traction/pacbio/poolCreate/getters.js
@@ -18,9 +18,25 @@ const mergeRepresentations = (parent, child, keyFunction = (id) => id) => {
 }
 
 const sortRequestByWellColumnIndex = (resources) => (a, b) =>
-  wellToIndex(resources.wells[a.well]) - wellToIndex(resources.wells[b.well])
-const sortRequestByPlate = (resources) => (a, b) =>
-  parseInt(resources.wells[a.well].plate) - parseInt(resources.wells[b.well].plate)
+  wellToIndex(resources.wells[a.well] || { position: 'A1' }) -
+  wellToIndex(resources.wells[b.well] || { position: 'A1' })
+
+/**
+ * Sort the requests based on their labware. Tubes will be sorted after plates,
+ * and then each labware is sorted in id order
+ */
+const sortRequestByLabware = (resources) => (a, b) => {
+  if (a.tube && b.tube) {
+    // Both our tubes
+    return parseInt(a.tube) - parseInt(b.tube)
+  } else if (a.well && b.well) {
+    // Both are plates
+    return parseInt(resources.wells[a.well].plate) - parseInt(resources.wells[b.well].plate)
+  } else {
+    // A plate and a tube
+    return parseInt(a.tube || 0) - parseInt(b.tube || 0)
+  }
+}
 
 export default {
   /**
@@ -97,7 +113,7 @@ export default {
         selected: true,
       }))
       .sort(sortRequestByWellColumnIndex(resources))
-      .sort(sortRequestByPlate(resources))
+      .sort(sortRequestByLabware(resources))
   },
   /**
    * Returns a list of all fetched wells

--- a/src/store/traction/pacbio/poolCreate/mutations.js
+++ b/src/store/traction/pacbio/poolCreate/mutations.js
@@ -29,6 +29,19 @@ export default {
     }
   },
   /**
+   * Flags tube with `id` as selected. (Or unselected if selected is false)
+   * @param {Object} state The Vuex state object
+   * @param {String} id The id of the tube
+   * @param {Boolean} selected Whether the tube is selected (defaults to true)
+   */
+  selectTube: (state, { id, selected = true }) => {
+    if (selected) {
+      Vue.set(state.selected.tubes, `${id}`, { id: id, selected: true })
+    } else {
+      Vue.delete(state.selected.tubes, `${id}`)
+    }
+  },
+  /**
    * Flags tagSet with `id` as selected.
    * @param {Object} state The Vuex state object
    * @param {String} id The id of the plate

--- a/src/store/traction/pacbio/poolCreate/mutations.js
+++ b/src/store/traction/pacbio/poolCreate/mutations.js
@@ -1,6 +1,7 @@
 import { dataToObjectById } from '@/api/JsonApi'
 import Vue from 'vue'
 import { newLibrary } from '@/store/traction/pacbio/poolCreate/pool.js'
+import defaultState from './state'
 
 const populateById =
   (resource, { includeRelationships = false } = {}) =>
@@ -54,6 +55,12 @@ export default {
    * @param {Array.{}} plates The plate resources to populate the store
    */
   populatePlates: populateById('plates', { includeRelationships: true }),
+  /**
+   * Populated with resources via APi calls from the actions
+   * @param {Object} state The VueXState object
+   * @param {Array.{}} tubes The tube resources to populate the store
+   */
+  populateTubes: populateById('tubes', { includeRelationships: true }),
   /**
    * Populated with resources via APi calls from the actions
    * @param {Object} state The VueXState object
@@ -122,13 +129,9 @@ export default {
     Vue.set(libraries, key, Object.assign({}, libraries[key], library))
   },
   // This method clears the editable data in the pool/new page
+  // We keep the resources though
   clearPoolData: (state) => {
-    state.libraries = {}
-    state.pool = {}
-    state.tube = {}
-    state.selected = {
-      tagSet: {},
-      plates: {},
-    }
+    const new_state = defaultState()
+    Object.assign(state, new_state, { resources: state.resources })
   },
 }

--- a/src/store/traction/pacbio/poolCreate/state.js
+++ b/src/store/traction/pacbio/poolCreate/state.js
@@ -12,6 +12,9 @@ export default () => {
       // The main plate store. Represents the authoritative source of plate
       // information. Plates are indexed by id.
       plates: {},
+      // The main tube store. Represents the authoritative source of tube
+      // information. Plates are indexed by id.
+      tubes: {},
       /**
        * The main source of well information. Wells are indexed by id.
        * Populated by the wells included in the request for plates.
@@ -39,6 +42,10 @@ export default () => {
       // id. Each plate is represented by an object with an id and a selected
       // attribute { id: 'plate_id', selected: true }
       plates: {},
+      // Object representing all selected tubes. Selected tubes are indexed by
+      // id. Each tube is represented by an object with an id and a selected
+      // attribute { id: 'tube_id', selected: true }
+      tubes: {},
     },
     // Libraries. Indexed by an internally generated id.
     libraries: {},

--- a/src/views/pacbio/PacbioPoolCreate.vue
+++ b/src/views/pacbio/PacbioPoolCreate.vue
@@ -3,8 +3,16 @@
     <b-container id="pool" fluid>
       <b-row>
         <b-col md="12" lg="6">
-          <PacbioLabwareFind ref="labwareFind" />
-          <PacbioLabwareSelectedList />
+          <b-tabs content-class="mt-3" fill no-fade>
+            <b-tab title="Add Plates">
+              <PacbioPlateFind ref="labwareFind" />
+              <PacbioPlateSelectedList />
+            </b-tab>
+            <b-tab title="Add Tubes">
+              <PacbioTubeFind ref="labwareFind" />
+              <PacbioTubeSelectedList
+            /></b-tab>
+          </b-tabs>
         </b-col>
         <b-col md="12" lg="6">
           <PacbioTagSetList ref="tagSetList" />
@@ -18,8 +26,10 @@
 
 <script>
 import PacbioTagSetList from '@/components/pacbio/PacbioTagSetList'
-import PacbioLabwareFind from '@/components/pacbio/PacbioLabwareFind'
-import PacbioLabwareSelectedList from '@/components/pacbio/PacbioLabwareSelectedList'
+import PacbioPlateFind from '@/components/pacbio/PacbioPlateFind'
+import PacbioPlateSelectedList from '@/components/pacbio/PacbioPlateSelectedList'
+import PacbioTubeFind from '@/components/pacbio/PacbioTubeFind'
+import PacbioTubeSelectedList from '@/components/pacbio/PacbioTubeSelectedList'
 import PacbioTagSetItem from '@/components/pacbio/PacbioTagSetItem'
 import PacbioPoolEdit from '@/components/pacbio/PacbioPoolEdit'
 
@@ -30,8 +40,10 @@ export default {
   name: 'PacbioPoolCreate',
   components: {
     PacbioTagSetList,
-    PacbioLabwareFind,
-    PacbioLabwareSelectedList,
+    PacbioPlateFind,
+    PacbioPlateSelectedList,
+    PacbioTubeFind,
+    PacbioTubeSelectedList,
     PacbioTagSetItem,
     PacbioPoolEdit,
   },

--- a/src/views/pacbio/PacbioPoolCreate.vue
+++ b/src/views/pacbio/PacbioPoolCreate.vue
@@ -2,19 +2,15 @@
   <div>
     <b-container id="pool" fluid>
       <b-row>
-        <PacbioLabwareFind ref="labwareFind" />
-        <b-col>
-          <b-row>
-            <PacbioTagSetList ref="tagSetList" />
-          </b-row>
-          <b-row>
-            <PacbioTagSetItem />
-          </b-row>
+        <b-col md="12" lg="6">
+          <PacbioLabwareFind ref="labwareFind" />
+          <PacbioLabwareSelectedList />
         </b-col>
-      </b-row>
-      <b-row>
-        <PacbioLabwareSelectedList />
-        <PacbioPoolEdit />
+        <b-col md="12" lg="6">
+          <PacbioTagSetList ref="tagSetList" />
+          <PacbioTagSetItem />
+          <PacbioPoolEdit />
+        </b-col>
       </b-row>
     </b-container>
   </div>
@@ -43,32 +39,27 @@ export default {
     return {}
   },
   created() {
-    const plates = this.fetchPacbioPlates()
+    const requests = this.fetchPacbioRequests()
     const tagSets = this.fetchPacbioTagSets()
     // Needed due to left over pool data from previously edited pools
     this.$store.commit('traction/pacbio/poolCreate/clearPoolData')
 
     if (this.$route.params.id !== 'new') {
       const libraries = this.populateLibrariesFromPool(this.$route.params.id)
-      libraries.then(this.plateAlert)
+      libraries.then(this.alertOnFail)
     }
     // We don't use await here as otherwise the handling of one response will be blocked
     // by the other
-    plates.then(this.plateAlert)
-    tagSets.then(this.tagSetAlert)
+    requests.then(this.alertOnFail)
+    tagSets.then(this.alertOnFail)
   },
   methods: {
-    plateAlert({ success, errors }) {
+    alertOnFail({ success, errors }) {
       if (!success) {
-        this.$refs['labwareFind'].showAlert(errors, 'danger')
+        this.showAlert(errors, 'danger')
       }
     },
-    tagSetAlert({ success, errors }) {
-      if (!success) {
-        this.$refs['tagSetList'].showAlert(errors, 'danger')
-      }
-    },
-    ...mapActions(['fetchPacbioPlates', 'fetchPacbioTagSets', 'populateLibrariesFromPool']),
+    ...mapActions(['fetchPacbioRequests', 'fetchPacbioTagSets', 'populateLibrariesFromPool']),
   },
 }
 </script>

--- a/tests/data/autoTagStore.json
+++ b/tests/data/autoTagStore.json
@@ -210,6 +210,26 @@
         ]
       }
     },
+    "tubes": {
+      "1": {
+        "id": "1",
+        "type": "tubes",
+        "barcode": "3980000001795",
+        "requests": ["97"]
+      },
+      "2": {
+        "id": "2",
+        "type": "tubes",
+        "barcode": "TRAC-2-2",
+        "requests": ["98"]
+      },
+      "3": {
+        "id": "3",
+        "type": "tubes",
+        "barcode": "TRAC-2-4",
+        "requests": ["99"]
+      }
+    },
     "wells": {
       "1": { "id": "1", "type": "wells", "position": "A1", "requests": ["1"], "plate": "1" },
       "2": { "id": "2", "type": "wells", "position": "A2", "requests": ["2"], "plate": "1" },
@@ -2011,6 +2031,57 @@
         "source_identifier": "DN2:D12",
         "well": "144",
         "plate": "2"
+      },
+      "97": {
+        "id": "97",
+        "type": "requests",
+        "library_type": "library_type_1",
+        "estimate_of_gb_required": 100,
+        "number_of_smrt_cells": 3,
+        "cost_code": "PSD1234",
+        "external_study_id": "1",
+        "sample_name": "Sample49",
+        "barcode": null,
+        "sample_species": "human",
+        "created_at": "2021/11/30 13:57",
+        "source_identifier": "DN2:D12",
+        "well": null,
+        "plate": null,
+        "tube": "1"
+      },
+      "98": {
+        "id": "98",
+        "type": "requests",
+        "library_type": "library_type_1",
+        "estimate_of_gb_required": 100,
+        "number_of_smrt_cells": 3,
+        "cost_code": "PSD1234",
+        "external_study_id": "1",
+        "sample_name": "Sample49",
+        "barcode": null,
+        "sample_species": "human",
+        "created_at": "2021/11/30 13:57",
+        "source_identifier": "DN2:D12",
+        "well": null,
+        "plate": null,
+        "tube": "2"
+      },
+      "99": {
+        "id": "99",
+        "type": "requests",
+        "library_type": "library_type_1",
+        "estimate_of_gb_required": 100,
+        "number_of_smrt_cells": 3,
+        "cost_code": "PSD1234",
+        "external_study_id": "1",
+        "sample_name": "Sample49",
+        "barcode": null,
+        "sample_species": "human",
+        "created_at": "2021/11/30 13:57",
+        "source_identifier": "DN2:D12",
+        "well": null,
+        "plate": null,
+        "tube": "3"
       }
     },
     "tagSets": {
@@ -2298,6 +2369,18 @@
     },
     "_62": {
       "pacbio_request_id": "62",
+      "tag_id": null
+    },
+    "_97": {
+      "pacbio_request_id": "97",
+      "tag_id": null
+    },
+    "_98": {
+      "pacbio_request_id": "98",
+      "tag_id": null
+    },
+    "_99": {
+      "pacbio_request_id": "99",
       "tag_id": null
     }
   },

--- a/tests/data/index.js
+++ b/tests/data/index.js
@@ -38,6 +38,8 @@ import PacbioWells from './pacbioWells'
 import PacbioWellLibrary from './pacbioWellLibrary'
 import TractionTags from './tractionTags'
 import SequencescapeLabware from './sequencescapeLabware'
+import SequencescapeLabwareTubeOnly from './sequencescapeLabwareTubeOnly'
+import SequencescapeLabwarePlateOnly from './sequencescapeLabwarePlateOnly'
 import SequencescapePlates from './sequencescapePlates'
 import TractionTubeWithContainerMaterials from './tractionTubeWithContainerMaterials'
 import TractionTubesWithPacbioPools from './tractionTubesWithPacbioPools'
@@ -85,6 +87,8 @@ export default {
   PacbioWellLibrary,
   TractionTags,
   SequencescapeLabware,
+  SequencescapeLabwarePlateOnly,
+  SequencescapeLabwareTubeOnly,
   SequencescapePlates,
   TractionTubeWithContainerMaterials,
   TractionTubesWithPacbioPools,

--- a/tests/data/index.js
+++ b/tests/data/index.js
@@ -30,6 +30,7 @@ import PacbioRuns from './pacbioRuns'
 import PacbioRun from './pacbioRun'
 import PacbioPlates from './pacbioPlates'
 import PacbioPlatesRequest from './pacbioPlatesRequest'
+import PacbioRequestsRequest from './pacbioRequestsRequest'
 import PacbioTagSets from './pacbioTagSets'
 import PacbioSequencingPlate from './pacbioSequencingPlate'
 import PacbioWell from './pacbioWell'
@@ -76,6 +77,7 @@ export default {
   PacbioRun,
   PacbioPlates,
   PacbioPlatesRequest,
+  PacbioRequestsRequest,
   PacbioTagSets,
   PacbioSequencingPlate,
   PacbioWell,

--- a/tests/data/pacbioRequestsRequest.json
+++ b/tests/data/pacbioRequestsRequest.json
@@ -148,6 +148,45 @@
             ]
           }
         }
+      },
+      {
+        "id": "3",
+        "type": "requests",
+        "links": { "self": "/v1/pacbio/requests/3" },
+        "attributes": {
+          "library_type": null,
+          "estimate_of_gb_required": null,
+          "number_of_smrt_cells": null,
+          "cost_code": "S4773",
+          "external_study_id": "5b173660-94c9-11ec-8c89-acde48001122",
+          "sample_name": "2STDY97",
+          "barcode": "3980000001795",
+          "sample_species": "Gryphon",
+          "created_at": "2022/03/01 10:41",
+          "source_identifier": "3980000001795"
+        },
+        "relationships": {
+          "well": {
+            "links": {
+              "self": "/v1/pacbio/requests/3/relationships/well",
+              "related": "/v1/pacbio/requests/3/well"
+            },
+            "data": null
+          },
+          "plate": {
+            "links": {
+              "self": "/v1/pacbio/requests/3/relationships/plate",
+              "related": "/v1/pacbio/requests/3/plate"
+            }
+          },
+          "tube": {
+            "links": {
+              "self": "/v1/pacbio/requests/3/relationships/tube",
+              "related": "/v1/pacbio/requests/3/tube"
+            },
+            "data": { "type": "tubes", "id": "1" }
+          }
+        }
       }
     ],
     "included": [
@@ -298,6 +337,33 @@
                 "id": "137"
               }
             ]
+          }
+        }
+      },
+      {
+        "id": "1",
+        "type": "tubes",
+        "links": { "self": "/v1/pacbio/tubes/1" },
+        "attributes": { "barcode": "3980000001795" },
+        "relationships": {
+          "materials": {
+            "links": {
+              "self": "/v1/pacbio/tubes/1/relationships/materials",
+              "related": "/v1/pacbio/tubes/1/materials"
+            }
+          },
+          "pools": {
+            "links": {
+              "self": "/v1/pacbio/tubes/1/relationships/pools",
+              "related": "/v1/pacbio/tubes/1/pools"
+            }
+          },
+          "requests": {
+            "links": {
+              "self": "/v1/pacbio/tubes/1/relationships/requests",
+              "related": "/v1/pacbio/tubes/1/requests"
+            },
+            "data": [{ "type": "requests", "id": "3" }]
           }
         }
       }

--- a/tests/data/pacbioRequestsRequest.json
+++ b/tests/data/pacbioRequestsRequest.json
@@ -1,0 +1,308 @@
+{
+  "data": {
+    "data": [
+      {
+        "id": "40",
+        "type": "requests",
+        "links": {
+          "self": "/v1/pacbio/requests/40"
+        },
+        "attributes": {
+          "library_type": null,
+          "estimate_of_gb_required": null,
+          "number_of_smrt_cells": null,
+          "cost_code": null,
+          "external_study_id": "fec8a1fa-b9e2-11e9-9123-fa163e99b035",
+          "sample_name": "sample_DN814327C_A1",
+          "barcode": null,
+          "sample_species": "human",
+          "created_at": "2021/06/03 06:59",
+          "source_identifier": "DN814327C:A1"
+        },
+        "relationships": {
+          "well": {
+            "data": [
+              {
+                "type": "wells",
+                "id": "4722"
+              }
+            ]
+          },
+          "plate": {
+            "data": [
+              {
+                "type": "plates",
+                "id": "61"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "id": "41",
+        "type": "requests",
+        "links": {
+          "self": "/v1/pacbio/requests/41"
+        },
+        "attributes": {
+          "library_type": null,
+          "estimate_of_gb_required": null,
+          "number_of_smrt_cells": null,
+          "cost_code": null,
+          "external_study_id": "fec8a1fa-b9e2-11e9-9123-fa163e99b035",
+          "sample_name": "sample_DN814327C_A2",
+          "barcode": null,
+          "sample_species": "human",
+          "created_at": "2021/06/03 06:59",
+          "source_identifier": "DN814327C:A2"
+        },
+        "relationships": {
+          "well": {
+            "data": [
+              {
+                "type": "wells",
+                "id": "4723"
+              }
+            ]
+          },
+          "plate": {
+            "data": [
+              {
+                "type": "plates",
+                "id": "61"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "id": "136",
+        "type": "requests",
+        "links": {
+          "self": "/v1/pacbio/requests/136"
+        },
+        "attributes": {
+          "library_type": null,
+          "estimate_of_gb_required": null,
+          "number_of_smrt_cells": null,
+          "cost_code": null,
+          "external_study_id": "d160363e-ba2e-11e7-b4cc-68b599768938",
+          "sample_name": "5049STDY8152829",
+          "barcode": null,
+          "sample_species": "human",
+          "created_at": "2021/06/03 14:57",
+          "source_identifier": "DN814567Q:A1"
+        },
+        "relationships": {
+          "well": {
+            "data": [
+              {
+                "type": "wells",
+                "id": "4818"
+              }
+            ]
+          },
+          "plate": {
+            "data": [
+              {
+                "type": "plates",
+                "id": "62"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "id": "137",
+        "type": "requests",
+        "links": {
+          "self": "/v1/pacbio/requests/137"
+        },
+        "attributes": {
+          "library_type": null,
+          "estimate_of_gb_required": null,
+          "number_of_smrt_cells": null,
+          "cost_code": null,
+          "external_study_id": "d160363e-ba2e-11e7-b4cc-68b599768938",
+          "sample_name": "5049STDY8152830",
+          "barcode": null,
+          "sample_species": "cat",
+          "created_at": "2021/06/03 14:57",
+          "source_identifier": "DN814567Q:B1"
+        },
+        "relationships": {
+          "well": {
+            "data": [
+              {
+                "type": "wells",
+                "id": "4819"
+              }
+            ]
+          },
+          "plate": {
+            "data": [
+              {
+                "type": "plates",
+                "id": "62"
+              }
+            ]
+          }
+        }
+      }
+    ],
+    "included": [
+      {
+        "id": "61",
+        "type": "plates",
+        "links": {
+          "self": "/v1/pacbio/plates/61"
+        },
+        "attributes": {
+          "barcode": "DN814327C",
+          "created_at": "2021/06/03 06:59"
+        },
+        "relationships": {
+          "wells": {
+            "links": {
+              "self": "/v1/pacbio/plates/61/relationships/wells",
+              "related": "/v1/pacbio/plates/61/wells"
+            },
+            "data": [
+              {
+                "type": "wells",
+                "id": "4722"
+              },
+              {
+                "type": "wells",
+                "id": "4723"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "id": "62",
+        "type": "plates",
+        "links": {
+          "self": "/v1/pacbio/plates/62"
+        },
+        "attributes": {
+          "barcode": "DN814567Q",
+          "created_at": "2021/06/03 14:57"
+        },
+        "relationships": {
+          "wells": {
+            "links": {
+              "self": "/v1/pacbio/plates/62/relationships/wells",
+              "related": "/v1/pacbio/plates/62/wells"
+            },
+            "data": [
+              {
+                "type": "wells",
+                "id": "4818"
+              },
+              {
+                "type": "wells",
+                "id": "4819"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "id": "4722",
+        "type": "wells",
+        "attributes": {
+          "position": "A1"
+        },
+        "relationships": {
+          "plate": {
+            "data": {
+              "type": "plates",
+              "id": "61"
+            }
+          },
+          "requests": {
+            "data": [
+              {
+                "type": "requests",
+                "id": "40"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "id": "4723",
+        "type": "wells",
+        "attributes": {
+          "position": "A2"
+        },
+        "relationships": {
+          "plate": {
+            "data": {
+              "type": "plates",
+              "id": "61"
+            }
+          },
+          "requests": {
+            "data": [
+              {
+                "type": "requests",
+                "id": "41"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "id": "4818",
+        "type": "wells",
+        "attributes": {
+          "position": "A1"
+        },
+        "relationships": {
+          "plate": {
+            "data": {
+              "type": "plates",
+              "id": "62"
+            }
+          },
+          "requests": {
+            "data": [
+              {
+                "type": "requests",
+                "id": "136"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "id": "4819",
+        "type": "wells",
+        "attributes": {
+          "position": "B1"
+        },
+        "relationships": {
+          "plate": {
+            "data": {
+              "type": "plates",
+              "id": "62"
+            }
+          },
+          "requests": {
+            "data": [
+              {
+                "type": "requests",
+                "id": "137"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "status": 200,
+  "statusText": "Success"
+}

--- a/tests/data/sequencescapeLabwarePlateOnly.json
+++ b/tests/data/sequencescapeLabwarePlateOnly.json
@@ -1,0 +1,1670 @@
+{
+  "data": {
+    "data": [
+      {
+        "id": "2",
+        "type": "plates",
+        "links": { "self": "http://sequencescape/api/v2/plates/2" },
+        "attributes": {
+          "labware_barcode": {
+            "ean13_barcode": "1229000002657",
+            "machine_barcode": "DN9000002A",
+            "human_barcode": "DN9000002A"
+          }
+        },
+        "relationships": {
+          "receptacles": {
+            "links": {
+              "self": "http://sequencescape/api/v2/plates/2/relationships/receptacles",
+              "related": "http://sequencescape/api/v2/plates/2/receptacles"
+            },
+            "data": [
+              { "type": "wells", "id": "97" },
+              { "type": "wells", "id": "98" },
+              { "type": "wells", "id": "99" },
+              { "type": "wells", "id": "100" },
+              { "type": "wells", "id": "101" },
+              { "type": "wells", "id": "102" },
+              { "type": "wells", "id": "103" },
+              { "type": "wells", "id": "104" },
+              { "type": "wells", "id": "105" },
+              { "type": "wells", "id": "106" },
+              { "type": "wells", "id": "107" },
+              { "type": "wells", "id": "108" },
+              { "type": "wells", "id": "109" },
+              { "type": "wells", "id": "110" },
+              { "type": "wells", "id": "111" },
+              { "type": "wells", "id": "112" },
+              { "type": "wells", "id": "113" },
+              { "type": "wells", "id": "114" },
+              { "type": "wells", "id": "115" },
+              { "type": "wells", "id": "116" },
+              { "type": "wells", "id": "117" },
+              { "type": "wells", "id": "118" },
+              { "type": "wells", "id": "119" },
+              { "type": "wells", "id": "120" },
+              { "type": "wells", "id": "121" },
+              { "type": "wells", "id": "122" },
+              { "type": "wells", "id": "123" },
+              { "type": "wells", "id": "124" },
+              { "type": "wells", "id": "125" },
+              { "type": "wells", "id": "126" },
+              { "type": "wells", "id": "127" },
+              { "type": "wells", "id": "128" },
+              { "type": "wells", "id": "129" },
+              { "type": "wells", "id": "130" },
+              { "type": "wells", "id": "131" },
+              { "type": "wells", "id": "132" },
+              { "type": "wells", "id": "133" },
+              { "type": "wells", "id": "134" },
+              { "type": "wells", "id": "135" },
+              { "type": "wells", "id": "136" },
+              { "type": "wells", "id": "137" },
+              { "type": "wells", "id": "138" },
+              { "type": "wells", "id": "139" },
+              { "type": "wells", "id": "140" },
+              { "type": "wells", "id": "141" },
+              { "type": "wells", "id": "142" },
+              { "type": "wells", "id": "143" },
+              { "type": "wells", "id": "144" },
+              { "type": "wells", "id": "145" },
+              { "type": "wells", "id": "146" },
+              { "type": "wells", "id": "147" },
+              { "type": "wells", "id": "148" },
+              { "type": "wells", "id": "149" },
+              { "type": "wells", "id": "150" },
+              { "type": "wells", "id": "151" },
+              { "type": "wells", "id": "152" },
+              { "type": "wells", "id": "153" },
+              { "type": "wells", "id": "154" },
+              { "type": "wells", "id": "155" },
+              { "type": "wells", "id": "156" },
+              { "type": "wells", "id": "157" },
+              { "type": "wells", "id": "158" },
+              { "type": "wells", "id": "159" },
+              { "type": "wells", "id": "160" },
+              { "type": "wells", "id": "161" },
+              { "type": "wells", "id": "162" },
+              { "type": "wells", "id": "163" },
+              { "type": "wells", "id": "164" },
+              { "type": "wells", "id": "165" },
+              { "type": "wells", "id": "166" },
+              { "type": "wells", "id": "167" },
+              { "type": "wells", "id": "168" },
+              { "type": "wells", "id": "169" },
+              { "type": "wells", "id": "170" },
+              { "type": "wells", "id": "171" },
+              { "type": "wells", "id": "172" },
+              { "type": "wells", "id": "173" },
+              { "type": "wells", "id": "174" },
+              { "type": "wells", "id": "175" },
+              { "type": "wells", "id": "176" },
+              { "type": "wells", "id": "177" },
+              { "type": "wells", "id": "178" },
+              { "type": "wells", "id": "179" },
+              { "type": "wells", "id": "180" },
+              { "type": "wells", "id": "181" },
+              { "type": "wells", "id": "182" },
+              { "type": "wells", "id": "183" },
+              { "type": "wells", "id": "184" },
+              { "type": "wells", "id": "185" },
+              { "type": "wells", "id": "186" },
+              { "type": "wells", "id": "187" },
+              { "type": "wells", "id": "188" },
+              { "type": "wells", "id": "189" },
+              { "type": "wells", "id": "190" },
+              { "type": "wells", "id": "191" },
+              { "type": "wells", "id": "192" }
+            ]
+          }
+        }
+      }
+    ],
+    "included": [
+      {
+        "id": "97",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/97" },
+        "attributes": { "position": { "name": "A1" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/97/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/97/aliquots"
+            },
+            "data": [{ "type": "aliquots", "id": "97" }]
+          }
+        }
+      },
+      {
+        "id": "98",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/98" },
+        "attributes": { "position": { "name": "B1" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/98/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/98/aliquots"
+            },
+            "data": [{ "type": "aliquots", "id": "98" }]
+          }
+        }
+      },
+      {
+        "id": "99",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/99" },
+        "attributes": { "position": { "name": "C1" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/99/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/99/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "100",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/100" },
+        "attributes": { "position": { "name": "D1" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/100/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/100/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "101",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/101" },
+        "attributes": { "position": { "name": "E1" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/101/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/101/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "102",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/102" },
+        "attributes": { "position": { "name": "F1" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/102/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/102/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "103",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/103" },
+        "attributes": { "position": { "name": "G1" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/103/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/103/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "104",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/104" },
+        "attributes": { "position": { "name": "H1" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/104/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/104/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "105",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/105" },
+        "attributes": { "position": { "name": "A2" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/105/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/105/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "106",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/106" },
+        "attributes": { "position": { "name": "B2" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/106/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/106/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "107",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/107" },
+        "attributes": { "position": { "name": "C2" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/107/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/107/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "108",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/108" },
+        "attributes": { "position": { "name": "D2" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/108/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/108/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "109",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/109" },
+        "attributes": { "position": { "name": "E2" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/109/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/109/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "110",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/110" },
+        "attributes": { "position": { "name": "F2" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/110/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/110/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "111",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/111" },
+        "attributes": { "position": { "name": "G2" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/111/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/111/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "112",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/112" },
+        "attributes": { "position": { "name": "H2" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/112/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/112/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "113",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/113" },
+        "attributes": { "position": { "name": "A3" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/113/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/113/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "114",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/114" },
+        "attributes": { "position": { "name": "B3" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/114/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/114/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "115",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/115" },
+        "attributes": { "position": { "name": "C3" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/115/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/115/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "116",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/116" },
+        "attributes": { "position": { "name": "D3" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/116/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/116/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "117",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/117" },
+        "attributes": { "position": { "name": "E3" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/117/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/117/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "118",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/118" },
+        "attributes": { "position": { "name": "F3" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/118/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/118/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "119",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/119" },
+        "attributes": { "position": { "name": "G3" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/119/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/119/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "120",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/120" },
+        "attributes": { "position": { "name": "H3" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/120/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/120/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "121",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/121" },
+        "attributes": { "position": { "name": "A4" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/121/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/121/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "122",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/122" },
+        "attributes": { "position": { "name": "B4" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/122/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/122/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "123",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/123" },
+        "attributes": { "position": { "name": "C4" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/123/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/123/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "124",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/124" },
+        "attributes": { "position": { "name": "D4" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/124/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/124/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "125",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/125" },
+        "attributes": { "position": { "name": "E4" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/125/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/125/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "126",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/126" },
+        "attributes": { "position": { "name": "F4" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/126/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/126/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "127",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/127" },
+        "attributes": { "position": { "name": "G4" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/127/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/127/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "128",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/128" },
+        "attributes": { "position": { "name": "H4" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/128/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/128/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "129",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/129" },
+        "attributes": { "position": { "name": "A5" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/129/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/129/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "130",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/130" },
+        "attributes": { "position": { "name": "B5" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/130/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/130/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "131",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/131" },
+        "attributes": { "position": { "name": "C5" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/131/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/131/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "132",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/132" },
+        "attributes": { "position": { "name": "D5" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/132/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/132/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "133",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/133" },
+        "attributes": { "position": { "name": "E5" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/133/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/133/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "134",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/134" },
+        "attributes": { "position": { "name": "F5" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/134/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/134/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "135",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/135" },
+        "attributes": { "position": { "name": "G5" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/135/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/135/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "136",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/136" },
+        "attributes": { "position": { "name": "H5" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/136/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/136/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "137",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/137" },
+        "attributes": { "position": { "name": "A6" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/137/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/137/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "138",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/138" },
+        "attributes": { "position": { "name": "B6" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/138/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/138/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "139",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/139" },
+        "attributes": { "position": { "name": "C6" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/139/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/139/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "140",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/140" },
+        "attributes": { "position": { "name": "D6" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/140/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/140/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "141",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/141" },
+        "attributes": { "position": { "name": "E6" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/141/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/141/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "142",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/142" },
+        "attributes": { "position": { "name": "F6" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/142/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/142/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "143",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/143" },
+        "attributes": { "position": { "name": "G6" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/143/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/143/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "144",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/144" },
+        "attributes": { "position": { "name": "H6" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/144/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/144/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "145",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/145" },
+        "attributes": { "position": { "name": "A7" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/145/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/145/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "146",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/146" },
+        "attributes": { "position": { "name": "B7" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/146/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/146/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "147",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/147" },
+        "attributes": { "position": { "name": "C7" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/147/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/147/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "148",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/148" },
+        "attributes": { "position": { "name": "D7" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/148/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/148/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "149",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/149" },
+        "attributes": { "position": { "name": "E7" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/149/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/149/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "150",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/150" },
+        "attributes": { "position": { "name": "F7" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/150/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/150/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "151",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/151" },
+        "attributes": { "position": { "name": "G7" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/151/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/151/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "152",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/152" },
+        "attributes": { "position": { "name": "H7" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/152/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/152/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "153",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/153" },
+        "attributes": { "position": { "name": "A8" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/153/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/153/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "154",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/154" },
+        "attributes": { "position": { "name": "B8" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/154/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/154/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "155",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/155" },
+        "attributes": { "position": { "name": "C8" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/155/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/155/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "156",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/156" },
+        "attributes": { "position": { "name": "D8" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/156/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/156/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "157",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/157" },
+        "attributes": { "position": { "name": "E8" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/157/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/157/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "158",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/158" },
+        "attributes": { "position": { "name": "F8" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/158/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/158/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "159",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/159" },
+        "attributes": { "position": { "name": "G8" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/159/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/159/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "160",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/160" },
+        "attributes": { "position": { "name": "H8" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/160/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/160/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "161",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/161" },
+        "attributes": { "position": { "name": "A9" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/161/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/161/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "162",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/162" },
+        "attributes": { "position": { "name": "B9" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/162/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/162/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "163",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/163" },
+        "attributes": { "position": { "name": "C9" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/163/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/163/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "164",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/164" },
+        "attributes": { "position": { "name": "D9" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/164/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/164/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "165",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/165" },
+        "attributes": { "position": { "name": "E9" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/165/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/165/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "166",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/166" },
+        "attributes": { "position": { "name": "F9" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/166/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/166/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "167",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/167" },
+        "attributes": { "position": { "name": "G9" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/167/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/167/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "168",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/168" },
+        "attributes": { "position": { "name": "H9" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/168/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/168/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "169",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/169" },
+        "attributes": { "position": { "name": "A10" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/169/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/169/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "170",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/170" },
+        "attributes": { "position": { "name": "B10" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/170/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/170/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "171",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/171" },
+        "attributes": { "position": { "name": "C10" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/171/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/171/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "172",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/172" },
+        "attributes": { "position": { "name": "D10" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/172/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/172/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "173",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/173" },
+        "attributes": { "position": { "name": "E10" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/173/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/173/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "174",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/174" },
+        "attributes": { "position": { "name": "F10" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/174/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/174/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "175",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/175" },
+        "attributes": { "position": { "name": "G10" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/175/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/175/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "176",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/176" },
+        "attributes": { "position": { "name": "H10" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/176/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/176/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "177",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/177" },
+        "attributes": { "position": { "name": "A11" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/177/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/177/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "178",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/178" },
+        "attributes": { "position": { "name": "B11" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/178/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/178/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "179",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/179" },
+        "attributes": { "position": { "name": "C11" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/179/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/179/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "180",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/180" },
+        "attributes": { "position": { "name": "D11" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/180/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/180/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "181",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/181" },
+        "attributes": { "position": { "name": "E11" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/181/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/181/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "182",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/182" },
+        "attributes": { "position": { "name": "F11" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/182/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/182/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "183",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/183" },
+        "attributes": { "position": { "name": "G11" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/183/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/183/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "184",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/184" },
+        "attributes": { "position": { "name": "H11" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/184/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/184/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "185",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/185" },
+        "attributes": { "position": { "name": "A12" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/185/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/185/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "186",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/186" },
+        "attributes": { "position": { "name": "B12" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/186/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/186/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "187",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/187" },
+        "attributes": { "position": { "name": "C12" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/187/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/187/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "188",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/188" },
+        "attributes": { "position": { "name": "D12" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/188/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/188/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "189",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/189" },
+        "attributes": { "position": { "name": "E12" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/189/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/189/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "190",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/190" },
+        "attributes": { "position": { "name": "F12" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/190/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/190/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "191",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/191" },
+        "attributes": { "position": { "name": "G12" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/191/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/191/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "192",
+        "type": "wells",
+        "links": { "self": "http://sequencescape/api/v2/wells/192" },
+        "attributes": { "position": { "name": "H12" } },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/wells/192/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/wells/192/aliquots"
+            },
+            "data": []
+          }
+        }
+      },
+      {
+        "id": "97",
+        "type": "aliquots",
+        "links": { "self": "http://sequencescape/api/v2/aliquots/97" },
+        "attributes": { "library_type": "Pacbio_HiFi" },
+        "relationships": {
+          "study": {
+            "links": {
+              "self": "http://sequencescape/api/v2/aliquots/97/relationships/study",
+              "related": "http://sequencescape/api/v2/aliquots/97/study"
+            },
+            "data": { "type": "studies", "id": "2" }
+          },
+          "sample": {
+            "links": {
+              "self": "http://sequencescape/api/v2/aliquots/97/relationships/sample",
+              "related": "http://sequencescape/api/v2/aliquots/97/sample"
+            },
+            "data": { "type": "samples", "id": "98" }
+          }
+        }
+      },
+      {
+        "id": "98",
+        "type": "aliquots",
+        "links": { "self": "http://sequencescape/api/v2/aliquots/98" },
+        "attributes": { "library_type": "Pacbio_HiFi" },
+        "relationships": {
+          "study": {
+            "links": {
+              "self": "http://sequencescape/api/v2/aliquots/98/relationships/study",
+              "related": "http://sequencescape/api/v2/aliquots/98/study"
+            },
+            "data": { "type": "studies", "id": "2" }
+          },
+          "sample": {
+            "links": {
+              "self": "http://sequencescape/api/v2/aliquots/98/relationships/sample",
+              "related": "http://sequencescape/api/v2/aliquots/98/sample"
+            },
+            "data": { "type": "samples", "id": "99" }
+          }
+        }
+      },
+      {
+        "id": "2",
+        "type": "studies",
+        "links": { "self": "http://sequencescape/api/v2/studies/2" },
+        "attributes": { "uuid": "5b173660-94c9-11ec-8c89-acde48001122" }
+      },
+      {
+        "id": "98",
+        "type": "samples",
+        "links": { "self": "http://sequencescape/api/v2/samples/98" },
+        "attributes": { "name": "2STDY1", "uuid": "d5008026-94c9-11ec-a9e3-acde48001122" },
+        "relationships": {
+          "sample_metadata": {
+            "links": {
+              "self": "http://sequencescape/api/v2/samples/98/relationships/sample_metadata",
+              "related": "http://sequencescape/api/v2/samples/98/sample_metadata"
+            },
+            "data": { "type": "sample_metadata", "id": "98" }
+          }
+        }
+      },
+      {
+        "id": "99",
+        "type": "samples",
+        "links": { "self": "http://sequencescape/api/v2/samples/99" },
+        "attributes": { "name": "2STDY2", "uuid": "d50bad48-94c9-11ec-a9e3-acde48001122" },
+        "relationships": {
+          "sample_metadata": {
+            "links": {
+              "self": "http://sequencescape/api/v2/samples/99/relationships/sample_metadata",
+              "related": "http://sequencescape/api/v2/samples/99/sample_metadata"
+            },
+            "data": { "type": "sample_metadata", "id": "99" }
+          }
+        }
+      },
+      {
+        "id": "98",
+        "type": "sample_metadata",
+        "links": { "self": "http://sequencescape/api/v2/sample_metadata/98" },
+        "attributes": { "sample_common_name": "Dragon" }
+      },
+      {
+        "id": "99",
+        "type": "sample_metadata",
+        "links": { "self": "http://sequencescape/api/v2/sample_metadata/99" },
+        "attributes": { "sample_common_name": "Unicorn" }
+      },
+      {
+        "id": "100",
+        "type": "sample_metadata",
+        "links": { "self": "http://sequencescape/api/v2/sample_metadata/100" },
+        "attributes": { "sample_common_name": "Gryphon" }
+      }
+    ],
+    "links": {
+      "first": "http://sequencescape/api/v2/labware?fields%5Baliquots%5D=study%2Clibrary_type%2Csample&fields%5Bplates%5D=labware_barcode%2Creceptacles&fields%5Breceptacles%5D=aliquots&fields%5Bsample_metadata%5D=sample_common_name&fields%5Bsamples%5D=sample_metadata%2Cname%2Cuuid&fields%5Bstudies%5D=uuid&fields%5Btubes%5D=labware_barcode%2Creceptacles&fields%5Bwells%5D=position%2Caliquots&filter%5Bbarcode%5D=DN9000002A%2CNT1O&include=receptacles.aliquots.sample.sample_metadata%2Creceptacles.aliquots.study&page%5Bnumber%5D=1&page%5Bsize%5D=100",
+      "last": "http://sequencescape/api/v2/labware?fields%5Baliquots%5D=study%2Clibrary_type%2Csample&fields%5Bplates%5D=labware_barcode%2Creceptacles&fields%5Breceptacles%5D=aliquots&fields%5Bsample_metadata%5D=sample_common_name&fields%5Bsamples%5D=sample_metadata%2Cname%2Cuuid&fields%5Bstudies%5D=uuid&fields%5Btubes%5D=labware_barcode%2Creceptacles&fields%5Bwells%5D=position%2Caliquots&filter%5Bbarcode%5D=DN9000002A%2CNT1O&include=receptacles.aliquots.sample.sample_metadata%2Creceptacles.aliquots.study&page%5Bnumber%5D=1&page%5Bsize%5D=100"
+    }
+  },
+  "status": 200,
+  "statusText": "Success"
+}

--- a/tests/data/sequencescapeLabwareTubeOnly.json
+++ b/tests/data/sequencescapeLabwareTubeOnly.json
@@ -1,0 +1,98 @@
+{
+  "data": {
+    "data": [
+      {
+        "id": "3",
+        "type": "tubes",
+        "links": { "self": "http://sequencescape/api/v2/tubes/3" },
+        "attributes": {
+          "labware_barcode": {
+            "ean13_barcode": "3980000001795",
+            "machine_barcode": "3980000001795",
+            "human_barcode": "NT1O"
+          }
+        },
+        "relationships": {
+          "receptacles": {
+            "links": {
+              "self": "http://sequencescape/api/v2/tubes/3/relationships/receptacles",
+              "related": "http://sequencescape/api/v2/tubes/3/receptacles"
+            },
+            "data": [{ "type": "receptacles", "id": "193" }]
+          }
+        }
+      }
+    ],
+    "included": [
+      {
+        "id": "99",
+        "type": "aliquots",
+        "links": { "self": "http://sequencescape/api/v2/aliquots/99" },
+        "attributes": { "library_type": "Pacbio_IsoSeq" },
+        "relationships": {
+          "study": {
+            "links": {
+              "self": "http://sequencescape/api/v2/aliquots/99/relationships/study",
+              "related": "http://sequencescape/api/v2/aliquots/99/study"
+            },
+            "data": { "type": "studies", "id": "2" }
+          },
+          "sample": {
+            "links": {
+              "self": "http://sequencescape/api/v2/aliquots/99/relationships/sample",
+              "related": "http://sequencescape/api/v2/aliquots/99/sample"
+            },
+            "data": { "type": "samples", "id": "100" }
+          }
+        }
+      },
+      {
+        "id": "2",
+        "type": "studies",
+        "links": { "self": "http://sequencescape/api/v2/studies/2" },
+        "attributes": { "uuid": "5b173660-94c9-11ec-8c89-acde48001122" }
+      },
+      {
+        "id": "100",
+        "type": "samples",
+        "links": { "self": "http://sequencescape/api/v2/samples/100" },
+        "attributes": { "name": "2STDY97", "uuid": "0db37dd8-94ca-11ec-a9e3-acde48001122" },
+        "relationships": {
+          "sample_metadata": {
+            "links": {
+              "self": "http://sequencescape/api/v2/samples/100/relationships/sample_metadata",
+              "related": "http://sequencescape/api/v2/samples/100/sample_metadata"
+            },
+            "data": { "type": "sample_metadata", "id": "100" }
+          }
+        }
+      },
+      {
+        "id": "100",
+        "type": "sample_metadata",
+        "links": { "self": "http://sequencescape/api/v2/sample_metadata/100" },
+        "attributes": { "sample_common_name": "Gryphon" }
+      },
+      {
+        "id": "193",
+        "type": "receptacles",
+        "links": { "self": "http://sequencescape/api/v2/receptacles/193" },
+        "relationships": {
+          "aliquots": {
+            "links": {
+              "self": "http://sequencescape/api/v2/receptacles/193/relationships/aliquots",
+              "related": "http://sequencescape/api/v2/receptacles/193/aliquots"
+            },
+            "data": [{ "type": "aliquots", "id": "99" }]
+          }
+        }
+      }
+    ],
+    "links": {
+      "first": "http://sequencescape/api/v2/labware?fields%5Baliquots%5D=study%2Clibrary_type%2Csample&fields%5Bplates%5D=labware_barcode%2Creceptacles&fields%5Breceptacles%5D=aliquots&fields%5Bsample_metadata%5D=sample_common_name&fields%5Bsamples%5D=sample_metadata%2Cname%2Cuuid&fields%5Bstudies%5D=uuid&fields%5Btubes%5D=labware_barcode%2Creceptacles&fields%5Bwells%5D=position%2Caliquots&filter%5Bbarcode%5D=DN9000002A%2CNT1O&include=receptacles.aliquots.sample.sample_metadata%2Creceptacles.aliquots.study&page%5Bnumber%5D=1&page%5Bsize%5D=100",
+      "last": "http://sequencescape/api/v2/labware?fields%5Baliquots%5D=study%2Clibrary_type%2Csample&fields%5Bplates%5D=labware_barcode%2Creceptacles&fields%5Breceptacles%5D=aliquots&fields%5Bsample_metadata%5D=sample_common_name&fields%5Bsamples%5D=sample_metadata%2Cname%2Cuuid&fields%5Bstudies%5D=uuid&fields%5Btubes%5D=labware_barcode%2Creceptacles&fields%5Bwells%5D=position%2Caliquots&filter%5Bbarcode%5D=DN9000002A%2CNT1O&include=receptacles.aliquots.sample.sample_metadata%2Creceptacles.aliquots.study&page%5Bnumber%5D=1&page%5Bsize%5D=100"
+    }
+  },
+  "status": 200,
+  "statusText": "Success"
+}

--- a/tests/e2e/fixtures/pacbioRequestsRequest.json
+++ b/tests/e2e/fixtures/pacbioRequestsRequest.json
@@ -1,0 +1,370 @@
+{
+  "data": [
+    {
+      "id": "40",
+      "type": "requests",
+      "links": {
+        "self": "/v1/pacbio/requests/40"
+      },
+      "attributes": {
+        "library_type": null,
+        "estimate_of_gb_required": null,
+        "number_of_smrt_cells": null,
+        "cost_code": null,
+        "external_study_id": "fec8a1fa-b9e2-11e9-9123-fa163e99b035",
+        "sample_name": "sample_DN814327C_A1",
+        "barcode": null,
+        "sample_species": "human",
+        "created_at": "2021/06/03 06:59",
+        "source_identifier": "DN814327C:A1"
+      },
+      "relationships": {
+        "well": {
+          "data": [
+            {
+              "type": "wells",
+              "id": "4722"
+            }
+          ]
+        },
+        "plate": {
+          "data": [
+            {
+              "type": "plates",
+              "id": "61"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "41",
+      "type": "requests",
+      "links": {
+        "self": "/v1/pacbio/requests/41"
+      },
+      "attributes": {
+        "library_type": null,
+        "estimate_of_gb_required": null,
+        "number_of_smrt_cells": null,
+        "cost_code": null,
+        "external_study_id": "fec8a1fa-b9e2-11e9-9123-fa163e99b035",
+        "sample_name": "sample_DN814327C_A2",
+        "barcode": null,
+        "sample_species": "human",
+        "created_at": "2021/06/03 06:59",
+        "source_identifier": "DN814327C:A2"
+      },
+      "relationships": {
+        "well": {
+          "data": [
+            {
+              "type": "wells",
+              "id": "4723"
+            }
+          ]
+        },
+        "plate": {
+          "data": [
+            {
+              "type": "plates",
+              "id": "61"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "136",
+      "type": "requests",
+      "links": {
+        "self": "/v1/pacbio/requests/136"
+      },
+      "attributes": {
+        "library_type": null,
+        "estimate_of_gb_required": null,
+        "number_of_smrt_cells": null,
+        "cost_code": null,
+        "external_study_id": "d160363e-ba2e-11e7-b4cc-68b599768938",
+        "sample_name": "5049STDY8152829",
+        "barcode": null,
+        "sample_species": "human",
+        "created_at": "2021/06/03 14:57",
+        "source_identifier": "DN814567Q:A1"
+      },
+      "relationships": {
+        "well": {
+          "data": [
+            {
+              "type": "wells",
+              "id": "4818"
+            }
+          ]
+        },
+        "plate": {
+          "data": [
+            {
+              "type": "plates",
+              "id": "62"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "137",
+      "type": "requests",
+      "links": {
+        "self": "/v1/pacbio/requests/137"
+      },
+      "attributes": {
+        "library_type": null,
+        "estimate_of_gb_required": null,
+        "number_of_smrt_cells": null,
+        "cost_code": null,
+        "external_study_id": "d160363e-ba2e-11e7-b4cc-68b599768938",
+        "sample_name": "5049STDY8152830",
+        "barcode": null,
+        "sample_species": "cat",
+        "created_at": "2021/06/03 14:57",
+        "source_identifier": "DN814567Q:B1"
+      },
+      "relationships": {
+        "well": {
+          "data": [
+            {
+              "type": "wells",
+              "id": "4819"
+            }
+          ]
+        },
+        "plate": {
+          "data": [
+            {
+              "type": "plates",
+              "id": "62"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "3",
+      "type": "requests",
+      "links": { "self": "/v1/pacbio/requests/3" },
+      "attributes": {
+        "library_type": null,
+        "estimate_of_gb_required": null,
+        "number_of_smrt_cells": null,
+        "cost_code": "S4773",
+        "external_study_id": "5b173660-94c9-11ec-8c89-acde48001122",
+        "sample_name": "2STDY97",
+        "barcode": "3980000001795",
+        "sample_species": "Gryphon",
+        "created_at": "2022/03/01 10:41",
+        "source_identifier": "3980000001795"
+      },
+      "relationships": {
+        "well": {
+          "links": {
+            "self": "/v1/pacbio/requests/3/relationships/well",
+            "related": "/v1/pacbio/requests/3/well"
+          },
+          "data": null
+        },
+        "plate": {
+          "links": {
+            "self": "/v1/pacbio/requests/3/relationships/plate",
+            "related": "/v1/pacbio/requests/3/plate"
+          }
+        },
+        "tube": {
+          "links": {
+            "self": "/v1/pacbio/requests/3/relationships/tube",
+            "related": "/v1/pacbio/requests/3/tube"
+          },
+          "data": { "type": "tubes", "id": "1" }
+        }
+      }
+    }
+  ],
+  "included": [
+    {
+      "id": "61",
+      "type": "plates",
+      "links": {
+        "self": "/v1/pacbio/plates/61"
+      },
+      "attributes": {
+        "barcode": "DN814327C",
+        "created_at": "2021/06/03 06:59"
+      },
+      "relationships": {
+        "wells": {
+          "links": {
+            "self": "/v1/pacbio/plates/61/relationships/wells",
+            "related": "/v1/pacbio/plates/61/wells"
+          },
+          "data": [
+            {
+              "type": "wells",
+              "id": "4722"
+            },
+            {
+              "type": "wells",
+              "id": "4723"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "62",
+      "type": "plates",
+      "links": {
+        "self": "/v1/pacbio/plates/62"
+      },
+      "attributes": {
+        "barcode": "DN814567Q",
+        "created_at": "2021/06/03 14:57"
+      },
+      "relationships": {
+        "wells": {
+          "links": {
+            "self": "/v1/pacbio/plates/62/relationships/wells",
+            "related": "/v1/pacbio/plates/62/wells"
+          },
+          "data": [
+            {
+              "type": "wells",
+              "id": "4818"
+            },
+            {
+              "type": "wells",
+              "id": "4819"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "4722",
+      "type": "wells",
+      "attributes": {
+        "position": "A1"
+      },
+      "relationships": {
+        "plate": {
+          "data": {
+            "type": "plates",
+            "id": "61"
+          }
+        },
+        "requests": {
+          "data": [
+            {
+              "type": "requests",
+              "id": "40"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "4723",
+      "type": "wells",
+      "attributes": {
+        "position": "A2"
+      },
+      "relationships": {
+        "plate": {
+          "data": {
+            "type": "plates",
+            "id": "61"
+          }
+        },
+        "requests": {
+          "data": [
+            {
+              "type": "requests",
+              "id": "41"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "4818",
+      "type": "wells",
+      "attributes": {
+        "position": "A1"
+      },
+      "relationships": {
+        "plate": {
+          "data": {
+            "type": "plates",
+            "id": "62"
+          }
+        },
+        "requests": {
+          "data": [
+            {
+              "type": "requests",
+              "id": "136"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "4819",
+      "type": "wells",
+      "attributes": {
+        "position": "B1"
+      },
+      "relationships": {
+        "plate": {
+          "data": {
+            "type": "plates",
+            "id": "62"
+          }
+        },
+        "requests": {
+          "data": [
+            {
+              "type": "requests",
+              "id": "137"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "1",
+      "type": "tubes",
+      "links": { "self": "/v1/pacbio/tubes/1" },
+      "attributes": { "barcode": "3980000001795" },
+      "relationships": {
+        "materials": {
+          "links": {
+            "self": "/v1/pacbio/tubes/1/relationships/materials",
+            "related": "/v1/pacbio/tubes/1/materials"
+          }
+        },
+        "pools": {
+          "links": {
+            "self": "/v1/pacbio/tubes/1/relationships/pools",
+            "related": "/v1/pacbio/tubes/1/pools"
+          }
+        },
+        "requests": {
+          "links": {
+            "self": "/v1/pacbio/tubes/1/relationships/requests",
+            "related": "/v1/pacbio/tubes/1/requests"
+          },
+          "data": [{ "type": "requests", "id": "3" }]
+        }
+      }
+    }
+  ]
+}

--- a/tests/e2e/specs/pacbio_pool_create.js
+++ b/tests/e2e/specs/pacbio_pool_create.js
@@ -12,8 +12,8 @@ describe('Pacbio Pool Create', () => {
   it('Creates a pool successfully', () => {
     cy.visit('#/pacbio/pool/new')
     cy.contains('Pool')
-    cy.get('[data-type=labware-list]').find('[data-action=select-labware]').first().click()
-    cy.get('[data-input=labware-find]').type('DN814567Q{enter}')
+    cy.get('[data-type=plate-list]').find('[data-action=select-plate]').first().click()
+    cy.get('[data-input=plate-find]').type('DN814567Q{enter}')
 
     cy.get('[data-type=plate-item]').should('have.length', 2)
 
@@ -58,8 +58,8 @@ describe('Pacbio Pool Create', () => {
   it('Will not create a pool if there is an error', () => {
     cy.visit('#/pacbio/pool/new')
     cy.contains('Pool')
-    cy.get('[data-type=labware-list]').find('button').first().click()
-    cy.get('[data-input=labware-find]').type('DN814567Q{enter}')
+    cy.get('[data-type=plate-list]').find('button').first().click()
+    cy.get('[data-input=plate-find]').type('DN814567Q{enter}')
 
     cy.get('[data-type=plate-item]').should('have.length', 2)
 
@@ -95,8 +95,8 @@ describe('Pacbio Pool Create', () => {
   it('can automate creation of large pools', () => {
     cy.visit('#/pacbio/pool/new')
     cy.contains('Pool')
-    cy.get('[data-type=labware-list]').find('[data-action=select-labware]').first().click()
-    cy.get('[data-input=labware-find]').type('DN814567Q{enter}')
+    cy.get('[data-type=plate-list]').find('[data-action=select-plate]').first().click()
+    cy.get('[data-input=plate-find]').type('DN814567Q{enter}')
 
     cy.get('[data-type=plate-item]').should('have.length', 2)
 
@@ -195,8 +195,8 @@ describe('Pacbio Pool Create', () => {
   it('can populate tags from csv', () => {
     cy.visit('#/pacbio/pool/new')
     cy.contains('Pool')
-    cy.get('[data-type=labware-list]').find('[data-action=select-labware]').first().click()
-    cy.get('[data-input=labware-find]').type('DN814567Q{enter}')
+    cy.get('[data-type=plate-list]').find('[data-action=select-plate]').first().click()
+    cy.get('[data-input=plate-find]').type('DN814567Q{enter}')
 
     cy.get('[data-type=plate-item]').should('have.length', 2)
 

--- a/tests/e2e/specs/pacbio_pool_create.js
+++ b/tests/e2e/specs/pacbio_pool_create.js
@@ -18,6 +18,7 @@ describe('Pacbio Pool Create', () => {
     cy.get('[data-type=plate-item]').should('have.length', 2)
 
     cy.get('[data-type=tag-set-list]').select('IsoSeq_v1')
+    cy.get('[data-attribute=tag-set-name]').click()
     cy.get('[data-attribute=group-id]').should('have.length', 12)
 
     //TODO: add at least one more sample

--- a/tests/e2e/specs/pacbio_pool_create.js
+++ b/tests/e2e/specs/pacbio_pool_create.js
@@ -4,8 +4,8 @@ describe('Pacbio Pool Create', () => {
       fixture: 'tractionPacbioTagSets.json',
     })
 
-    cy.intercept('/v1/pacbio/plates?include=wells.requests', {
-      fixture: 'pacbioPlatesRequest.json',
+    cy.intercept('/v1/pacbio/requests?include=well.plate,tube', {
+      fixture: 'pacbioRequestsRequest.json',
     })
   })
 

--- a/tests/e2e/specs/pacbio_pool_edit.js
+++ b/tests/e2e/specs/pacbio_pool_edit.js
@@ -25,7 +25,7 @@ describe('Pacbio Pool Edit', () => {
     cy.visit('#/pacbio/pools')
     cy.get('.pool [data-action=edit-pool]').first().click()
     cy.get('[data-type=plate-item]').should('be.visible')
-    cy.get('[data-type=tag-set-item]').should('be.visible')
+    cy.get('[data-attribute=tag-set-name]').should('be.visible')
     cy.get('[data-type=pool-edit]').within(() => {
       cy.get('[data-attribute=barcode]').should('have.length.greaterThan', 0)
       cy.get('[data-attribute=template-prep-kit-box-barcode]').type('ABC1')
@@ -45,7 +45,7 @@ describe('Pacbio Pool Edit', () => {
     cy.visit('#/pacbio/pools')
     cy.get('.pool [data-action=edit-pool]').first().click()
     cy.get('[data-type=plate-item]').should('be.visible')
-    cy.get('[data-type=tag-set-item]').should('be.visible')
+    cy.get('[data-type=tag-set-name]').should('be.visible')
     cy.get('[data-type=pool-library-edit]').within(() => {
       cy.get('[data-attribute=insert-size]').clear()
     })

--- a/tests/e2e/specs/pacbio_pool_edit.js
+++ b/tests/e2e/specs/pacbio_pool_edit.js
@@ -45,7 +45,7 @@ describe('Pacbio Pool Edit', () => {
     cy.visit('#/pacbio/pools')
     cy.get('.pool [data-action=edit-pool]').first().click()
     cy.get('[data-type=plate-item]').should('be.visible')
-    cy.get('[data-type=tag-set-name]').should('be.visible')
+    cy.get('[data-attribute=tag-set-name]').should('be.visible')
     cy.get('[data-type=pool-library-edit]').within(() => {
       cy.get('[data-attribute=insert-size]').clear()
     })

--- a/tests/unit/.eslintrc.js
+++ b/tests/unit/.eslintrc.js
@@ -1,5 +1,6 @@
 module.exports = {
   env: {
     jest: true,
+    jasmine: true,
   },
 }

--- a/tests/unit/components/pacbio/PacbioLabwareFind.spec.js
+++ b/tests/unit/components/pacbio/PacbioLabwareFind.spec.js
@@ -45,7 +45,7 @@ describe('PacbioLabwareFind', () => {
       wrapper.vm.handleSubmit()
       expect(wrapper.vm.setSelected).not.toBeCalled()
       expect(wrapper.vm.showAlert).toBeCalledWith(
-        'Unable to find a plate with the barcode: Not a plate Barcode',
+        'Unable to find labware with the barcode: Not a plate Barcode',
         'danger',
       )
     })

--- a/tests/unit/components/pacbio/PacbioPlateFind.spec.js
+++ b/tests/unit/components/pacbio/PacbioPlateFind.spec.js
@@ -1,22 +1,22 @@
 import { mount, localVue, store, Data } from 'testHelper'
-import PacbioLabwareFind from '@/components/pacbio/PacbioLabwareFind'
+import PacbioPlateFind from '@/components/pacbio/PacbioPlateFind'
 import Response from '@/api/Response'
 
-describe('PacbioLabwareFind', () => {
+describe('PacbioPlateFind', () => {
   let wrapper, mockPlates
 
   beforeEach(() => {
     mockPlates = new Response(Data.PacbioPlates)._body.data
     store.commit('traction/pacbio/poolCreate/populatePlates', mockPlates)
 
-    wrapper = mount(PacbioLabwareFind, {
+    wrapper = mount(PacbioPlateFind, {
       localVue,
       store,
     })
   })
 
   it('will have a form', () => {
-    expect(wrapper.find('.labware-list')).toBeDefined()
+    expect(wrapper.find('.plate-list')).toBeDefined()
   })
 
   it('contains the correct data', () => {

--- a/tests/unit/components/pacbio/PacbioPlateSelectedList.spec.js
+++ b/tests/unit/components/pacbio/PacbioPlateSelectedList.spec.js
@@ -1,8 +1,8 @@
 import { mount, localVue, store, Data } from 'testHelper'
-import PacbioLabwareSelectedList from '@/components/pacbio/PacbioLabwareSelectedList'
+import PacbioPlateSelectedList from '@/components/pacbio/PacbioPlateSelectedList'
 import Response from '@/api/Response'
 
-describe('PacbioLabwareSelectedList', () => {
+describe('PacbioPlateSelectedList', () => {
   let wrapper, mockPlates
 
   beforeEach(() => {
@@ -12,7 +12,7 @@ describe('PacbioLabwareSelectedList', () => {
     store.commit('traction/pacbio/poolCreate/populatePlates', mockPlates)
     store.commit('traction/pacbio/poolCreate/populateWells', mockWells)
 
-    wrapper = mount(PacbioLabwareSelectedList, {
+    wrapper = mount(PacbioPlateSelectedList, {
       localVue,
 
       store,

--- a/tests/unit/components/pacbio/PacbioTagSetItem.spec.js
+++ b/tests/unit/components/pacbio/PacbioTagSetItem.spec.js
@@ -77,7 +77,7 @@ describe('PacbioTagSetItem', () => {
       expect(wrapper.find('[data-type=tag-set-item]').exists()).toBeFalsy()
     })
     it('should show an appropriate message', () => {
-      const message = wrapper.find('[data-attribute=tag-set-name]')
+      const message = wrapper.find('[data-attribute=tag-set-name-placeholder]')
       expect(message.text()).toMatch('No tag set selected')
     })
   })

--- a/tests/unit/components/pacbio/PacbioTagSetItem.spec.js
+++ b/tests/unit/components/pacbio/PacbioTagSetItem.spec.js
@@ -61,15 +61,6 @@ describe('PacbioTagSetItem', () => {
       const groupIds = wrapper.findAll('[data-attribute=group-id]')
       expect(groupIds.at(0).text()).toEqual(tags['1'].group_id)
     })
-
-    it('click on tag selects it', async () => {
-      const groupIds = wrapper.findAll('[data-attribute=group-id]')
-      await groupIds.at(0).trigger('click')
-      await groupIds.at(1).trigger('click')
-
-      const selected = wrapper.vm.selected
-      expect(selected).toEqual(['1', '2'])
-    })
   })
 
   describe('when there is no selected tag list', () => {

--- a/tests/unit/services/traction/Pacbio.spec.js
+++ b/tests/unit/services/traction/Pacbio.spec.js
@@ -56,6 +56,40 @@ describe('Pacbio', () => {
       expect(response.message).toEqual('Labware created with barcodes DN9000002A,NT1O')
     })
 
+    it('does not create plates if none are present', async () => {
+      fetchLabware.mockResolvedValue(Data.SequencescapeLabwareTubeOnly)
+      createTube.mockResolvedValue(createdRequestResponse)
+
+      try {
+        await createLabware({
+          requests,
+          barcodes: ['NT1O'],
+          libraryType: 'Example',
+        })
+      } catch (error) {
+        fail('createLabware threw an error')
+      }
+
+      expect(createPlate).not.toHaveBeenCalled()
+    })
+
+    it('does not create tubes if none are present', async () => {
+      fetchLabware.mockResolvedValue(Data.SequencescapeLabwarePlateOnly)
+      createPlate.mockResolvedValue(createdPlateResponse)
+
+      try {
+        await createLabware({
+          requests,
+          barcodes: ['DN9000002A'],
+          libraryType: 'Example',
+        })
+      } catch (error) {
+        fail('createLabware threw an error')
+      }
+
+      expect(createTube).not.toHaveBeenCalled()
+    })
+
     it('generates a valid plate payload', async () => {
       fetchLabware.mockResolvedValue(Data.SequencescapeLabware)
       createPlate.mockResolvedValue(createdPlateResponse)

--- a/tests/unit/store/traction/pacbio/poolCreate/actions.spec.js
+++ b/tests/unit/store/traction/pacbio/poolCreate/actions.spec.js
@@ -10,6 +10,8 @@ describe('actions.js', () => {
     fetchPacbioTagSets,
     selectWellRequests,
     deselectPlateAndContents,
+    deselectTubeAndContents,
+    selectTubeAndContents,
     createPool,
     updatePool,
     populateLibrariesFromPool,
@@ -236,6 +238,74 @@ describe('actions.js', () => {
       expect(commit).toHaveBeenCalledWith('selectPlate', { id: '1', selected: false })
       expect(commit).toHaveBeenCalledWith('selectRequest', { id: '100', selected: false })
       expect(commit).toHaveBeenCalledWith('selectRequest', { id: '300', selected: false })
+      // We don't want to select any unselected requests
+      expect(commit).not.toHaveBeenCalledWith('selectRequest', { id: '200', selected: true })
+    })
+  })
+
+  describe('deselectTubeAndContents', () => {
+    it('deselects requests if unselected', async () => {
+      // mock commit
+      const commit = jest.fn()
+      // mock dependencies
+      const defaultStateObject = defaultState()
+      const state = {
+        ...defaultStateObject,
+        resources: {
+          ...defaultStateObject.resources,
+          tubes: {
+            1: { id: 1, requests: ['100', '300'] },
+            2: { id: 2, requests: ['200', '400'] },
+          },
+        },
+        selected: {
+          ...defaultStateObject.selected,
+          requests: {
+            _100: { id: '100', selected: true },
+            _300: { id: '300', selected: true },
+          },
+        },
+      }
+      // apply action
+      await deselectTubeAndContents({ commit, state }, '1')
+      // assert result
+      expect(commit).toHaveBeenCalledWith('selectTube', { id: '1', selected: false })
+      expect(commit).toHaveBeenCalledWith('selectRequest', { id: '100', selected: false })
+      expect(commit).toHaveBeenCalledWith('selectRequest', { id: '300', selected: false })
+      // We don't want to select any unselected requests
+      expect(commit).not.toHaveBeenCalledWith('selectRequest', { id: '200', selected: true })
+    })
+  })
+
+  describe('selectTubeAndContents', () => {
+    it('selects requests if unselected', async () => {
+      // mock commit
+      const commit = jest.fn()
+      // mock dependencies
+      const defaultStateObject = defaultState()
+      const state = {
+        ...defaultStateObject,
+        resources: {
+          ...defaultStateObject.resources,
+          tubes: {
+            1: { id: 1, requests: ['100', '300'] },
+            2: { id: 2, requests: ['200', '400'] },
+          },
+        },
+        selected: {
+          ...defaultStateObject.selected,
+          requests: {
+            _100: { id: '100', selected: true },
+            _300: { id: '300', selected: true },
+          },
+        },
+      }
+      // apply action
+      await selectTubeAndContents({ commit, state }, '1')
+      // assert result
+      expect(commit).toHaveBeenCalledWith('selectTube', { id: '1', selected: true })
+      expect(commit).toHaveBeenCalledWith('selectRequest', { id: '100', selected: true })
+      expect(commit).toHaveBeenCalledWith('selectRequest', { id: '300', selected: true })
       // We don't want to select any unselected requests
       expect(commit).not.toHaveBeenCalledWith('selectRequest', { id: '200', selected: true })
     })

--- a/tests/unit/store/traction/pacbio/poolCreate/actions.spec.js
+++ b/tests/unit/store/traction/pacbio/poolCreate/actions.spec.js
@@ -559,9 +559,85 @@ describe('actions.js', () => {
           pacbio_request_id: '73', // C1
         }),
       )
+      // or a tube
+      expect(commit).not.toHaveBeenCalledWith(
+        'updateLibrary',
+        expect.objectContaining({
+          pacbio_request_id: '96',
+        }),
+      )
+      expect(commit).not.toHaveBeenCalledWith(
+        'updateLibrary',
+        expect.objectContaining({
+          pacbio_request_id: '97',
+        }),
+      )
 
       // In total we expect ot update8 wells in this case
       expect(commit).toHaveBeenCalledTimes(6)
+    })
+
+    it('applies tags to tubes with a higher index when autoTag is true', async () => {
+      const commit = jest.fn()
+      const autoTag = true
+      const library = { pacbio_request_id: '98', tag_id: '130' }
+
+      const selectedRequests = Object.values(state.libraries).map(
+        ({ pacbio_request_id }) => state.resources.requests[pacbio_request_id],
+      )
+      await applyTags(
+        {
+          commit,
+          state,
+          getters: {
+            selectedRequests,
+          },
+        },
+        {
+          library,
+          autoTag,
+        },
+      )
+
+      // We update the changed well
+      expect(commit).toHaveBeenCalledWith('updateLibrary', {
+        pacbio_request_id: '98',
+        tag_id: '130',
+      })
+
+      // We don't update earlier wells
+      expect(commit).not.toHaveBeenCalledWith(
+        'updateLibrary',
+        expect.objectContaining({
+          pacbio_request_id: '1',
+        }),
+      )
+
+      // We don't update earlier tubes
+      expect(commit).not.toHaveBeenCalledWith(
+        'updateLibrary',
+        expect.objectContaining({
+          pacbio_request_id: '97',
+        }),
+      )
+      // We don't update unselected wells
+      expect(commit).not.toHaveBeenCalledWith(
+        'updateLibrary',
+        expect.objectContaining({
+          pacbio_request_id: '25', // C1
+        }),
+      )
+      // We do update tubes with higher ids
+      expect(commit).toHaveBeenCalledWith(
+        'updateLibrary',
+        expect.objectContaining({
+          pacbio_request_id: '99', // D1
+          tag_id: '131',
+        }),
+      )
+
+      // In total we expect ot update 2 tubes in this case
+      expect(commit).toHaveBeenCalledTimes(2)
     })
   })
 

--- a/tests/unit/store/traction/pacbio/poolCreate/actions.spec.js
+++ b/tests/unit/store/traction/pacbio/poolCreate/actions.spec.js
@@ -6,7 +6,7 @@ import { payload } from '@/store/traction/pacbio/poolCreate/pool'
 
 describe('actions.js', () => {
   const {
-    fetchPacbioPlates,
+    fetchPacbioRequests,
     fetchPacbioTagSets,
     selectWellRequests,
     deselectPlateAndContents,
@@ -17,25 +17,25 @@ describe('actions.js', () => {
     updateLibraryFromCsvRecord,
   } = actions
 
-  describe('fetchPacbioPlates', () => {
+  describe('fetchPacbioRequests', () => {
     it('handles success', async () => {
       // mock commit
       const commit = jest.fn()
       // mock dependencies
       const get = jest.fn()
-      const rootState = { api: { traction: { pacbio: { plates: { get } } } } }
-      get.mockResolvedValue(Data.PacbioPlatesRequest)
+      const rootState = { api: { traction: { pacbio: { requests: { get } } } } }
+      get.mockResolvedValue(Data.PacbioRequestsRequest)
       // apply action
-      const { success } = await fetchPacbioPlates({ commit, rootState })
+      const { success } = await fetchPacbioRequests({ commit, rootState })
       // assert result (Might make sense to pull these into separate tests)
-      expect(commit).toHaveBeenCalledWith('populatePlates', Data.PacbioPlatesRequest.data.data)
+      expect(commit).toHaveBeenCalledWith('populateRequests', Data.PacbioRequestsRequest.data.data)
       expect(commit).toHaveBeenCalledWith(
-        'populateWells',
-        Data.PacbioPlatesRequest.data.included.slice(0, 4),
+        'populatePlates',
+        Data.PacbioRequestsRequest.data.included.slice(0, 2),
       )
       expect(commit).toHaveBeenCalledWith(
-        'populateRequests',
-        Data.PacbioPlatesRequest.data.included.slice(4, 8),
+        'populateWells',
+        Data.PacbioRequestsRequest.data.included.slice(2, 6),
       )
       expect(success).toEqual(true)
     })
@@ -45,14 +45,14 @@ describe('actions.js', () => {
       const commit = jest.fn()
       // mock dependencies
       const get = jest.fn()
-      const rootState = { api: { traction: { pacbio: { plates: { get } } } } }
+      const rootState = { api: { traction: { pacbio: { requests: { get } } } } }
       get.mockRejectedValue({
         data: { data: [] },
         status: 500,
         statusText: 'Internal Server Error',
       })
       // apply action
-      const { success } = await fetchPacbioPlates({ commit, rootState })
+      const { success } = await fetchPacbioRequests({ commit, rootState })
       // assert result (Might make sense to pull these into separate tests)
       expect(commit).not.toHaveBeenCalled()
       expect(success).toEqual(false)

--- a/tests/unit/store/traction/pacbio/poolCreate/actions.spec.js
+++ b/tests/unit/store/traction/pacbio/poolCreate/actions.spec.js
@@ -690,6 +690,31 @@ describe('actions.js', () => {
       )
     })
 
+    it('updates the corresponding library for tubes', async () => {
+      const commit = jest.fn()
+      const record = {
+        source: 'TRAC-2-2',
+        tag: 'bc1024T',
+        genome_size: 6.3,
+        insert_size: 15230,
+        concentration: 13,
+        volume: 15,
+      }
+
+      updateLibraryFromCsvRecord({ state, commit, getters }, { record, info })
+
+      expect(commit).toHaveBeenCalledWith(
+        'updateLibrary',
+        expect.objectContaining({
+          pacbio_request_id: '98',
+          tag_id: '131',
+          insert_size: 15230,
+          concentration: 13,
+          volume: 15,
+        }),
+      )
+    })
+
     it('records an error when source is missing', async () => {
       const commit = jest.fn()
       const record = {
@@ -712,25 +737,6 @@ describe('actions.js', () => {
       )
     })
 
-    it('records an error when source is invalid', async () => {
-      const commit = jest.fn()
-      const record = {
-        source: 'DN1A10',
-      }
-
-      updateLibraryFromCsvRecord({ state, commit, getters }, { record, info })
-
-      expect(commit).toHaveBeenCalledWith(
-        'traction/addMessage',
-        {
-          type: 'danger',
-          message:
-            'Library 2 on line 3: DN1A10 should be in the format barcode-well. Eg. DN123S-A1',
-        },
-        { root: true },
-      )
-    })
-
     it('records an error when the plate cant be found', async () => {
       const commit = jest.fn()
       const record = {
@@ -743,7 +749,8 @@ describe('actions.js', () => {
         'traction/addMessage',
         {
           type: 'danger',
-          message: 'Library 2 on line 3: DN34 could not be found',
+          message:
+            'Library 2 on line 3: DN34 could not be found. Barcode should be in the format barcode-well for plates (eg. DN123S-A1) or just barcode for tubes.',
         },
         { root: true },
       )

--- a/tests/unit/store/traction/pacbio/poolCreate/getters.spec.js
+++ b/tests/unit/store/traction/pacbio/poolCreate/getters.spec.js
@@ -74,6 +74,43 @@ describe('getters.js', () => {
     })
   })
 
+  describe('tubeList', () => {
+    it('returns a list of labware resources', () => {
+      const tubes = {
+        1: {
+          barcode: 'NT1',
+          id: '1',
+          type: 'tubes',
+          wells: [],
+        },
+        2: {
+          barcode: 'NT2',
+          id: '2',
+          type: 'tubes',
+          wells: [],
+        },
+      }
+      const expected = [
+        {
+          barcode: 'NT1',
+          id: '1',
+          type: 'tubes',
+          wells: [],
+          selected: true,
+        },
+        {
+          barcode: 'NT2',
+          id: '2',
+          type: 'tubes',
+          wells: [],
+        },
+      ]
+      state.resources.tubes = tubes
+      state.selected.tubes = { 1: { id: '1', selected: true } }
+      expect(tubeList(state)).toEqual(expected)
+    })
+  })
+
   describe('tagSetList', () => {
     it('returns what it does', () => {
       state.resources.tagSets = tagSets

--- a/tests/unit/store/traction/pacbio/poolCreate/getters.spec.js
+++ b/tests/unit/store/traction/pacbio/poolCreate/getters.spec.js
@@ -1,7 +1,7 @@
 import getters from '@/store/traction/pacbio/poolCreate/getters'
 import defaultState from '@/store/traction/pacbio/poolCreate/state'
 import { Data } from 'testHelper'
-import { dataToObjectById } from '@/api/JsonApi'
+import { dataToObjectById, groupIncludedByResource } from '@/api/JsonApi'
 
 describe('getters.js', () => {
   const state = defaultState()
@@ -127,11 +127,13 @@ describe('getters.js', () => {
   })
 
   describe('selectedRequests', () => {
+    const payload = Data.PacbioRequestsRequest.data
     const defaultStateObject = defaultState()
-    const requestResources = Data.PacbioPlatesRequest.data.included.slice(4, 8)
-    const wellResources = Data.PacbioPlatesRequest.data.included.slice(0, 4)
+    const requestResources = payload.data
+    const { wells: wellResources, tubes: tubeResources } = groupIncludedByResource(payload.included)
     const requests = dataToObjectById({ data: requestResources, includeRelationships: true })
     const wells = dataToObjectById({ data: wellResources, includeRelationships: true })
+    const tubes = dataToObjectById({ data: tubeResources, includeRelationships: true })
 
     // When selecting a request with append the id with an underscore. This ensures
     // keys are maintained in insertion order, not numeric order. This allow our requests
@@ -139,6 +141,13 @@ describe('getters.js', () => {
     const libraries = {
       _136: {
         pacbio_request_id: '136',
+        tag_id: null,
+        volume: null,
+        concentration: null,
+        insert_size: null,
+      }, // A selected request
+      _3: {
+        pacbio_request_id: '3',
         tag_id: null,
         volume: null,
         concentration: null,
@@ -155,7 +164,7 @@ describe('getters.js', () => {
 
     const state = {
       ...defaultStateObject,
-      resources: { ...defaultStateObject.resources, requests, wells },
+      resources: { ...defaultStateObject.resources, requests, wells, tubes },
       libraries,
     }
 

--- a/tests/unit/store/traction/pacbio/poolCreate/getters.spec.js
+++ b/tests/unit/store/traction/pacbio/poolCreate/getters.spec.js
@@ -6,7 +6,7 @@ import { dataToObjectById, groupIncludedByResource } from '@/api/JsonApi'
 describe('getters.js', () => {
   const state = defaultState()
   const {
-    labwareList,
+    plateList,
     tubeList,
     tagSetList,
     selectedTagSet,
@@ -37,7 +37,7 @@ describe('getters.js', () => {
     },
   }
 
-  describe('labwareList', () => {
+  describe('plateList', () => {
     it('returns a list of labware resources', () => {
       const plates = {
         1: {
@@ -70,7 +70,7 @@ describe('getters.js', () => {
       ]
       state.resources.plates = plates
       state.selected.plates = { 1: { id: '1', selected: true } }
-      expect(labwareList(state)).toEqual(expected)
+      expect(plateList(state)).toEqual(expected)
     })
   })
 
@@ -209,6 +209,7 @@ describe('getters.js', () => {
       expect(selectedRequests(state)).toEqual([
         { ...requests['40'], selected: true },
         { ...requests['136'], selected: true },
+        { ...requests['3'], selected: true },
       ])
     })
   })

--- a/tests/unit/store/traction/pacbio/poolCreate/getters.spec.js
+++ b/tests/unit/store/traction/pacbio/poolCreate/getters.spec.js
@@ -7,6 +7,7 @@ describe('getters.js', () => {
   const state = defaultState()
   const {
     labwareList,
+    tubeList,
     tagSetList,
     selectedTagSet,
     selectedPlates,

--- a/tests/unit/store/traction/pacbio/poolCreate/mutations.spec.js
+++ b/tests/unit/store/traction/pacbio/poolCreate/mutations.spec.js
@@ -9,6 +9,7 @@ describe('mutations.js', () => {
     selectTagSet,
     selectRequest,
     populatePlates,
+    populateTubes,
     populateWells,
     populateRequests,
     populateTagSets,
@@ -183,6 +184,20 @@ describe('mutations.js', () => {
     })
   })
 
+  describe('populateTubes', () => {
+    it('updates the state', () => {
+      // mock state
+      const tubes = Data.TractionTubesWithPacbioPools.data.data
+      const state = defaultState()
+      // apply mutation
+      populateTubes(state, tubes)
+      // assert result
+      expect(state.resources.tubes).toEqual(
+        dataToObjectById({ data: tubes, includeRelationships: true }),
+      )
+    })
+  })
+
   describe('populateWells', () => {
     it('updates the state', () => {
       // mock state
@@ -339,6 +354,7 @@ describe('mutations.js', () => {
       expect(state.selected).toEqual({
         tagSet: {},
         plates: {},
+        tubes: {},
       })
       expect(state.libraries).toEqual({})
       expect(state.pool).toEqual({})

--- a/tests/unit/store/traction/pacbio/poolCreate/mutations.spec.js
+++ b/tests/unit/store/traction/pacbio/poolCreate/mutations.spec.js
@@ -6,6 +6,7 @@ import { dataToObjectById } from '@/api/JsonApi'
 describe('mutations.js', () => {
   const {
     selectPlate,
+    selectTube,
     selectTagSet,
     selectRequest,
     populatePlates,
@@ -41,6 +42,32 @@ describe('mutations.js', () => {
       // - Prefix the key with an _ to maintain insert order
       // - Not disrupt other plates in the store
       expect(state.selected.plates).toEqual({
+        1: { id: '1', selected: true },
+        2: { id: '2', selected: true },
+      })
+    })
+  })
+
+  describe('selectTube', () => {
+    it('selects a tube by default', () => {
+      // mock state
+      const defaultStateObject = defaultState()
+      const state = {
+        ...defaultStateObject,
+        selected: {
+          ...defaultStateObject.selected,
+          tubes: {
+            2: { id: '2', selected: true },
+          },
+        },
+      }
+      // apply mutation
+      selectTube(state, { id: '1' })
+      // assert result
+      // We expect the tube to be recorded in the selected tubes it should:
+      // - Prefix the key with an _ to maintain insert order
+      // - Not disrupt other tubes in the store
+      expect(state.selected.tubes).toEqual({
         1: { id: '1', selected: true },
         2: { id: '2', selected: true },
       })

--- a/tests/unit/views/pacbio/PacbioPoolCreate.spec.js
+++ b/tests/unit/views/pacbio/PacbioPoolCreate.spec.js
@@ -8,13 +8,13 @@ describe('PacbioPoolCreate', () => {
       state: {
         api: {
           traction: {
-            pacbio: { plates: platesRequest, tag_sets: tagSetsRequest },
+            pacbio: { requests: requestsRequest, tag_sets: tagSetsRequest },
           },
         },
       },
     } = store
 
-    platesRequest.get = jest.fn(() => Data.PacbioPlatesRequest)
+    requestsRequest.get = jest.fn(() => Data.PacbioRequestsRequest)
     tagSetsRequest.get = jest.fn(() => Data.PacbioTagSets)
 
     mount(PacbioPoolCreate, {


### PR DESCRIPTION
Closes #716

Some associated traction-service changes

Changes proposed in this pull request:

* Tubes can be found in the pool create interface
* Autotagging supports tubes
* CSV upload supports tubes
* Interface better handles resizing
* Only show tag list when requested
