### PR TITLE
clearPoolData in pacbio runs

### DIFF
--- a/src/store/traction/pacbio/runCreate/mutations.js
+++ b/src/store/traction/pacbio/runCreate/mutations.js
@@ -1,6 +1,7 @@
 import { populateById } from '@/api/JsonApi'
 import { dataToObjectById } from '@/api/JsonApi'
 import Vue from 'vue'
+import defaultState from './state'
 
 // Mutations handle synchronous update of state
 
@@ -19,21 +20,10 @@ export default {
    * @param {Array.{}} smrtLinkVersions The SmrtLinkVersions to populate the store
    */
   populateSmrtLinkVersions: populateById('smrtLinkVersions'),
-  // ...mutations,
   setPools(state, pools) {
     Vue.set(state, 'pools', {
       ...state.pools,
       ...dataToObjectById({ data: pools, includeRelationships: true }),
-    })
-  },
-  setPoolsForExistingRun(state, pools) {
-    const poolsObject = pools.reduce(function (acc, cur) {
-      acc[cur.id] = cur
-      return acc
-    }, {})
-    Vue.set(state, 'pools', {
-      ...state.pools,
-      ...poolsObject,
     })
   },
 
@@ -49,8 +39,11 @@ export default {
   setRequests(state, requests) {
     setData(state, 'requests', requests, false)
   },
-
   removePool(state, id) {
     Vue.delete(state.pools, id)
+  },
+  clearPoolData(state) {
+    const new_state = defaultState()
+    Object.assign(state, new_state, { resources: state.resources })
   },
 }

--- a/src/views/pacbio/PacbioRunShow.vue
+++ b/src/views/pacbio/PacbioRunShow.vue
@@ -130,6 +130,7 @@ export default {
     },
     async provider() {
       await this.$store.dispatch('traction/pacbio/runCreate/fetchSmrtLinkVersions')
+      await this.$store.commit('traction/pacbio/runCreate/clearPoolData')
       if (this.id === 'new') {
         this.newRun()
       } else if (!this.newRecord) {

--- a/tests/unit/store/traction/pacbio/runCreate/mutations.spec.js
+++ b/tests/unit/store/traction/pacbio/runCreate/mutations.spec.js
@@ -76,4 +76,25 @@ describe('mutations.js', () => {
     mutations.removePool(state, 2)
     expect(state.pools).toEqual({ 1: storePools.pools[1] })
   })
+
+  describe('clearPoolData', () => {
+    it('clears existing pool data', () => {
+      const defaultStateObject = defaultState()
+      const state = {
+        ...defaultStateObject,
+      }
+      // populates an existing pool into state
+      mutations.clearPoolData(state)
+      expect(state).toEqual({
+        resources: {
+          smrtLinkVersions: {},
+        },
+        pools: {},
+        tubes: {},
+        libraries: {},
+        requests: {},
+        tags: {},
+      })
+    })
+  })
 })


### PR DESCRIPTION
Closes #

Changes proposed in this pull request:

* clears the runCreate store from previous data when creating a new run
*
* ...
