### PR TITLE
Centre and adjust spacing of dashboard cards

### DIFF
--- a/src/components/LabelledCard.vue
+++ b/src/components/LabelledCard.vue
@@ -4,11 +4,13 @@
     :data-pipeline="title"
   >
     <div class="text-center text-2xl" data-attribute="title">{{ title }}</div>
-    <div class="text-center text-xs italic" data-attribute="description">{{ description }}</div>
-    <div class="py-2">
+    <div class="text-center text-xs italic px-2" data-attribute="description">
+      {{ description }}
+    </div>
+    <div class="pt-2">
       <h1 class="border-b-2 border-sp" />
     </div>
-    <div class="flex flex-row flex-wrap gap-y-8 gap-x-3 mt-2 px-3 py-4">
+    <div class="flex flex-row flex-wrap justify-center gap-y-8 gap-x-3 py-8 px-3">
       <slot />
     </div>
   </div>

--- a/src/views/TractionDashboard.vue
+++ b/src/views/TractionDashboard.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div class="grid grid-cols-3 p-4 gap-x-8">
+    <div class="grid grid-cols-3 px-4 gap-x-8">
       <LabelledCard
         v-for="(pipeline, index) in pipelines"
         :key="index"


### PR DESCRIPTION
Minor rendering changes to adjust spacing of dashboard cards:

<table border="0">
 <tr>
    <td><b style="font-size:30px">Before</b></td>
    <td><b style="font-size:30px">After</b></td>
 </tr>
<tr>
    <td valign="top">
        <img alt="Before" src="https://github.com/sanger/traction-ui/assets/135011085/ca0e64fc-fa51-4409-b311-c5a09d0702f0" />
</td><td valign="top">
        <img alt="After" src="https://github.com/sanger/traction-ui/assets/135011085/872b8340-e81f-4a0f-bf1c-5371d4820c70" />
</td>
</tr>
</table>
