### PR TITLE
ESLint warnings fix

### DIFF
--- a/src/views/ont/ONTPoolIndex.vue
+++ b/src/views/ont/ONTPoolIndex.vue
@@ -24,8 +24,8 @@
         @filtered="onFiltered"
         @row-selected="onRowSelected"
       >
-        <template #cell(selected)="{ selected }">
-          <template v-if="selected">
+        <template #cell(selected)="selectedCell">
+          <template v-if="selectedCell.selected">
             <span>&check;</span>
             <span class="sr-only">Selected</span>
           </template>

--- a/src/views/ont/ONTSampleIndex.vue
+++ b/src/views/ont/ONTSampleIndex.vue
@@ -24,8 +24,8 @@
         @filtered="onFiltered"
         @row-selected="onRowSelected"
       >
-        <template #cell(selected)="{ selected }">
-          <template v-if="selected">
+        <template #cell(selected)="selectedCell">
+          <template v-if="selectedCell.selected">
             <span>&check;</span>
             <span class="sr-only">Selected</span>
           </template>

--- a/src/views/pacbio/PacbioLibraryIndex.vue
+++ b/src/views/pacbio/PacbioLibraryIndex.vue
@@ -84,11 +84,7 @@ export default {
   data() {
     return {
       fields: [
-        { 
-          key: 'selected',
-          label: '\u2713',
-          formatter: (obj) => (obj['selected'] ? '✓' : ''),
-        },
+        { key: 'selected', label: '\u2713' },
         { key: 'pool.id', label: 'pool ID', sortable: true },
         { key: 'id', label: 'Library ID', sortable: true },
         {

--- a/src/views/pacbio/PacbioLibraryIndex.vue
+++ b/src/views/pacbio/PacbioLibraryIndex.vue
@@ -40,8 +40,8 @@
         @filtered="onFiltered"
         @row-selected="onRowSelected"
       >
-        <template #cell(selected)="{ selected }">
-          <template v-if="selected">
+        <template #cell(selected)="selectedCell">
+          <template v-if="selectedCell.selected">
             <span>&check;</span>
             <span class="sr-only">Selected</span>
           </template>
@@ -84,7 +84,11 @@ export default {
   data() {
     return {
       fields: [
-        { key: 'selected', label: '\u2713' },
+        { 
+          key: 'selected',
+          label: '\u2713',
+          formatter: (obj) => (obj['selected'] ? '✓' : ''),
+        },
         { key: 'pool.id', label: 'pool ID', sortable: true },
         { key: 'id', label: 'Library ID', sortable: true },
         {

--- a/src/views/pacbio/PacbioPoolIndex.vue
+++ b/src/views/pacbio/PacbioPoolIndex.vue
@@ -32,8 +32,8 @@
         @filtered="onFiltered"
         @row-selected="onRowSelected"
       >
-        <template #cell(selected)="{ selected }">
-          <template v-if="selected">
+        <template #cell(selected)="selectedCell">
+          <template v-if="selectedCell.selected">
             <span>&check;</span>
             <span class="sr-only">Selected</span>
           </template>

--- a/src/views/pacbio/PacbioSampleIndex.vue
+++ b/src/views/pacbio/PacbioSampleIndex.vue
@@ -42,8 +42,8 @@
         @filtered="onFiltered"
         @row-selected="onRowSelected"
       >
-        <template #cell(selected)="{ selected }">
-          <template v-if="selected">
+        <template #cell(selected)="selectedCell">
+          <template v-if="selectedCell.selected">
             <span>&check;</span>
             <span class="sr-only">Selected</span>
           </template>

--- a/src/views/saphyr/SaphyrLibraries.vue
+++ b/src/views/saphyr/SaphyrLibraries.vue
@@ -25,8 +25,8 @@
       @filtered="onFiltered"
       @row-selected="onRowSelected"
     >
-      <template #cell(selected)="{ selected }">
-        <template v-if="selected">
+      <template #cell(selected)="selectedCell">
+        <template v-if="selectedCell.selected">
           <span>&check;</span>
           <span class="sr-only">Selected</span>
         </template>


### PR DESCRIPTION
* Fix for eslint warning: https://eslint.vuejs.org/rules/no-template-shadow.html
* Changed cell selection for interactable tables to prevent vue template shadows and to be more explicit

