### PR TITLE
fix(pacbio-runs-view): fix filter card not responding to filters

### DIFF
--- a/src/views/pacbio/PacbioRunIndex.vue
+++ b/src/views/pacbio/PacbioRunIndex.vue
@@ -1,6 +1,6 @@
 <template>
   <DataFetcher :fetcher="provider">
-    <FilterCard :fetcher="provider" :filter-options="filterOptions" />
+    <FilterCard :fetcher="fetchPacbioRuns" :filter-options="filterOptions" />
     <div class="flex flex-col">
       <div class="clearfix">
         <traction-button


### PR DESCRIPTION
This bug was caused by the provider method not taking parameters which apply to the pacbio runs request. There is a wider issue that FilterCard and DataFetcher need to handle multiple requests more elegantly. I will create an issue for this.

This fix works because we can assume smrtLinkVersions are already populated by the page load so we can just search pacbioRuns directly instead of handling multiple requests and re-fetching smrtlinkversions.
