### PR TITLE
Issue783/dpl 396 as a team lead {james} i would like to create libraries without the qc data so we can print barcodes in the lab and freeze them {c s v 4}

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -19,13 +19,15 @@
     <div class="flex flex-col mb-auto px-4 py-10">
       <router-view class="text-center" />
     </div>
-    <Message
-      v-for="(message, index) in messages"
-      ref="alert"
-      :key="index"
-      v-bind="message"
-      @dismissed="dismiss(index)"
-    ></Message>
+    <div class="message-container">
+      <Message
+        v-for="(message, index) in messages"
+        ref="alert"
+        :key="index"
+        v-bind="message"
+        @dismissed="dismiss(index)"
+      ></Message>
+    </div>
     <InfoFooter></InfoFooter>
   </div>
 </template>
@@ -95,5 +97,13 @@ a {
     text-decoration: none;
     color: black;
   }
+}
+.message-container {
+  position: fixed;
+  bottom: 0;
+  right: 1em;
+  width: 30em;
+  z-index: 1051;
+  word-break: break-word;
 }
 </style>

--- a/src/components/pacbio/PacbioLibraryCreate.vue
+++ b/src/components/pacbio/PacbioLibraryCreate.vue
@@ -17,7 +17,7 @@
       :static="isStatic"
       scrollable
     >
-      <b-form id="libraryCreateModal">
+      <b-form id="libraryCreateModal" @submit="createLibrary">
         <b-form-group id="selected-sample" label="The sample selected for this library is:">
           {{ selectedSample.sample_name }} ({{ selectedSample.source_identifier }})
         </b-form-group>
@@ -38,7 +38,6 @@
             type="number"
             min="0"
             step="any"
-            required
             placeholder="Example: 1.0"
           >
           </b-form-input>
@@ -55,7 +54,6 @@
             type="number"
             min="0"
             step="any"
-            required
             placeholder="Example: 1.0"
           >
           </b-form-input>
@@ -70,8 +68,11 @@
             id="library-templatePrepKitBoxBarcode"
             v-model="library.template_prep_kit_box_barcode"
             type="text"
-            required
+            minlength="21"
+            maxlength="21"
             placeholder="Example: 012345678901234567890"
+            pattern="\d*"
+            inputmode="numeric"
           >
           </b-form-input>
         </b-form-group>
@@ -85,7 +86,6 @@
             id="library-insertSize"
             v-model="library.insert_size"
             type="number"
-            required
             step="1"
             min="0"
             placeholder="Example: 100"
@@ -94,10 +94,12 @@
         </b-form-group>
       </b-form>
 
-      <template v-slot:modal-footer="{ ok, cancel }">
+      <template v-slot:modal-footer="{ cancel }">
         <b-button @click="cancel()"> Cancel </b-button>
 
-        <b-button id="create-btn" variant="success" @click="createLibrary()"> Create </b-button>
+        <b-button id="create-btn" variant="success" type="submit" form="libraryCreateModal">
+          Create
+        </b-button>
       </template>
     </b-modal>
   </div>

