### PR TITLE
DPL-871 View old runs

### DIFF
--- a/src/components/pacbio/PacbioRunInfoEdit.vue
+++ b/src/components/pacbio/PacbioRunInfoEdit.vue
@@ -87,19 +87,14 @@ export default {
     ...mapGetters(['runItem', 'smrtLinkVersionList', 'smrtLinkVersion', 'instrumentType']),
     // Makes an array of objects with value and text properties to make
     // the options of smrt-link-version select drop-down list.
+    // Only includes 'active' versions in the list, unless this record already has an inactive version as its value.
     smrtLinkVersionSelectOptions() {
-      var activeVersionsList = []
-      for (const versionKey in this.smrtLinkVersionList) {
-        const version = this.smrtLinkVersionList[versionKey]
-        // Only includes 'active' versions in the list, unless this record already has an inactive version as its value
-        if (version.active == true || version.id == this.smrtLinkVersion.id) {
-          activeVersionsList.push({
-            value: version.id,
-            text: version.name,
-          })
-        }
-      }
-      return activeVersionsList
+      return Object.values(this.smrtLinkVersionList)
+        .filter((version) => version.active || version.id == this.smrtLinkVersion.id)
+        .map(({ id, name }) => ({
+          value: id,
+          text: name,
+        }))
     },
     instrumentTypeSelectOptions() {
       // Returns an array of objects with value and text properties to make

--- a/src/components/pacbio/PacbioRunInfoEdit.vue
+++ b/src/components/pacbio/PacbioRunInfoEdit.vue
@@ -85,13 +85,21 @@ export default {
   },
   computed: {
     ...mapGetters(['runItem', 'smrtLinkVersionList', 'smrtLinkVersion', 'instrumentType']),
+    // Makes an array of objects with value and text properties to make
+    // the options of smrt-link-version select drop-down list.
     smrtLinkVersionSelectOptions() {
-      // Returns an array of objects with value and text properties to make
-      // the options of smrt-link-version select drop-down list.
-      return Object.values(this.smrtLinkVersionList).map(({ id, name }) => ({
-        value: id,
-        text: name,
-      }))
+      var activeVersionsList = []
+      for(const versionKey in this.smrtLinkVersionList) {
+        const version = this.smrtLinkVersionList[versionKey]
+        // Only includes 'active' versions in the list, unless this record already has an inactive version as its value
+        if(version.active == true || version.id == this.smrtLinkVersion.id) {
+          activeVersionsList.push({
+            value: version.id,
+            text: version.name,
+          })
+        }
+      }
+      return activeVersionsList
     },
     instrumentTypeSelectOptions() {
       // Returns an array of objects with value and text properties to make

--- a/src/components/pacbio/PacbioRunInfoEdit.vue
+++ b/src/components/pacbio/PacbioRunInfoEdit.vue
@@ -90,7 +90,7 @@ export default {
     // Only includes 'active' versions in the list, unless this record already has an inactive version as its value.
     smrtLinkVersionSelectOptions() {
       return Object.values(this.smrtLinkVersionList)
-        .filter((version) => version.active || version.id == this.smrtLinkVersion.id)
+        .filter((version) => version.active || version.id === this.smrtLinkVersion.id)
         .map(({ id, name }) => ({
           value: id,
           text: name,

--- a/src/components/pacbio/PacbioRunInfoEdit.vue
+++ b/src/components/pacbio/PacbioRunInfoEdit.vue
@@ -89,10 +89,10 @@ export default {
     // the options of smrt-link-version select drop-down list.
     smrtLinkVersionSelectOptions() {
       var activeVersionsList = []
-      for(const versionKey in this.smrtLinkVersionList) {
+      for (const versionKey in this.smrtLinkVersionList) {
         const version = this.smrtLinkVersionList[versionKey]
         // Only includes 'active' versions in the list, unless this record already has an inactive version as its value
-        if(version.active == true || version.id == this.smrtLinkVersion.id) {
+        if (version.active == true || version.id == this.smrtLinkVersion.id) {
           activeVersionsList.push({
             value: version.id,
             text: version.name,

--- a/src/lib/PacbioInstrumentTypes.js
+++ b/src/lib/PacbioInstrumentTypes.js
@@ -4,6 +4,9 @@ import { LabwareTypes } from '@/lib/LabwareTypes'
  * A collection of methods to deal with Pacbio Instrument Types
  * we could possibly add these methods to the object itself
  * which would be better for naming and usage
+ *
+ * TODO: Find out the correct values for the old SequelII and SequelI entries.
+ *
  * @module PacbioInstrumentTypes
  */
 
@@ -28,6 +31,22 @@ const PacbioInstrumentTypes = {
   SequelIIe: {
     key: 'SequelIIe',
     name: 'Sequel IIe',
+    plateCount: 1,
+    labwareType: LabwareTypes.Plate96,
+    plateClasses: 'w-full',
+    sequencingKitBoxBarcodeLength: 21,
+  },
+  SequelII: {
+    key: 'SequelII',
+    name: 'Sequel II',
+    plateCount: 1,
+    labwareType: LabwareTypes.Plate96,
+    plateClasses: 'w-full',
+    sequencingKitBoxBarcodeLength: 21,
+  },
+  SequelI: {
+    key: 'SequelI',
+    name: 'Sequel I',
     plateCount: 1,
     labwareType: LabwareTypes.Plate96,
     plateClasses: 'w-full',

--- a/src/lib/PacbioInstrumentTypes.js
+++ b/src/lib/PacbioInstrumentTypes.js
@@ -5,8 +5,6 @@ import { LabwareTypes } from '@/lib/LabwareTypes'
  * we could possibly add these methods to the object itself
  * which would be better for naming and usage
  *
- * TODO: Find out the correct values for the old SequelII and SequelI entries.
- *
  * @module PacbioInstrumentTypes
  */
 

--- a/src/lib/PacbioInstrumentTypes.js
+++ b/src/lib/PacbioInstrumentTypes.js
@@ -4,7 +4,6 @@ import { LabwareTypes } from '@/lib/LabwareTypes'
  * A collection of methods to deal with Pacbio Instrument Types
  * we could possibly add these methods to the object itself
  * which would be better for naming and usage
- *
  * @module PacbioInstrumentTypes
  */
 

--- a/src/store/traction/pacbio/runCreate/mutations.js
+++ b/src/store/traction/pacbio/runCreate/mutations.js
@@ -21,7 +21,7 @@ const setData = (state, type, data, includeRelationships = false) => {
 
 export default {
   /**
-   * Populated with resources via APi calls from the actions
+   * Populated with resources via API calls from the actions
    * @param {Object} state The VueXState object
    * @param {Array.{}} smrtLinkVersions The SmrtLinkVersions to populate the store
    */

--- a/tests/data/tractionPacbioSmrtLinkVersions.json
+++ b/tests/data/tractionPacbioSmrtLinkVersions.json
@@ -28,7 +28,8 @@
         },
         "attributes": {
           "name": "v11",
-          "default": true
+          "default": true,
+          "active": true
         },
         "relationships": {
           "smrt_link_option_versions": {
@@ -47,7 +48,8 @@
         },
         "attributes": {
           "name": "v12_revio",
-          "default": false
+          "default": false,
+          "active": true
         },
         "relationships": {
           "smrt_link_option_versions": {
@@ -66,7 +68,8 @@
         },
         "attributes": {
           "name": "v12_sequel_iie",
-          "default": false
+          "default": false,
+          "active": true
         },
         "relationships": {
           "smrt_link_option_versions": {

--- a/tests/e2e/fixtures/tractionPacbioSmrtLinkVersions.json
+++ b/tests/e2e/fixtures/tractionPacbioSmrtLinkVersions.json
@@ -8,7 +8,8 @@
       },
       "attributes": {
         "name": "v11",
-        "default": true
+        "default": true,
+        "active": true
       },
       "relationships": {
         "smrt_link_option_versions": {
@@ -27,7 +28,8 @@
       },
       "attributes": {
         "name": "v12_revio",
-        "default": false
+        "default": false,
+        "active": true
       },
       "relationships": {
         "smrt_link_option_versions": {

--- a/tests/unit/components/labware/PacbioRunPlateItem.spec.js
+++ b/tests/unit/components/labware/PacbioRunPlateItem.spec.js
@@ -5,7 +5,7 @@ import { it } from 'vitest'
 import { PacbioInstrumentTypes } from '@/lib/PacbioInstrumentTypes'
 
 const smrtLinkVersions = {
-  1: { id: 1, name: 'v11', default: true },
+  1: { id: 1, name: 'v11', default: true, active: true },
 }
 
 store.state.traction.pacbio.runCreate.resources.smrtLinkVersions = smrtLinkVersions

--- a/tests/unit/components/labware/PacbioRunPlateList.spec.js
+++ b/tests/unit/components/labware/PacbioRunPlateList.spec.js
@@ -5,7 +5,7 @@ import { it } from 'vitest'
 import { PacbioInstrumentTypes } from '@/lib/PacbioInstrumentTypes'
 
 const smrtLinkVersions = {
-  1: { id: 1, name: 'v11', default: true },
+  1: { id: 1, name: 'v11', default: true, active: true },
 }
 store.state.traction.pacbio.runCreate.resources.smrtLinkVersions = smrtLinkVersions
 

--- a/tests/unit/components/labware/PacbioRunWell.spec.js
+++ b/tests/unit/components/labware/PacbioRunWell.spec.js
@@ -7,8 +7,8 @@ describe('PacbioRunWell.vue', () => {
   let well, wrapper, props, storeWell, smrtLinkVersion
 
   const smrtLinkVersions = {
-    1: { id: 1, name: 'v11', default: true },
-    2: { id: 2, name: 'v12_revio', default: false },
+    1: { id: 1, name: 'v11', default: true, active: true },
+    2: { id: 2, name: 'v12_revio', default: false, active: true },
   }
 
   beforeEach(() => {

--- a/tests/unit/components/pacbio/PacbioRunInfoEdit.spec.js
+++ b/tests/unit/components/pacbio/PacbioRunInfoEdit.spec.js
@@ -28,16 +28,19 @@ describe('PacbioRunInfoEdit', () => {
       id: '1',
       name: 'v1',
       default: true,
+      active: true,
     },
     2: {
       id: '2',
       name: 'v12_revio',
       default: false,
+      active: true,
     },
     3: {
       id: '3',
       name: 'v12_sequel_iie',
       default: false,
+      active: true,
     },
   }
 

--- a/tests/unit/components/pacbio/PacbioRunInfoEdit.spec.js
+++ b/tests/unit/components/pacbio/PacbioRunInfoEdit.spec.js
@@ -10,39 +10,47 @@ if (document.body) {
   document.body.appendChild(elem)
 }
 
-const props = {
-  newRecord: true,
+const smrtLinkVersions = {
+  1: {
+    id: '1',
+    name: 'v1',
+    default: true,
+    active: true,
+  },
+  2: {
+    id: '2',
+    name: 'v12_revio',
+    default: false,
+    active: true,
+  },
+  3: {
+    id: '3',
+    name: 'v12_sequel_iie',
+    default: false,
+    active: true,
+  },
+  4: {
+    id: '4',
+    name: 'v10',
+    default: false,
+    active: false,
+  },
 }
 
-const buildWrapper = () =>
+let runInfo, wrapper
+
+describe('PacbioRunInfoEdit', () => {
+  const props = {
+    newRecord: true,
+  }
+
+  const buildWrapper = () =>
   mount(PacbioRunInfoEdit, {
     store,
     sync: false,
     attachTo: elem,
     props,
   })
-
-describe('PacbioRunInfoEdit', () => {
-  const smrtLinkVersions = {
-    1: {
-      id: '1',
-      name: 'v1',
-      default: true,
-      active: true,
-    },
-    2: {
-      id: '2',
-      name: 'v12_revio',
-      default: false,
-      active: true,
-    },
-    3: {
-      id: '3',
-      name: 'v12_sequel_iie',
-      default: false,
-      active: true,
-    },
-  }
 
   const run = {
     id: 'new',
@@ -51,8 +59,6 @@ describe('PacbioRunInfoEdit', () => {
     dna_control_complex_box_barcode: null,
     comments: null,
   }
-
-  let runInfo, wrapper
 
   beforeEach(() => {
     wrapper = buildWrapper()
@@ -85,12 +91,12 @@ describe('PacbioRunInfoEdit', () => {
 
   describe('#computed', () => {
     describe('#smrtLinkVersionSelectOptions', () => {
-      it('returns the correct versions', () => {
-        expect(Object.values(runInfo.smrtLinkVersionList).length).toEqual(3)
+      it('returns only the active versions', () => {
+        expect(runInfo.smrtLinkVersionSelectOptions.length).toEqual(3)
       })
 
       it('returns smrt link version select options', () => {
-        const options = Object.values(runInfo.smrtLinkVersionList).map(({ id, name }) => ({
+        const options = Object.values(runInfo.smrtLinkVersionList).slice(0, 3).map(({ id, name }) => ({
           value: id,
           text: name,
         }))
@@ -155,6 +161,46 @@ describe('PacbioRunInfoEdit', () => {
       const input = wrapper.find('[data-attribute=comments]')
       await input.setValue('example comment')
       expect(store.state.traction.pacbio.runCreate.run.comments).toEqual('example comment')
+    })
+  })
+})
+
+describe('PacbioRunInfoEdit old run', () => {
+  const props = {
+    newRecord: false,
+  }
+
+  const buildWrapper = () =>
+  mount(PacbioRunInfoEdit, {
+    store,
+    sync: false,
+    attachTo: elem,
+    props,
+  })
+
+  const run = {
+    id: 'new',
+    name: 'TRACTION-RUN-4',
+    system_name: 'Sequel I',
+    dna_control_complex_box_barcode: null,
+    comments: null,
+  }
+
+  beforeEach(() => {
+    wrapper = buildWrapper()
+    runInfo = wrapper.vm
+    store.state.traction.pacbio.runCreate.run = { ...run }
+    store.state.traction.pacbio.runCreate.smrtLinkVersion = smrtLinkVersions[4]
+    store.state.traction.pacbio.runCreate.resources.smrtLinkVersions = smrtLinkVersions
+    store.state.traction.pacbio.runCreate.instrumentTypeList = PacbioInstrumentTypes
+    store.state.traction.pacbio.runCreate.instrumentType = PacbioInstrumentTypes.SequelI
+  })
+
+  describe('#computed', () => {
+    describe('#smrtLinkVersionSelectOptions', () => {
+      it('includes an inactive version if the record has that value', () => {
+        expect(runInfo.smrtLinkVersionSelectOptions.length).toEqual(4)
+      })
     })
   })
 })

--- a/tests/unit/components/pacbio/PacbioRunInfoEdit.spec.js
+++ b/tests/unit/components/pacbio/PacbioRunInfoEdit.spec.js
@@ -45,12 +45,12 @@ describe('PacbioRunInfoEdit', () => {
   }
 
   const buildWrapper = () =>
-  mount(PacbioRunInfoEdit, {
-    store,
-    sync: false,
-    attachTo: elem,
-    props,
-  })
+    mount(PacbioRunInfoEdit, {
+      store,
+      sync: false,
+      attachTo: elem,
+      props,
+    })
 
   const run = {
     id: 'new',
@@ -96,10 +96,12 @@ describe('PacbioRunInfoEdit', () => {
       })
 
       it('returns smrt link version select options', () => {
-        const options = Object.values(runInfo.smrtLinkVersionList).slice(0, 3).map(({ id, name }) => ({
-          value: id,
-          text: name,
-        }))
+        const options = Object.values(runInfo.smrtLinkVersionList)
+          .slice(0, 3)
+          .map(({ id, name }) => ({
+            value: id,
+            text: name,
+          }))
 
         expect(runInfo.smrtLinkVersionSelectOptions).toEqual(options)
       })
@@ -171,12 +173,12 @@ describe('PacbioRunInfoEdit old run', () => {
   }
 
   const buildWrapper = () =>
-  mount(PacbioRunInfoEdit, {
-    store,
-    sync: false,
-    attachTo: elem,
-    props,
-  })
+    mount(PacbioRunInfoEdit, {
+      store,
+      sync: false,
+      attachTo: elem,
+      props,
+    })
 
   const run = {
     id: 'new',

--- a/tests/unit/components/pacbio/PacbioRunWellDefaultEdit.spec.js
+++ b/tests/unit/components/pacbio/PacbioRunWellDefaultEdit.spec.js
@@ -22,11 +22,13 @@ const smrtLinkVersions = {
     id: 1,
     name: 'v11',
     default: false,
+    active: true,
   },
   2: {
     id: 2,
     name: 'v12_revio',
     default: false,
+    active: true,
   },
 }
 

--- a/tests/unit/components/pacbio/PacbioRunWellEdit.spec.js
+++ b/tests/unit/components/pacbio/PacbioRunWellEdit.spec.js
@@ -9,11 +9,13 @@ const smrtLinkVersions = {
     id: 1,
     name: 'v11',
     default: false,
+    active: true,
   },
   2: {
     id: 2,
     name: 'v12_revio',
     default: 'false',
+    active: true,
   },
 }
 

--- a/tests/unit/store/traction/pacbio/runCreate/actions.spec.js
+++ b/tests/unit/store/traction/pacbio/runCreate/actions.spec.js
@@ -392,8 +392,8 @@ describe('actions.js', () => {
       const state = {
         resources: {
           smrtLinkVersions: {
-            1: { id: '1', version: 'v1', default: true },
-            2: { id: '2', version: 'v2', default: false },
+            1: { id: '1', version: 'v1', default: true, active: true },
+            2: { id: '2', version: 'v2', default: false, active: true },
           },
         },
       }

--- a/tests/unit/store/traction/pacbio/runCreate/getters.spec.js
+++ b/tests/unit/store/traction/pacbio/runCreate/getters.spec.js
@@ -114,11 +114,13 @@ describe('getters.js', () => {
       id: 1,
       name: 'v1',
       default: true,
+      active: true,
     },
     2: {
       id: 2,
       name: 'v2',
       default: false,
+      active: true,
     },
   }
 

--- a/tests/unit/store/traction/pacbio/runCreate/run.spec.js
+++ b/tests/unit/store/traction/pacbio/runCreate/run.spec.js
@@ -17,16 +17,19 @@ const smrtLinkVersions = {
     id: 1,
     name: 'v11',
     default: false,
+    active: true,
   },
   2: {
     id: 2,
     name: 'v12_revio',
     default: false,
+    active: true,
   },
   3: {
     id: 2,
     name: 'v12_sequel_iie',
     default: false,
+    active: true,
   },
 }
 

--- a/tests/unit/views/pacbio/PacbioRunShow.spec.js
+++ b/tests/unit/views/pacbio/PacbioRunShow.spec.js
@@ -8,6 +8,7 @@ const smrtLinkVersions = {
     id: 1,
     name: 'v11',
     default: true,
+    active: true,
   },
 }
 


### PR DESCRIPTION
Fixes around the 'system name' and 'smrt link version' fields
- System name wasn't showing because Sequel I and Sequel II weren't present in the config, due to being old systems.
- Therefore the instrument type data wasn't getting populated and things were erroring that tried to access it
- I've just copied the Sequel IIe config to create entries for the old systems - will need to find out the correct values here
- This allows the Plate section to render, and the value to appear in the 'system name' drop down.
- smrt link version wasn't showing because the database entry said 'inactive', and the API only retrieved 'active' values
- Tweaked the API to allow through active values (in traction service), and filtered them out from the drop down unless the record value was an inactive one

See comment https://github.com/sanger/traction-ui/issues/1300#issuecomment-1748946591 and screenshots on story https://github.com/sanger/traction-ui/issues/1300#issuecomment-1749062904

Closes #1300 

#### Changes proposed in this pull request

- 

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
