### PR TITLE
Formatter function prop in traction-input

### DIFF
--- a/src/components/pacbio/PacbioRunWellEdit.vue
+++ b/src/components/pacbio/PacbioRunWellEdit.vue
@@ -210,7 +210,6 @@ export default {
       if (component.name == 'loading_target_p1_plus_p2') {
         return {
           ...component.props,
-          // This doesn't work at the moment as traction-input doesnt have a formatter prop
           formatter: this.formatLoadingTargetValue,
         }
       }

--- a/src/components/shared/TractionInput.vue
+++ b/src/components/shared/TractionInput.vue
@@ -60,7 +60,7 @@ export default {
       type: Number,
       default: 0,
     },
-    //Formatter function to format the displayed value in input field, if given 
+    //Formatter function to format the displayed value in input field, if given
     formatter: {
       type: Function,
       default: undefined,

--- a/src/components/shared/TractionInput.vue
+++ b/src/components/shared/TractionInput.vue
@@ -17,7 +17,7 @@
     <input
       v-bind="$attrs"
       ref="inputRef"
-      :value="value"
+      :value="displayValue()"
       :data-attribute="dataAttribute"
       :class="`w-full border border-gray-300 p-2 rounded-md focus:ring-sdb-100 focus:border-sdb-100 disabled:opacity-75 disabled:cursor-not-allowed${classes}`"
       @input="input($event)"
@@ -60,6 +60,11 @@ export default {
       type: Number,
       default: 0,
     },
+    //Formatter function to format the displayed value in input field, if given 
+    formatter: {
+      type: Function,
+      default: undefined,
+    },
   },
   data() {
     return {
@@ -81,6 +86,13 @@ export default {
         // Emit text data the payload event
         this.$emit('input', event.target.value)
       }
+    },
+    displayValue() {
+      //Formatter function given, so return formated value to display
+      if (this.formatter) {
+        return this.formatter(this.value)
+      }
+      return this.value
     },
   },
 }

--- a/tests/unit/components/shared/TractionInput.spec.js
+++ b/tests/unit/components/shared/TractionInput.spec.js
@@ -2,7 +2,7 @@ import { localVue, mount } from '@support/testHelper'
 
 import TractionInput from '@/components/shared/TractionInput'
 
-describe('TractionInput.vue"', () => {
+describe('TractionInput.vue', () => {
   const buildWrapper = (props = {}) => {
     return mount(TractionInput, {
       localVue,
@@ -71,5 +71,23 @@ describe('TractionInput.vue"', () => {
     expect(textInput.element.value).toBe('')
     await wrapper.setData({ test: 'New Test value' })
     expect(textInput.element.value).toBe('New Test value')
+  })
+  it('displays formatted text,', async () => {
+    var wrapper = mount({
+      template: '<traction-input :value="test" :formatter="formatText"></traction-input>',
+      components: { 'traction-input': TractionInput },
+      data() {
+        return { test: 'Test' }
+      },
+      methods: {
+        formatText(val) {
+          return val + '_formatted'
+        },
+      },
+    })
+    const textInput = wrapper.find('input')
+    expect(textInput.element.value).toBe('Test_formatted')
+    await wrapper.setData({ test: 'New Test' })
+    expect(textInput.element.value).toBe('New Test_formatted')
   })
 })


### PR DESCRIPTION
- Added 'formatter' property in traction-input  - a function that determines how the value to be displayed in traction-input
- Added unit test case for formatter property
 Use case in PacbioRunWellEdit
