### PR TITLE
Bug fix - Ok,cancel button texts are not visible in Print Label modal dialog

### DIFF
--- a/src/components/PrinterModal.vue
+++ b/src/components/PrinterModal.vue
@@ -18,6 +18,10 @@
       @shown="clearSelect"
     >
       <traction-select v-model="selectedPrinterId" :options="printerOptions" />
+      <template #modal-footer="{ ok, cancel }">
+        <traction-button size="sm" theme="accent" @click="ok()"> OK </traction-button>
+        <traction-button size="sm" theme="cancel" @click="cancel()"> Cancel </traction-button>
+      </template>
     </traction-modal>
   </div>
 </template>

--- a/tests/unit/components/PrinterModal.spec.js
+++ b/tests/unit/components/PrinterModal.spec.js
@@ -21,7 +21,7 @@ describe('Modal.vue', () => {
   })
 
   it('will have an button component', () => {
-    expect(wrapper.find('.btn').element).toBeTruthy()
+    expect(wrapper.find('button').element).toBeTruthy()
   })
 
   it('will have an modal component', () => {


### PR DESCRIPTION
Fix for the issue - Ok,cancel button texts are not visible in Print Label modal dialog
![Screenshot 2022-12-05 at 16 05 30](https://user-images.githubusercontent.com/55585488/207920428-a5dc648f-a067-4a19-a812-387d66574ce0.png)
