### PR TITLE
BUG fix - Libraries page not showing correct source identifier

### DIFF
--- a/src/lib/DataHelpers.js
+++ b/src/lib/DataHelpers.js
@@ -54,27 +54,26 @@ export const alphaNumericSortDefault = (a, b, alphaFirst) => {
  * e.g
  * { name: 'Person1',job: { name: 'Job1'}} is flattened to {name:'Person1,job.name:"Job1"}
  *
- * Limitations:-
- * If there are more than one level of identical fields, it will be overwritten
- * For eg
- * { name:"Test", type:{ name:"class1"},type1:{type:{name:"class2"}}
- * Here there is only one field called type.name which will be overwritten with 'class2'
- *
  * @param {*} obj - object to flatten
- * @param {*} objectAccessor - accessor for object which is useful to uniquely identify
- *                             a field if there are dupliacte names, useed only in recursive calls
+ * @param {*} parentKey = the key of the parent object
  * @param {*} result - result/flattened object in progress which can be used in recursive calls
  * @returns
  */
-export const flattenObject = (obj, objectAccessor, result) => {
+export const flattenObject = (obj, parentKey) => {
   if (!obj) {
     return {}
   }
-  return Object.keys(obj).reduce((acc, cur) => {
-    return typeof obj[cur] === 'object'
-      ? { ...acc, ...flattenObject(obj[cur], cur, acc) }
-      : result && Object.keys(result).includes(cur)
-      ? { ...acc, [objectAccessor + '.' + cur]: obj[cur] }
-      : { ...acc, [cur]: obj[cur] }
-  }, {})
+  let result = {}
+
+  Object.keys(obj).forEach((key) => {
+    const value = obj[key]
+    const _key = parentKey ? parentKey + '.' + key : key
+    if (typeof value === 'object') {
+      result = { ...result, ...flattenObject(value, _key) }
+    } else {
+      result[_key] = value
+    }
+  })
+
+  return result
 }

--- a/src/views/pacbio/PacbioLibraryIndex.vue
+++ b/src/views/pacbio/PacbioLibraryIndex.vue
@@ -95,9 +95,9 @@ export default {
         { key: 'pool.id', label: 'pool ID', sortable: true, tdClass: 'pool-id' },
         { key: 'id', label: 'Library ID', sortable: true, tdClass: 'library-id' },
         {
-          key: 'run_suitability',
+          key: 'run_suitability.ready_for_run',
           label: 'Ready',
-          formatter: ({ ready_for_run }) => (ready_for_run ? '✓' : ''),
+          formatter: (obj) => (obj['run_suitability.ready_for_run'] ? '✓' : ''),
           sortable: true,
         },
         { key: 'sample_name', label: 'Sample Name', sortable: true, tdClass: 'sample-name' },

--- a/src/views/pacbio/PacbioPoolIndex.vue
+++ b/src/views/pacbio/PacbioPoolIndex.vue
@@ -118,9 +118,9 @@ export default {
         { key: 'selected', label: '\u2713' },
         { key: 'id', label: 'Pool ID', sortable: true, tdClass: 'pool-id' },
         {
-          key: 'run_suitability',
+          key: 'run_suitability.ready_for_run',
           label: 'Ready',
-          formatter: ({ ready_for_run }) => (ready_for_run ? '✓' : ''),
+          formatter: (obj) => (obj['run_suitability.ready_for_run'] ? '✓' : ''),
           sortable: true,
         },
         { key: 'barcode', label: 'Pool Barcode', sortable: true, tdClass: 'barcode' },

--- a/tests/unit/lib/DataHelpers.spec.js
+++ b/tests/unit/lib/DataHelpers.spec.js
@@ -10,13 +10,13 @@ describe('DataHelpers', () => {
       }
       expect(flattenObject(testPersonObject)).toEqual({
         name: 'Person1',
-        company: 'Company X',
-        title: 'Test role',
-        place: 'Place X',
-        postcode: 'AB1 2A4',
+        'job.company': 'Company X',
+        'job.title': 'Test role',
+        'location.place': 'Place X',
+        'location.postcode': 'AB1 2A4',
       })
     })
-    it('when there  are duplicated fields', () => {
+    it('when there are duplicated fields', () => {
       const testPersonObject = {
         name: 'Person1',
         job: { name: 'Company X', title: 'Test role' },
@@ -25,9 +25,23 @@ describe('DataHelpers', () => {
       expect(flattenObject(testPersonObject)).toEqual({
         name: 'Person1',
         'job.name': 'Company X',
-        title: 'Test role',
+        'job.title': 'Test role',
         'location.name': 'Place X',
-        postcode: 'AB1 2A4',
+        'location.postcode': 'AB1 2A4',
+      })
+    })
+    it('when there are nested duplicated fields', () => {
+      const testPersonObject = {
+        name: 'Person1',
+        job: { attributes: { name: 'Company X', title: 'Test role' } },
+        location: { name: 'Place X', postcode: 'AB1 2A4' },
+      }
+      expect(flattenObject(testPersonObject)).toEqual({
+        name: 'Person1',
+        'job.attributes.name': 'Company X',
+        'job.attributes.title': 'Test role',
+        'location.name': 'Place X',
+        'location.postcode': 'AB1 2A4',
       })
     })
   })


### PR DESCRIPTION
Changed flattenObject to be more explicit about nested attributes. This fixes a bug where values were being overwritten incorrectly on the pacbio libraries page
