### PR TITLE
DPL-871 - bug where old system names showing in new runs

### DIFF
--- a/src/components/pacbio/PacbioRunInfoEdit.vue
+++ b/src/components/pacbio/PacbioRunInfoEdit.vue
@@ -73,9 +73,6 @@ import { createNamespacedHelpers } from 'vuex'
 const { mapGetters, mapActions } = createNamespacedHelpers('traction/pacbio/runCreate')
 import { PacbioInstrumentTypes } from '@/lib/PacbioInstrumentTypes'
 
-const SMRT_LINK_VERSION_V12_REVIO = 'v12_revio'
-const SMRT_LINK_VERSION_V12_SEQUEL_IIE = 'v12_sequel_iie'
-
 export default {
   name: 'PacbioRunInfoEdit',
   props: {
@@ -99,15 +96,18 @@ export default {
     instrumentTypeSelectOptions() {
       // Returns an array of objects with value and text properties to make
       // the options of instrument-type select drop-down list.
-      return Object.values(PacbioInstrumentTypes).map(({ key, name }) => ({
-        value: key,
-        text: name,
-      }))
+      return Object.values(PacbioInstrumentTypes)
+        .filter(
+          (instrumentType) =>
+            instrumentType.active || instrumentType.key === this.instrumentType.key,
+        )
+        .map(({ key, name }) => ({
+          value: key,
+          text: name,
+        }))
     },
     smrtLinkVersionv12() {
-      return [SMRT_LINK_VERSION_V12_SEQUEL_IIE, SMRT_LINK_VERSION_V12_REVIO].includes(
-        this.smrtLinkVersion.name,
-      )
+      return /^v12/.test(this.smrtLinkVersion.name)
     },
   },
   methods: {

--- a/src/components/pacbio/PacbioRunInfoEdit.vue
+++ b/src/components/pacbio/PacbioRunInfoEdit.vue
@@ -69,6 +69,18 @@
 </template>
 
 <script>
+/*
+ @param {Array} list - An array of objects
+  @param {String} key - The key of the object to use as the value of the select option
+  @returns {Array} - An array of objects with value and text properties
+*/
+const createSelectOptions = (list, key) => {
+  return list.map((item) => ({
+    value: item[key],
+    text: item.name,
+  }))
+}
+
 import { createNamespacedHelpers } from 'vuex'
 const { mapGetters, mapActions } = createNamespacedHelpers('traction/pacbio/runCreate')
 import { PacbioInstrumentTypes } from '@/lib/PacbioInstrumentTypes'
@@ -86,25 +98,18 @@ export default {
     // the options of smrt-link-version select drop-down list.
     // Only includes 'active' versions in the list, unless this record already has an inactive version as its value.
     smrtLinkVersionSelectOptions() {
-      return Object.values(this.smrtLinkVersionList)
-        .filter((version) => version.active || version.id === this.smrtLinkVersion.id)
-        .map(({ id, name }) => ({
-          value: id,
-          text: name,
-        }))
+      const list = Object.values(this.smrtLinkVersionList).filter(
+        (version) => version.active || version.id === this.smrtLinkVersion.id,
+      )
+      return createSelectOptions(list, 'id')
     },
     instrumentTypeSelectOptions() {
       // Returns an array of objects with value and text properties to make
       // the options of instrument-type select drop-down list.
-      return Object.values(PacbioInstrumentTypes)
-        .filter(
-          (instrumentType) =>
-            instrumentType.active || instrumentType.key === this.instrumentType.key,
-        )
-        .map(({ key, name }) => ({
-          value: key,
-          text: name,
-        }))
+      const list = Object.values(PacbioInstrumentTypes).filter(
+        (instrumentType) => instrumentType.active || instrumentType.key === this.instrumentType.key,
+      )
+      return createSelectOptions(list, 'key')
     },
     smrtLinkVersionv12() {
       return /^v12/.test(this.smrtLinkVersion.name)

--- a/src/lib/PacbioInstrumentTypes.js
+++ b/src/lib/PacbioInstrumentTypes.js
@@ -24,6 +24,7 @@ const PacbioInstrumentTypes = {
     labwareType: LabwareTypes.Plate4,
     plateClasses: 'w-32 mx-auto',
     sequencingKitBoxBarcodeLength: 28,
+    active: true,
   },
   SequelIIe: {
     key: 'SequelIIe',
@@ -32,6 +33,7 @@ const PacbioInstrumentTypes = {
     labwareType: LabwareTypes.Plate96,
     plateClasses: 'w-full',
     sequencingKitBoxBarcodeLength: 21,
+    active: true,
   },
   SequelII: {
     key: 'SequelII',
@@ -40,6 +42,7 @@ const PacbioInstrumentTypes = {
     labwareType: LabwareTypes.Plate96,
     plateClasses: 'w-full',
     sequencingKitBoxBarcodeLength: 21,
+    active: false,
   },
   SequelI: {
     key: 'SequelI',
@@ -48,6 +51,7 @@ const PacbioInstrumentTypes = {
     labwareType: LabwareTypes.Plate96,
     plateClasses: 'w-full',
     sequencingKitBoxBarcodeLength: 21,
+    active: false,
   },
 }
 

--- a/tests/unit/components/pacbio/PacbioRunInfoEdit.spec.js
+++ b/tests/unit/components/pacbio/PacbioRunInfoEdit.spec.js
@@ -89,7 +89,7 @@ describe('PacbioRunInfoEdit', () => {
     )
   })
 
-  it.only('will only show the instrument type options that are active', () => {
+  it('will only show the instrument type options that are active', () => {
     const options = wrapper.find('[data-attribute=system_name]').findAll('option')
     expect(options.length).toEqual(2)
   })

--- a/tests/unit/components/pacbio/PacbioRunInfoEdit.spec.js
+++ b/tests/unit/components/pacbio/PacbioRunInfoEdit.spec.js
@@ -89,6 +89,11 @@ describe('PacbioRunInfoEdit', () => {
     )
   })
 
+  it.only('will only show the instrument type options that are active', () => {
+    const options = wrapper.find('[data-attribute=system_name]').findAll('option')
+    expect(options.length).toEqual(2)
+  })
+
   describe('#computed', () => {
     describe('#smrtLinkVersionSelectOptions', () => {
       it('returns only the active versions', () => {


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

- modifed computed method for checking if SMRT Link Version is v12
- filter system names for new runs to only include active versions

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
