### PR TITLE
Reverts aa309bc2 printer due to wrong printer type

### DIFF
--- a/src/config/PrinterList.json
+++ b/src/config/PrinterList.json
@@ -6,6 +6,5 @@
   { "printerName": "ssrtubebc-sq1" },
   { "printerName": "aa309bc1" },
   { "printerName": "g311bc1" },
-  { "printerName": "aa309bc3" },
-  { "printerName": "aa309bc2" }
+  { "printerName": "aa309bc3" }
 ]


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

- reverts aa309bc2 printer due to wrong printer type

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
