### PR TITLE
BUG - Pacbio well deletion

### DIFF
--- a/src/store/traction/pacbio/runCreate/mutations.js
+++ b/src/store/traction/pacbio/runCreate/mutations.js
@@ -122,10 +122,10 @@ export default {
    * Adds _destroy key to the well in store so future wells
    * for the same position can be added
    */
-  deleteWell: (state, { position, plateNumber }) => {
-    const id = state.wells[plateNumber][position].id
+  deleteWell: (state, { well, plateNumber }) => {
+    const id = state.wells[plateNumber][well.position].id
 
-    delete state.wells[plateNumber][position]
+    delete state.wells[plateNumber][well.position]
     state.wells[plateNumber]['_destroy'].push({ _destroy: true, id })
   },
 
@@ -155,14 +155,21 @@ export default {
    * @param {Object} plates The plates for the run
    * @param {Object} wells The wells for the run
    * Adds the wells to state by plate number and well position, two dimensional array
+   * Adds the _destroy key to each well plate
    */
   populateWells: (state, { plates, wells }) => {
-    state.wells = splitDataByParent({
+    const wellsByPlate = splitDataByParent({
       data: wells,
       fn: dataToObjectByPosition,
       includeRelationships: true,
       parent: { parentData: plates, children: 'wells', key: 'plate_number' },
     })
+    // We need to add the _destroy key to each plate to handle well deletions
+    // eslint-disable-next-line no-unused-vars
+    Object.entries(wellsByPlate).forEach(([_plateNumber, plate]) => {
+      plate['_destroy'] = []
+    })
+    state.wells = wellsByPlate
   },
 
   /**

--- a/tests/unit/store/traction/pacbio/runCreate/mutations.spec.js
+++ b/tests/unit/store/traction/pacbio/runCreate/mutations.spec.js
@@ -270,7 +270,7 @@ describe('mutations.js', () => {
       const wells = Data.PacbioRun.data.included.slice(2, 5)
       const state = defaultState()
       // Expected wells are the wells that are expected to be in the state after the mutation
-      // We add the _destroy key to the expected wells on like 281
+      // We add the _destroy key to the expected wells on line 281
       const expectedWells = splitDataByParent({
         data: wells,
         fn: dataToObjectByPosition,

--- a/tests/unit/store/traction/pacbio/runCreate/mutations.spec.js
+++ b/tests/unit/store/traction/pacbio/runCreate/mutations.spec.js
@@ -229,7 +229,7 @@ describe('mutations.js', () => {
           _destroy: [],
         },
       }
-      deleteWell(state, { position: 'A1', plateNumber })
+      deleteWell(state, { well: { position: 'A1', id: 1 }, plateNumber })
       expect(state.wells[plateNumber]).toEqual({
         _destroy: [{ _destroy: true, id: 1 }],
         A2: { position: 'A2', id: 2 },
@@ -269,17 +269,22 @@ describe('mutations.js', () => {
       const plates = Data.PacbioRun.data.included.slice(0, 2)
       const wells = Data.PacbioRun.data.included.slice(2, 5)
       const state = defaultState()
+      // Expected wells are the wells that are expected to be in the state after the mutation
+      // We add the _destroy key to the expected wells on like 281
+      const expectedWells = splitDataByParent({
+        data: wells,
+        fn: dataToObjectByPosition,
+        includeRelationships: true,
+        parent: { parentData: plates, children: 'wells', key: 'plate_number' },
+      })
+      // eslint-disable-next-line no-unused-vars
+      Object.entries(expectedWells).forEach(([_plateNumber, plate]) => {
+        plate['_destroy'] = []
+      })
       // apply mutations
       populateWells(state, { plates, wells })
       // assert result
-      expect(state.wells).toEqual(
-        splitDataByParent({
-          data: wells,
-          fn: dataToObjectByPosition,
-          includeRelationships: true,
-          parent: { parentData: plates, children: 'wells', key: 'plate_number' },
-        }),
-      )
+      expect(state.wells).toEqual(expectedWells)
     })
   })
 


### PR DESCRIPTION
BUG fix related to PacBio Run's not being able to have wells deleted

Changes proposed in this pull request:

- Added _destroy key to existing pacbio run plate wells
- Fixed Pacbio RunCreate deleteWell method to reference position of passed in well

#### Instructions for Reviewers

Please pull down locally and check it is working as expected. You should now be able to delete wells in both new and existing PacBio runs.

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check version_  
