### PR TITLE
Fix for general reception styling bug

### DIFF
--- a/src/views/GeneralReception.vue
+++ b/src/views/GeneralReception.vue
@@ -11,7 +11,7 @@
           <traction-select
             id="sourceSelect"
             v-model="source"
-            class="mt-2"
+            class="inline-block w-full"
             :options="receptions"
             data-type="source-list"
           />
@@ -26,6 +26,7 @@
             id="sourceSelect"
             v-model="pipeline"
             :options="pipelineOptions"
+            class="inline-block w-full"
             data-type="pipeline-list"
             @input="resetRequestOptions()"
           />


### PR DESCRIPTION
Added inline block and width full to general reception select fields
Bug occured because I wasn't using enable_custom_select flag locally and therefore didnt have the new select component styling. This component, by default, doesnt have inline-block.
