### PR TITLE
Disable QC Upload button after upload

### DIFF
--- a/src/components/TractionMessage.vue
+++ b/src/components/TractionMessage.vue
@@ -7,7 +7,8 @@
       fade
       :show="dismissSeconds"
       @dismissed="dismiss()"
-    >{{ message }}</traction-alert>
+      >{{ message }}</traction-alert
+    >
   </div>
 </template>
 

--- a/src/components/TractionMessage.vue
+++ b/src/components/TractionMessage.vue
@@ -4,10 +4,10 @@
       :variant="variant"
       :data-type="dataType"
       dismissible
-      show
+      fade
+      :show="dismissSeconds"
       @dismissed="dismiss()"
-      >{{ message }}</traction-alert
-    >
+    >{{ message }}</traction-alert>
   </div>
 </template>
 
@@ -32,7 +32,9 @@ export default {
     },
   },
   data() {
-    return {}
+    return {
+      dismissSeconds: 15,
+    }
   },
   computed: {
     variant() {

--- a/src/components/TractionMessage.vue
+++ b/src/components/TractionMessage.vue
@@ -4,12 +4,10 @@
       :variant="variant"
       :data-type="dataType"
       dismissible
-      fade
-      :show="dismissSeconds"
+      show
       @dismissed="dismiss()"
+      >{{ message }}</traction-alert
     >
-      {{ message }}
-    </traction-alert>
   </div>
 </template>
 
@@ -34,9 +32,7 @@ export default {
     },
   },
   data() {
-    return {
-      dismissSeconds: 15,
-    }
+    return {}
   },
   computed: {
     variant() {

--- a/src/components/qcResultsUpload/QcResultsUploadForm.vue
+++ b/src/components/qcResultsUpload/QcResultsUploadForm.vue
@@ -37,7 +37,8 @@
         size="lg"
         :disabled="!disableUpload"
         @click="disableUpload = !disableUpload"
-      >Re-enable</traction-button>
+        >Re-enable</traction-button
+      >
     </traction-form>
   </div>
 </template>

--- a/src/components/qcResultsUpload/QcResultsUploadForm.vue
+++ b/src/components/qcResultsUpload/QcResultsUploadForm.vue
@@ -21,11 +21,23 @@
           required
         ></traction-file>
       </traction-sub-section>
-      <traction-button id="upload-button" type="submit" theme="create" size="lg" :disabled="busy">
+      <traction-button
+        id="upload-button"
+        type="submit"
+        theme="create"
+        size="lg"
+        :disabled="disableUpload"
+      >
         <!-- Weird bug - spinner won't show unless button text is two words/ big enough? -->
         Upload File
         <traction-spinner v-show="busy"></traction-spinner>
       </traction-button>
+      <traction-button
+        id="reenable-button"
+        size="lg"
+        :disabled="!disableUpload"
+        @click="disableUpload = !disableUpload"
+      >Re-enable</traction-button>
     </traction-form>
   </div>
 </template>
@@ -46,6 +58,7 @@ export default {
       file: null,
       usedBySelected: 'extraction',
       busy: null,
+      disableUpload: null,
     }
   },
   computed: {
@@ -57,7 +70,9 @@ export default {
       await this.postCSV()
     },
     async postCSV() {
+      // We want to keep the button disabled after every upload, unless refreshed or "Re-enable" clicked
       this.busy = true
+      this.disableUpload = true
       try {
         const csv = await this.file.text()
         let data = { csv: csv, usedBySelected: this.usedBySelected }

--- a/tests/e2e/specs/visit_qc_results_upload_page.cy.js
+++ b/tests/e2e/specs/visit_qc_results_upload_page.cy.js
@@ -8,6 +8,8 @@ describe('Extraction QC page', () => {
 
     cy.visit('#/qc-results-upload')
     cy.get('#used-by-select-input').select('Extraction')
+    cy.contains('Upload File')
+    cy.contains('Re-enable')
   })
 
   it('Shows the correct components', () => {

--- a/tests/unit/components/qcResultsUpload/QcResultsUploadForm.spec.js
+++ b/tests/unit/components/qcResultsUpload/QcResultsUploadForm.spec.js
@@ -33,9 +33,18 @@ describe('QcResultsUploadForm.vue', () => {
       })
     })
     describe('busy', () => {
-      it('gets the busy', () => {
+      it('gets the busy status', () => {
+        expect(form.busy).toEqual(null)
         wrapper.setData({ busy: true })
         expect(form.busy).toEqual(true)
+      })
+    })
+
+    describe('disableUpload', () => {
+      it('gets the disableUpload status', () => {
+        expect(form.disableUpload).toEqual(null)
+        wrapper.setData({ disableUpload: true })
+        expect(form.disableUpload).toEqual(true)
       })
     })
   })
@@ -79,7 +88,7 @@ describe('QcResultsUploadForm.vue', () => {
     it('handles a successful import', async () => {
       const createQcResultsUploadResource = vi
         .spyOn(QcResultsUpload, 'createQcResultsUploadResource')
-        .mockImplementation(() => {})
+        .mockImplementation(() => { })
 
       await form.postCSV()
 
@@ -89,6 +98,7 @@ describe('QcResultsUploadForm.vue', () => {
       })
       expect(form.showAlert).toBeCalledWith('Successfully imported: fileName', 'success')
       expect(form.busy).toEqual(false)
+      expect(form.disableUpload).toEqual(true)
     })
 
     it('handles a failed import', async () => {
@@ -104,6 +114,7 @@ describe('QcResultsUploadForm.vue', () => {
       })
       expect(form.showAlert).toBeCalledWith('This is an error msg', 'danger')
       expect(form.busy).toEqual(false)
+      expect(form.disableUpload).toEqual(true)
     })
   })
 })

--- a/tests/unit/components/qcResultsUpload/QcResultsUploadForm.spec.js
+++ b/tests/unit/components/qcResultsUpload/QcResultsUploadForm.spec.js
@@ -88,7 +88,7 @@ describe('QcResultsUploadForm.vue', () => {
     it('handles a successful import', async () => {
       const createQcResultsUploadResource = vi
         .spyOn(QcResultsUpload, 'createQcResultsUploadResource')
-        .mockImplementation(() => { })
+        .mockImplementation(() => {})
 
       await form.postCSV()
 


### PR DESCRIPTION
Changes proposed in this pull request:

After uploading Qc Result CSV..
* The successful message or the error message is shown
* The message will still automatically disappear after 15 seconds
* The Upload File  button will be disabled after uploading (failed or successful)
* You can click Re-enable  to make the Upload File button enabled again, or you can refresh the page.

Non-blocking relationship with: https://github.com/sanger/traction-service/pull/900