--- a/src/components/pacbio/PacbioPoolList.vue
+++ b/src/components/pacbio/PacbioPoolList.vue
@@ -49,6 +49,6 @@ export default {
 
 .list-group {
   max-height: 400px;
-  overflow: scroll;
+  overflow-y: auto;
 }
 </style>

--- a/src/components/pacbio/PacbioPoolTubeItem.vue
+++ b/src/components/pacbio/PacbioPoolTubeItem.vue
@@ -9,6 +9,14 @@
     <b-row>
       <b-col cols="3">
         <b-img src="/tube.png" />
+        <b-button
+          :id="`editPool-${id}`"
+          size="sm"
+          variant="outline-primary"
+          class="btn-block"
+          :to="{ name: 'PacbioPoolCreate', params: { id: id } }"
+          >Edit</b-button
+        >
       </b-col>
       <b-col cols="9">
         <dl class="row">
@@ -58,6 +66,10 @@ img.src = '/tube.png'
 export default {
   name: 'PacbioPoolTubeItem',
   props: {
+    id: {
+      type: String,
+      required: true,
+    },
     barcode: {
       type: String,
       required: true,

--- a/src/components/pacbio/PacbioPoolTubeItem.vue
+++ b/src/components/pacbio/PacbioPoolTubeItem.vue
@@ -123,13 +123,7 @@ export default {
       return this.valid || this.expanded
     },
     errors() {
-      return [
-        ...this.run_suitability.errors.map(({ detail }) => `Pool ${detail}`),
-        ...this.libraries.flatMap((library) => {
-          const libraryName = `Library ${library.id} (${library.sample_name})`
-          return library.run_suitability.errors.map(({ detail }) => `${libraryName} ${detail}`)
-        }),
-      ]
+      return this.run_suitability.formattedErrors
     },
   },
   // TODO: need to add a a test for drag

--- a/src/store/traction/pacbio/pools/actions.js
+++ b/src/store/traction/pacbio/pools/actions.js
@@ -9,7 +9,7 @@ const setPools = async ({ commit, getters }) => {
       requests: 'sample_name',
       tubes: 'barcode',
       tags: 'group_id',
-      libraries: 'request,tag',
+      libraries: 'request,tag,run_suitability',
     },
   })
   let response = await handleResponse(promise)

--- a/src/store/traction/pacbio/pools/getters.js
+++ b/src/store/traction/pacbio/pools/getters.js
@@ -1,3 +1,11 @@
+const buildRunSuitabilityErrors = ({ pool, libraries }) => [
+  ...pool.run_suitability.errors.map(({ detail }) => `Pool ${detail}`),
+  ...libraries.flatMap((library) => {
+    const libraryName = `Library ${library.id} (${library.sample_name})`
+    return library.run_suitability.errors.map(({ detail }) => `${libraryName} ${detail}`)
+  }),
+]
+
 const getters = {
   poolRequest: (state, getters, rootState) => rootState.api.traction.pacbio.pools,
   pools: (state) => {
@@ -10,7 +18,15 @@ const getters = {
       })
       const { barcode } = state.tubes[pool.tube]
 
-      return { ...pool, libraries, barcode }
+      return {
+        ...pool,
+        libraries,
+        barcode,
+        run_suitability: {
+          ...pool.run_suitability,
+          formattedErrors: buildRunSuitabilityErrors({ libraries, pool }),
+        },
+      }
     })
   },
   poolByBarcode:

