### PR TITLE
General reception bug fix

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -112,5 +112,7 @@ a {
   width: 30em;
   z-index: 1051;
   word-break: break-word;
+  max-height: 500px;
+  overflow-y: scroll;
 }
 </style>

--- a/src/components/TractionMessage.vue
+++ b/src/components/TractionMessage.vue
@@ -4,7 +4,8 @@
       :variant="variant"
       :data-type="dataType"
       dismissible
-      show
+      fade
+      :show="dismissSeconds"
       @dismissed="dismiss()"
     >
       {{ message }}
@@ -31,6 +32,11 @@ export default {
       type: String,
       required: true,
     },
+  },
+  data() {
+    return {
+      dismissSeconds: 15,
+    }
   },
   computed: {
     variant() {

--- a/src/components/shared/TractionFieldGroup.vue
+++ b/src/components/shared/TractionFieldGroup.vue
@@ -37,7 +37,6 @@
       :is="component"
       v-if="component"
       :id="fieldId"
-      v-model="getAttribute"
       :value="value"
       :data-attribute="attribute"
       v-bind="componentProps"
@@ -69,12 +68,6 @@ export default {
     value: { type: [String, Number, Object, Array], required: false, default: null },
   },
   data: (component) => ({ fieldId: component.for || uniqueId() }),
-
-  computed: {
-    getAttribute() {
-      return this.attribute
-    },
-  },
   methods: {
     input(value) {
       // Support either native components emiting events, or components


### PR DESCRIPTION
Prevented alerts from growing over the page, fixed TractionFieldGroup attribute bug.

Alert contains now has a max height
Alerts auto disappear after 15 seconds
General reception input fields now accept data properly
