### PR TITLE
Fix warnings when running tests

### DIFF
--- a/tests/data/tractionPacbioLibraries.json
+++ b/tests/data/tractionPacbioLibraries.json
@@ -15,7 +15,11 @@
           "insert_size": 100,
           "created_at": "2021/06/15 10:25",
           "deactivated_at": null,
-          "source_identifier": "DN1:A1"
+          "source_identifier": "DN1:A1",
+          "run_suitability": {
+            "ready_for_run": true,
+            "errors": []
+          }
         },
         "relationships": {
           "request": {
@@ -74,7 +78,11 @@
           "insert_size": 100,
           "created_at": "2021/06/15 10:25",
           "deactivated_at": null,
-          "source_identifier": "DN1:A2"
+          "source_identifier": "DN1:A2",
+          "run_suitability": {
+            "ready_for_run": true,
+            "errors": []
+          }
         },
         "relationships": {
           "request": {
@@ -133,7 +141,11 @@
           "insert_size": 100,
           "created_at": "2021/06/15 10:25",
           "deactivated_at": null,
-          "source_identifier": "DN1:A3"
+          "source_identifier": "DN1:A3",
+          "run_suitability": {
+            "ready_for_run": true,
+            "errors": []
+          }
         },
         "relationships": {
           "request": {
@@ -192,7 +204,11 @@
           "insert_size": 100,
           "created_at": "2021/06/15 10:25",
           "deactivated_at": null,
-          "source_identifier": "DN1:A4"
+          "source_identifier": "DN1:A4",
+          "run_suitability": {
+            "ready_for_run": true,
+            "errors": []
+          }
         },
         "relationships": {
           "request": {
@@ -251,7 +267,11 @@
           "insert_size": 100,
           "created_at": "2021/06/15 10:25",
           "deactivated_at": null,
-          "source_identifier": "DN1:A5"
+          "source_identifier": "DN1:A5",
+          "run_suitability": {
+            "ready_for_run": true,
+            "errors": []
+          }
         },
         "relationships": {
           "request": {

--- a/tests/unit/components/pacbio/PacbioPoolList.spec.js
+++ b/tests/unit/components/pacbio/PacbioPoolList.spec.js
@@ -6,6 +6,8 @@ describe('pacbioPoolList', () => {
   let wrapper
 
   beforeEach(() => {
+    const setPoolsAction = vi.spyOn(store.getters.api.traction.pacbio.libraries, 'get')
+    setPoolsAction.mockImplementation(() => {})
     store.state.traction.pacbio.pools = storePools
 
     wrapper = mount(pacbioPoolList, {

--- a/tests/unit/views/pacbio/PacbioLibraryIndex.spec.js
+++ b/tests/unit/views/pacbio/PacbioLibraryIndex.spec.js
@@ -7,6 +7,7 @@ describe('Libraries.vue', () => {
   let wrapper, libraries, mockLibraries
 
   beforeEach(() => {
+    const setLibrariesAction = vi.spyOn(store.getters.api.traction.pacbio.libraries, 'get')
     mockLibraries = [
       {
         id: 1,
@@ -55,8 +56,9 @@ describe('Libraries.vue', () => {
         },
       },
     ]
-
-    store.commit('traction/pacbio/libraries/setLibraries', mockLibraries)
+    setLibrariesAction.mockImplementation(() => {
+      store.commit('traction/pacbio/libraries/setLibraries', mockLibraries)
+    })
 
     wrapper = mount(Libraries, {
       store,

--- a/tests/unit/views/pacbio/PacbioPoolCreate.spec.js
+++ b/tests/unit/views/pacbio/PacbioPoolCreate.spec.js
@@ -1,6 +1,7 @@
 import PacbioPoolCreate from '@/views/pacbio/PacbioPoolCreate'
 import { mount, localVue, store, Data, router } from '@support/testHelper'
 import flushPromises from 'flush-promises'
+import { expect } from 'vitest'
 
 describe('PacbioPoolCreate', () => {
   it('will fetch all of the data', async () => {
@@ -8,7 +9,7 @@ describe('PacbioPoolCreate', () => {
       state: {
         api: {
           traction: {
-            pacbio: { requests: requestsRequest, tag_sets: tagSetsRequest },
+            pacbio: { requests: requestsRequest, tag_sets: tagSetsRequest, pools: poolsRequest },
           },
         },
       },
@@ -16,6 +17,51 @@ describe('PacbioPoolCreate', () => {
 
     requestsRequest.get = vi.fn(() => Data.PacbioRequestsRequest)
     tagSetsRequest.get = vi.fn(() => Data.PacbioTagSets)
+    poolsRequest.find = vi.fn()
+
+    router.push('pacbio/pool/new')
+
+    mount(PacbioPoolCreate, {
+      localVue,
+      store,
+      router,
+    })
+
+    await flushPromises()
+
+    const {
+      state: {
+        traction: {
+          pacbio: {
+            poolCreate: {
+              resources: { plates, tagSets },
+            },
+          },
+        },
+      },
+    } = store
+
+    expect(Object.keys(plates).length).toBeGreaterThan(0)
+    expect(Object.keys(tagSets).length).toBeGreaterThan(0)
+    expect(poolsRequest.find).not.toBeCalled()
+  })
+
+  it('will fetch existing pools', async () => {
+    const {
+      state: {
+        api: {
+          traction: {
+            pacbio: { requests: requestsRequest, tag_sets: tagSetsRequest, pools: poolsRequest },
+          },
+        },
+      },
+    } = store
+
+    requestsRequest.get = vi.fn(() => Data.PacbioRequestsRequest)
+    tagSetsRequest.get = vi.fn(() => Data.PacbioTagSets)
+    poolsRequest.find = vi.fn(() => Data.TractionPacbioPool)
+
+    router.push('pacbio/pool/1')
 
     mount(PacbioPoolCreate, {
       localVue,


### PR DESCRIPTION
PacbioPoolCreate was trying to look up the pools.
This change:

1 - Ensures we're testing with a sensible route
2 - Mocks the pool find request
3 - Tests that we only fetch the pool when grabbing a pool id

Closes #

Changes proposed in this pull request:

*
*
* ...
