### PR TITLE
BUG fix - Removed unsupported __vueParentComponent references

### DIFF
--- a/src/components/ont/OntPlateSelectedList.vue
+++ b/src/components/ont/OntPlateSelectedList.vue
@@ -110,10 +110,10 @@ export default {
     },
     onSelect(e) {
       e.added.forEach((el) => {
-        this.selectWellRequests(el.__vueParentComponent.attrs.id)
+        this.selectWellRequests(el.getAttribute('id'))
       })
       e.removed.forEach((el) => {
-        this.selectWellRequests(el.__vueParentComponent.attrs.id)
+        this.selectWellRequests(el.getAttribute('id'))
       })
     },
     setSource(indx) {

--- a/src/components/pacbio/PacbioPlateSelectedList.vue
+++ b/src/components/pacbio/PacbioPlateSelectedList.vue
@@ -104,10 +104,10 @@ export default {
     },
     onSelect(e) {
       e.added.forEach((el) => {
-        this.selectWellRequests(el.__vueParentComponent.attrs.id)
+        this.selectWellRequests(el.getAttribute('id'))
       })
       e.removed.forEach((el) => {
-        this.selectWellRequests(el.__vueParentComponent.attrs.id)
+        this.selectWellRequests(el.getAttribute('id'))
       })
     },
     setSource(indx) {

--- a/tests/unit/components/ont/OntPlateSelectedList.spec.js
+++ b/tests/unit/components/ont/OntPlateSelectedList.spec.js
@@ -65,12 +65,13 @@ describe('OntPlateSelectedList', () => {
       const dispatch = vi.fn()
       store.dispatch = dispatch
       const selecto = wrapper.findComponent('.selecto-selection')
+      const addedWell = wrapper.findAll('[data-attribute=well]')[0]
+      addedWell.getAttribute = vi.fn(() => '1')
+      const removedWell = wrapper.findAll('[data-attribute=well]')[1]
+      removedWell.getAttribute = vi.fn(() => '2')
       await selecto.vm.$emit('select', {
-        // I'm not particularly happy with this, and would prefer to test with
-        // something a little more realistic. TBH, I'd be happier if we were
-        // emitting a vue component.
-        added: [{ __vueParentComponent: { attrs: { id: '1' } } }],
-        removed: [{ __vueParentComponent: { attrs: { id: '2' } } }],
+        added: [addedWell],
+        removed: [removedWell],
       })
 
       expect(dispatch).toHaveBeenCalledWith('traction/ont/pools/selectWellRequests', '1')

--- a/tests/unit/components/pacbio/PacbioPlateSelectedList.spec.js
+++ b/tests/unit/components/pacbio/PacbioPlateSelectedList.spec.js
@@ -65,12 +65,13 @@ describe('PacbioPlateSelectedList', () => {
       const dispatch = vi.fn()
       store.dispatch = dispatch
       const selecto = wrapper.findComponent('.selecto-selection')
+      const addedWell = wrapper.findAll('[data-attribute=well]')[0]
+      addedWell.getAttribute = vi.fn(() => '1')
+      const removedWell = wrapper.findAll('[data-attribute=well]')[1]
+      removedWell.getAttribute = vi.fn(() => '2')
       await selecto.vm.$emit('select', {
-        // I'm not particularly happy with this, and would prefer to test with
-        // something a little more realistic. TBH, I'd be happier if we were
-        // emitting a vue component.
-        added: [{ __vueParentComponent: { attrs: { id: '1' } } }],
-        removed: [{ __vueParentComponent: { attrs: { id: '2' } } }],
+        added: [addedWell],
+        removed: [removedWell],
       })
 
       expect(dispatch).toHaveBeenCalledWith('traction/pacbio/poolCreate/selectWellRequests', '1')


### PR DESCRIPTION
Changes proposed in this pull request:

- Removed references to __vueParentComponent as they are removed in production env 

Quite an interesting one. __ vue __ was removed in vue3 but we used this to access an elements attributes during runtime for vueSelecto elements. This was replaced during the vue3 upgrade with __vueParentComponent but this value is removed in production builds. So it worked locally but not when compiled.
https://stackoverflow.com/questions/64119722/what-is-the-vue-3-equivalent-of-vue-2s-vue

The fix in this case is to use the javascript `getAttribute` method as ID is exposed as an attribute. 
https://developer.mozilla.org/en-US/docs/Web/API/Element/getAttribute

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check version_  
