### PR TITLE
Enable webpack aliasing to enhance @ symbol navigation

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,5 +1,11 @@
 {
   "include": ["src/**/*", "tailwind.config.js"],
   "exclude": ["node_modules", "build", "dist"],
-  "vueCompilerOptions": { "target": 2.7 }
+  "vueCompilerOptions": { "target": 2.7 },
+  "compilerOptions": {
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  }
 }


### PR DESCRIPTION
A minor tweak to `jsconfig` to tell VScode about `@` paths  making navigation between JS modules easier

Example:
In `import { handleResponse } from '@/api/ResponseHelper'`:
`@/api/ResponseHelper` expands to `./src/api/ResponseHelper` in VS Code's interpretation of the path

- enhances VScode navigation
- follows https://code.visualstudio.com/docs/languages/jsconfig#_using-webpack-aliases

