### PR TITLE
Sorted the well objects to be in correct order in pacbio revio run creation

### DIFF
--- a/src/store/traction/pacbio/runCreate/run.js
+++ b/src/store/traction/pacbio/runCreate/run.js
@@ -189,7 +189,11 @@ const hasPlateAttributes = ({ sequencing_kit_box_barcode, wells_attributes }) =>
  */
 const createWellsPayload = (wells) => {
   // isolate the _destroy attribute from the rest of the wells
-  const { _destroy, ...rest } = wells
+  // sorting the wells, so if the wells are added to a plate in the order e.g. B1, C1, A1,
+  // they are sorted to be A1, B1, C1, to avoid the validation error - "wells must be in a valid order"
+  const { _destroy, ...rest } = Object.keys(wells)
+    .sort()
+    .reduce((result, key) => ((result[key] = wells[key]), result), {})
 
   // return the wells with the pools replaced by pool_ids attribute
   return (


### PR DESCRIPTION
Closes #

Changes proposed in this pull request:

Issue:  If the wells are filled in the order e.g. A1, C1, B1 & D1 in a four well plate, though it is a valid combination, the run creation fails stating - "plate 1 wells must be in a valid order".
Fix:
-  Sorted the well objects before run creation.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check version_  