--- a/src/store/traction/pacbio/pools/getters.js
+++ b/src/store/traction/pacbio/pools/getters.js
@@ -3,10 +3,10 @@ const getters = {
   pools: (state) => {
     return Object.values(state.pools).map((pool) => {
       const libraries = pool.libraries.map((libraryId) => {
-        const { id, type, request, tag } = state.libraries[libraryId]
+        const { id, type, request, tag, run_suitability } = state.libraries[libraryId]
         const { sample_name } = state.requests[request]
         const { group_id } = state.tags[tag] || {}
-        return { id, type, sample_name, group_id }
+        return { id, type, sample_name, group_id, run_suitability }
       })
       const { barcode } = state.tubes[pool.tube]
 

--- a/src/views/pacbio/PacbioLibraryIndex.vue
+++ b/src/views/pacbio/PacbioLibraryIndex.vue
@@ -113,6 +113,12 @@ export default {
         { key: 'selected', label: '' },
         { key: 'pool.id', label: 'pool ID', sortable: true, tdClass: 'pool-id' },
         { key: 'id', label: 'Library ID', sortable: true, tdClass: 'library-id' },
+        {
+          key: 'run_suitability',
+          label: 'Ready',
+          formatter: ({ ready_for_run }) => (ready_for_run ? '✓' : ''),
+          sortable: true,
+        },
         { key: 'sample_name', label: 'Sample Name', sortable: true, tdClass: 'sample-name' },
         { key: 'barcode', label: 'Barcode', sortable: true, tdClass: 'barcode' },
         { key: 'source_identifier', label: 'Source', sortable: true, tdClass: 'source-identifier' },

--- a/src/views/pacbio/PacbioPoolIndex.vue
+++ b/src/views/pacbio/PacbioPoolIndex.vue
@@ -80,6 +80,11 @@
             :filter="filter"
           >
           </b-table>
+          <ul v-if="!row.item.run_suitability.valid">
+            <li v-for="(error, index) in row.item.run_suitability.formattedErrors" :key="index">
+              {{ error }}
+            </li>
+          </ul>
         </b-card>
       </template>
     </b-table>
@@ -129,6 +134,12 @@ export default {
       fields: [
         { key: 'selected', label: '' },
         { key: 'id', label: 'Pool ID', sortable: true, tdClass: 'pool-id' },
+        {
+          key: 'run_suitability',
+          label: 'Ready',
+          formatter: ({ ready_for_run }) => (ready_for_run ? '✓' : ''),
+          sortable: true,
+        },
         { key: 'barcode', label: 'Pool Barcode', sortable: true, tdClass: 'barcode' },
         { key: 'source_identifier', label: 'Source', sortable: true, tdClass: 'source-identifier' },
         { key: 'volume', label: 'Volume', sortable: true, tdClass: 'volume' },

--- a/tests/data/StorePools.json
+++ b/tests/data/StorePools.json
@@ -11,7 +11,11 @@
       "insert_size": 100,
       "source_identifier": "DN1:A1",
       "created_at": "2021-07-15T15:26:29.000Z",
-      "updated_at": "2021-07-15T15:26:29.000Z"
+      "updated_at": "2021-07-15T15:26:29.000Z",
+      "run_suitability": {
+        "ready_for_run": true,
+        "errors": []
+      }
     },
     "2": {
       "id": "2",
@@ -21,10 +25,31 @@
       "volume": 1.0,
       "concentration": 1.0,
       "template_prep_kit_box_barcode": "LK12345",
-      "insert_size": 100,
+      "insert_size": null,
       "source_identifier": "DN1:B1",
       "created_at": "2021-07-15T15:26:29.000Z",
-      "updated_at": "2021-07-15T15:26:29.000Z"
+      "updated_at": "2021-07-15T15:26:29.000Z",
+      "run_suitability": {
+        "ready_for_run": false,
+        "errors": [
+          {
+            "title": "can't be blank",
+            "detail": "insert_size - can't be blank",
+            "code": "100",
+            "source": {
+              "pointer": "/data/attributes/insert_size"
+            }
+          },
+          {
+            "title": "is invalid",
+            "detail": "libraries - is invalid",
+            "code": "100",
+            "source": {
+              "pointer": "/data/relationships/libraries"
+            }
+          }
+        ]
+      }
     }
   },
   "tubes": {
@@ -32,8 +57,35 @@
     "2": { "barcode": "TRAC-2-2", "id": "2", "type": "tubes" }
   },
   "libraries": {
-    "1": { "id": "1", "request": "1", "tag": "26", "type": "libraries" },
-    "2": { "id": "2", "request": "2", "tag": "7", "type": "libraries" }
+    "1": {
+      "id": "1",
+      "request": "1",
+      "tag": "26",
+      "type": "libraries",
+      "run_suitability": {
+        "ready_for_run": true,
+        "errors": []
+      }
+    },
+    "2": {
+      "id": "2",
+      "request": "2",
+      "tag": "7",
+      "type": "libraries",
+      "run_suitability": {
+        "ready_for_run": false,
+        "errors": [
+          {
+            "title": "can't be blank",
+            "detail": "insert_size - can't be blank",
+            "code": "100",
+            "source": {
+              "pointer": "/data/attributes/insert_size"
+            }
+          }
+        ]
+      }
+    }
   },
   "tags": {
     "26": { "group_id": "bc1019", "id": "26", "type": "tags" },

--- a/tests/data/tractionPacbioPools.json
+++ b/tests/data/tractionPacbioPools.json
@@ -14,7 +14,11 @@
           "insert_size": 100,
           "source_identifier": "DN1:A1",
           "created_at": "2021-07-15T15:26:29.000Z",
-          "updated_at": "2021-07-15T15:26:29.000Z"
+          "updated_at": "2021-07-15T15:26:29.000Z",
+          "run_suitability": {
+            "ready_for_run": true,
+            "errors": []
+          }
         },
         "relationships": {
           "tube": {
@@ -51,10 +55,31 @@
           "volume": 1.0,
           "concentration": 1.0,
           "template_prep_kit_box_barcode": "LK12345",
-          "insert_size": 100,
+          "insert_size": null,
           "source_identifier": "DN1:B1",
           "created_at": "2021-07-15T15:26:29.000Z",
-          "updated_at": "2021-07-15T15:26:29.000Z"
+          "updated_at": "2021-07-15T15:26:29.000Z",
+          "run_suitability": {
+            "ready_for_run": false,
+            "errors": [
+              {
+                "title": "can't be blank",
+                "detail": "insert_size - can't be blank",
+                "code": "100",
+                "source": {
+                  "pointer": "/data/attributes/insert_size"
+                }
+              },
+              {
+                "title": "is invalid",
+                "detail": "libraries - is invalid",
+                "code": "100",
+                "source": {
+                  "pointer": "/data/relationships/libraries"
+                }
+              }
+            ]
+          }
         },
         "relationships": {
           "tube": {
@@ -109,6 +134,12 @@
         "links": {
           "self": "http://localhost:3100/v1/pacbio/libraries/1"
         },
+        "attributes": {
+          "run_suitability": {
+            "ready_for_run": true,
+            "errors": []
+          }
+        },
         "relationships": {
           "request": {
             "links": {
@@ -137,6 +168,21 @@
         "type": "libraries",
         "links": {
           "self": "http://localhost:3100/v1/pacbio/libraries/2"
+        },
+        "attributes": {
+          "run_suitability": {
+            "ready_for_run": false,
+            "errors": [
+              {
+                "title": "can't be blank",
+                "detail": "insert_size - can't be blank",
+                "code": "100",
+                "source": {
+                  "pointer": "/data/attributes/insert_size"
+                }
+              }
+            ]
+          }
         },
         "relationships": {
           "request": {

--- a/tests/e2e/specs/pacbio/pacbio_pool_edit.js
+++ b/tests/e2e/specs/pacbio/pacbio_pool_edit.js
@@ -1,7 +1,7 @@
 describe('Pacbio Pool Edit', () => {
   beforeEach(() => {
     cy.intercept(
-      'v1/pacbio/pools?include=tube,libraries.tag,libraries.request&fields[requests]=sample_name&fields[tubes]=barcode&fields[tags]=group_id&fields[libraries]=request,tag',
+      'v1/pacbio/pools?include=tube,libraries.tag,libraries.request&fields[requests]=sample_name&fields[tubes]=barcode&fields[tags]=group_id&fields[libraries]=request,tag,run_suitability',
       {
         fixture: 'tractionPacbioPools.json',
       },

--- a/tests/e2e/specs/pacbio/pacbio_pools_view.js
+++ b/tests/e2e/specs/pacbio/pacbio_pools_view.js
@@ -1,7 +1,7 @@
 describe('Pacbio Pools view', () => {
   it('Visits the pacbio pools url', () => {
     cy.intercept(
-      'v1/pacbio/pools?include=tube,libraries.tag,libraries.request&fields[requests]=sample_name&fields[tubes]=barcode&fields[tags]=group_id&fields[libraries]=request,tag',
+      'v1/pacbio/pools?include=tube,libraries.tag,libraries.request&fields[requests]=sample_name&fields[tubes]=barcode&fields[tags]=group_id&fields[libraries]=request,tag,run_suitability',
       {
         fixture: 'tractionPacbioPools.json',
       },

--- a/tests/e2e/specs/pacbio/pacbio_run_create.js
+++ b/tests/e2e/specs/pacbio/pacbio_run_create.js
@@ -25,7 +25,7 @@ describe('Pacbio Run Create view', () => {
       },
     })
     cy.intercept(
-      '/v1/pacbio/pools?include=tube,libraries.tag,libraries.request&fields[requests]=sample_name&fields[tubes]=barcode&fields[tags]=group_id&fields[libraries]=request,tag',
+      '/v1/pacbio/pools?include=tube,libraries.tag,libraries.request&fields[requests]=sample_name&fields[tubes]=barcode&fields[tags]=group_id&fields[libraries]=request,tag,run_suitability',
       {
         fixture: 'tractionPacbioPools.json',
       },

--- a/tests/e2e/specs/pacbio/pacbio_run_edit.js
+++ b/tests/e2e/specs/pacbio/pacbio_run_edit.js
@@ -7,7 +7,7 @@ describe('Pacbio Run Edit view', () => {
       fixture: 'tractionPacbioRun.json',
     })
     cy.intercept(
-      '/v1/pacbio/pools?include=tube,libraries.tag,libraries.request&fields[requests]=sample_name&fields[tubes]=barcode&fields[tags]=group_id&fields[libraries]=request,tag',
+      '/v1/pacbio/pools?include=tube,libraries.tag,libraries.request&fields[requests]=sample_name&fields[tubes]=barcode&fields[tags]=group_id&fields[libraries]=request,tag,run_suitability',
       {
         fixture: 'tractionPacbioPools.json',
       },

--- a/tests/unit/components/pacbio/PacbioPoolLibraryList.spec.js
+++ b/tests/unit/components/pacbio/PacbioPoolLibraryList.spec.js
@@ -7,6 +7,10 @@ const libraryAttributes = {
   volume: '1.0',
   concentration: '10.0',
   insert_size: '100',
+  run_suitability: {
+    ready_for_run: true,
+    errors: [],
+  },
 }
 
 const requests = {

--- a/tests/unit/components/pacbio/PacbioPoolTubeItem.spec.js
+++ b/tests/unit/components/pacbio/PacbioPoolTubeItem.spec.js
@@ -60,8 +60,48 @@ describe('LibraryTubeItem.vue', () => {
     beforeEach(() => {
       props = {
         barcode: 'TRAC-1',
-        libraries: [{ id: '1', sample_name: 'Sample1', group_id: 'TAG_1' }],
+        libraries: [
+          {
+            id: '1',
+            sample_name: 'Sample1',
+            group_id: 'TAG_1',
+            run_suitability: {
+              ready_for_run: false,
+              errors: [
+                {
+                  title: "can't be blank",
+                  detail: "insert_size - can't be blank",
+                  code: '100',
+                  source: {
+                    pointer: '/data/attributes/insert_size',
+                  },
+                },
+              ],
+            },
+          },
+        ],
         source_identifier: 'DN1S:A1',
+        run_suitability: {
+          ready_for_run: false,
+          errors: [
+            {
+              title: "can't be blank",
+              detail: "insert_size - can't be blank",
+              code: '100',
+              source: {
+                pointer: '/data/attributes/insert_size',
+              },
+            },
+            {
+              title: 'is invalid',
+              detail: 'libraries - is invalid',
+              code: '100',
+              source: {
+                pointer: '/data/relationships/libraries',
+              },
+            },
+          ],
+        },
       }
 
       wrapper = mount(Tube, {

--- a/tests/unit/components/pacbio/PacbioPoolTubeItem.spec.js
+++ b/tests/unit/components/pacbio/PacbioPoolTubeItem.spec.js
@@ -99,6 +99,10 @@ describe('LibraryTubeItem.vue', () => {
         source_identifier: 'DN1S:A1',
         run_suitability: {
           ready_for_run: false,
+          formattedErrors: [
+            "Pool insert_size - can't be blank",
+            "Library 1 (Sample1) insert_size - can't be blank",
+          ],
           errors: [
             {
               title: "can't be blank",

--- a/tests/unit/components/pacbio/PacbioPoolTubeItem.spec.js
+++ b/tests/unit/components/pacbio/PacbioPoolTubeItem.spec.js
@@ -9,6 +9,7 @@ describe('LibraryTubeItem.vue', () => {
   describe('when valid', () => {
     beforeEach(() => {
       props = {
+        id: '1',
         barcode: 'TRAC-1',
         libraries: [
           {
@@ -73,6 +74,7 @@ describe('LibraryTubeItem.vue', () => {
   describe('when invalid', () => {
     beforeEach(() => {
       props = {
+        id: '1',
         barcode: 'TRAC-1',
         libraries: [
           {
@@ -135,6 +137,15 @@ describe('LibraryTubeItem.vue', () => {
       expect(wrapper.find('[data-attribute=volume]').text()).toContain(unknownField)
       expect(wrapper.text()).toContain("Pool insert_size - can't be blank")
       expect(wrapper.text()).toContain("Library 1 (Sample1) insert_size - can't be blank")
+    })
+
+    it('has an edit button per library', () => {
+      const button = wrapper.find('#editPool-1')
+      expect(button.text()).toEqual('Edit')
+      expect(button.props('to')).toStrictEqual({
+        name: 'PacbioPoolCreate',
+        params: { id: '1' },
+      })
     })
   })
 })

--- a/tests/unit/components/pacbio/PacbioPoolTubeItem.spec.js
+++ b/tests/unit/components/pacbio/PacbioPoolTubeItem.spec.js
@@ -10,12 +10,26 @@ describe('LibraryTubeItem.vue', () => {
     beforeEach(() => {
       props = {
         barcode: 'TRAC-1',
-        libraries: [{ id: '1', sample_name: 'Sample1', group_id: 'TAG_1' }],
+        libraries: [
+          {
+            id: '1',
+            sample_name: 'Sample1',
+            group_id: 'TAG_1',
+            run_suitability: {
+              ready_for_run: true,
+              errors: [],
+            },
+          },
+        ],
         volume: 10.2,
         concentration: 13.1,
         template_prep_kit_box_barcode: 'BB1',
         insert_size: 100,
         source_identifier: 'DN1S:A1',
+        run_suitability: {
+          ready_for_run: true,
+          errors: [],
+        },
       }
 
       wrapper = mount(Tube, {
@@ -119,6 +133,8 @@ describe('LibraryTubeItem.vue', () => {
     it('reports more information when clicked', async () => {
       await wrapper.trigger('click')
       expect(wrapper.find('[data-attribute=volume]').text()).toContain(unknownField)
+      expect(wrapper.text()).toContain("Pool insert_size - can't be blank")
+      expect(wrapper.text()).toContain("Library 1 (Sample1) insert_size - can't be blank")
     })
   })
 })

--- a/tests/unit/store/traction/pacbio/pools/getters.spec.js
+++ b/tests/unit/store/traction/pacbio/pools/getters.spec.js
@@ -31,6 +31,7 @@ const pools = [
     run_suitability: {
       ready_for_run: true,
       errors: [],
+      formattedErrors: [],
     },
   },
   {
@@ -68,6 +69,11 @@ const pools = [
     updated_at: '2021-07-15T15:26:29.000Z',
     run_suitability: {
       ready_for_run: false,
+      formattedErrors: [
+        "Pool insert_size - can't be blank",
+        'Pool libraries - is invalid',
+        "Library 2 (Sample47) insert_size - can't be blank",
+      ],
       errors: [
         {
           title: "can't be blank",
@@ -102,7 +108,13 @@ describe('getters', () => {
   })
 
   it('"pools" returns pools successfully and with an empty library group_id if that library has no tag', () => {
-    state.libraries[1] = { id: '1', request: '1', tag: '', type: 'libraries' }
+    state.libraries[1] = {
+      id: '1',
+      request: '1',
+      tag: '',
+      type: 'libraries',
+      run_suitability: { ready_for_run: true, errors: [] },
+    }
     const pools = getters.pools(state)
     expect(pools[0].libraries[0].group_id).toEqual(undefined)
   })

--- a/tests/unit/store/traction/pacbio/pools/getters.spec.js
+++ b/tests/unit/store/traction/pacbio/pools/getters.spec.js
@@ -8,7 +8,18 @@ const pools = [
     id: '1',
     type: 'pools',
     barcode: 'TRAC-2-1',
-    libraries: [{ id: '1', sample_name: 'Sample48', group_id: 'bc1019', type: 'libraries' }],
+    libraries: [
+      {
+        id: '1',
+        sample_name: 'Sample48',
+        group_id: 'bc1019',
+        type: 'libraries',
+        run_suitability: {
+          ready_for_run: true,
+          errors: [],
+        },
+      },
+    ],
     tube: '1',
     volume: 1.0,
     concentration: 1.0,
@@ -17,22 +28,65 @@ const pools = [
     source_identifier: 'DN1:A1',
     created_at: '2021-07-15T15:26:29.000Z',
     updated_at: '2021-07-15T15:26:29.000Z',
+    run_suitability: {
+      ready_for_run: true,
+      errors: [],
+    },
   },
   {
     id: '2',
     type: 'pools',
     barcode: 'TRAC-2-2',
     libraries: [
-      { id: '2', sample_name: 'Sample47', group_id: 'bc1011_BAK8A_OA', type: 'libraries' },
+      {
+        id: '2',
+        sample_name: 'Sample47',
+        group_id: 'bc1011_BAK8A_OA',
+        type: 'libraries',
+        run_suitability: {
+          ready_for_run: false,
+          errors: [
+            {
+              title: "can't be blank",
+              detail: "insert_size - can't be blank",
+              code: '100',
+              source: {
+                pointer: '/data/attributes/insert_size',
+              },
+            },
+          ],
+        },
+      },
     ],
     tube: '2',
     volume: 1.0,
     concentration: 1.0,
     template_prep_kit_box_barcode: 'LK12345',
-    insert_size: 100,
+    insert_size: null,
     source_identifier: 'DN1:B1',
     created_at: '2021-07-15T15:26:29.000Z',
     updated_at: '2021-07-15T15:26:29.000Z',
+    run_suitability: {
+      ready_for_run: false,
+      errors: [
+        {
+          title: "can't be blank",
+          detail: "insert_size - can't be blank",
+          code: '100',
+          source: {
+            pointer: '/data/attributes/insert_size',
+          },
+        },
+        {
+          title: 'is invalid',
+          detail: 'libraries - is invalid',
+          code: '100',
+          source: {
+            pointer: '/data/relationships/libraries',
+          },
+        },
+      ],
+    },
   },
 ]
 


### PR DESCRIPTION
Dependent on: https://github.com/sanger/traction-service/pull/755

Closes #783

- Ensures native form validation is triggered on library creation
- Remove required flag from the volume/concentration/insert_size fields
- Improve visibility of alerts by converting them to toasts instead
- Display run-readiness on library and pool pages
- Use server side validation. and resultant errors, of pools on run creation
- Add pool edit button on run creation page to easily fix incomplete pools