### PR TITLE
Fix - Update stores to use library_pools type when getting libraries via pools

### DIFF
--- a/src/store/traction/pacbio/poolCreate/actions.js
+++ b/src/store/traction/pacbio/poolCreate/actions.js
@@ -228,7 +228,7 @@ export default {
 
     if (success) {
       const {
-        libraries,
+        library_pools,
         requests,
         wells,
         plates = [],
@@ -241,7 +241,7 @@ export default {
         1,
       )[0]
       commit('populatePoolAttributes', data)
-      commit('populateLibraries', libraries)
+      commit('populateLibraries', library_pools)
       commit('populateRequests', requests)
       commit('populateWells', wells)
       commit('populatePlates', plates)

--- a/src/store/traction/pacbio/pools/actions.js
+++ b/src/store/traction/pacbio/pools/actions.js
@@ -19,10 +19,10 @@ const setPools = async ({ commit, getters }, filter, page) => {
   const { success, data: { data, included = [], meta = {} } = {}, errors = [] } = response
 
   if (success) {
-    const { tubes, libraries, tags, requests } = groupIncludedByResource(included)
+    const { tubes, library_pools, tags, requests } = groupIncludedByResource(included)
     commit('setPools', data)
     commit('setTubes', tubes)
-    commit('setLibraries', libraries)
+    commit('setLibraries', library_pools)
     commit('setTags', tags)
     commit('setRequests', requests)
   }

--- a/src/stores/pacbioRunCreate.js
+++ b/src/stores/pacbioRunCreate.js
@@ -220,12 +220,12 @@ export const usePacbioRunCreateStore = defineStore('pacbioRunCreate', {
       const { success, data: { data, included = [] } = {}, errors = [] } = response
       // success is true with an empty list when no pools match the filter
       if (success && data.length > 0) {
-        const { tubes, libraries, tags, requests } = groupIncludedByResource(included)
+        const { tubes, library_pools, tags, requests } = groupIncludedByResource(included)
 
         // populate pools, tubes, libraries, tags and requests in store
         this.pools = formatById(this.pools, data, true)
         this.tubes = formatById(this.tubes, tubes)
-        this.libraries = formatById(this.libraries, libraries, true)
+        this.libraries = formatById(this.libraries, library_pools, true)
         this.requests = formatById(this.requests, requests)
         this.tags = formatById(this.tags, tags)
 
@@ -267,7 +267,7 @@ export const usePacbioRunCreateStore = defineStore('pacbioRunCreate', {
           wells,
           pools,
           tubes,
-          libraries,
+          library_pools,
           tags,
           requests,
           smrt_link_versions: [smrt_link_version = {}] = [],
@@ -299,7 +299,7 @@ export const usePacbioRunCreateStore = defineStore('pacbioRunCreate', {
 
         //Populate libraries, tags,tubes and requests
         this.pools = formatById(this.pools, pools, true)
-        this.libraries = formatById(this.libraries, libraries, true)
+        this.libraries = formatById(this.libraries, library_pools, true)
         this.tags = formatById(this.tags, tags)
         this.requests = formatById(this.requests, requests)
         this.tubes = formatById(this.tubes, tubes)

--- a/tests/data/StorePools.json
+++ b/tests/data/StorePools.json
@@ -61,7 +61,7 @@
       "id": "1",
       "request": "1",
       "tag": "26",
-      "type": "libraries",
+      "type": "library_pools",
       "run_suitability": {
         "ready_for_run": true,
         "errors": []
@@ -71,7 +71,7 @@
       "id": "2",
       "request": "2",
       "tag": "7",
-      "type": "libraries",
+      "type": "library_pools",
       "run_suitability": {
         "ready_for_run": false,
         "errors": [

--- a/tests/data/pacbioPool.json
+++ b/tests/data/pacbioPool.json
@@ -38,7 +38,7 @@
             },
             "data": [
               {
-                "type": "libraries",
+                "type": "library_pools",
                 "id": "1"
               }
             ]
@@ -59,7 +59,7 @@
       },
       {
         "id": "1",
-        "type": "libraries",
+        "type": "library_pools",
         "links": {
           "self": "http://localhost:3100/v1/pacbio/libraries/1"
         },

--- a/tests/data/pacbioRun.json
+++ b/tests/data/pacbioRun.json
@@ -243,7 +243,7 @@
             },
             "data": [
               {
-                "type": "libraries",
+                "type": "library_pools",
                 "id": "1"
               }
             ]
@@ -288,7 +288,7 @@
       },
       {
         "id": "1",
-        "type": "libraries",
+        "type": "library_pools",
         "links": {
           "self": "http://localhost:3100/v1/pacbio/libraries/1"
         },

--- a/tests/data/tractionPacbioPool.json
+++ b/tests/data/tractionPacbioPool.json
@@ -37,7 +37,7 @@
           },
           "data": [
             {
-              "type": "libraries",
+              "type": "library_pools",
               "id": "242"
             }
           ]
@@ -47,7 +47,7 @@
     "included": [
       {
         "id": "242",
-        "type": "libraries",
+        "type": "library_pools",
         "links": {
           "self": "http://localhost:3100/v1/pacbio/libraries/242"
         },

--- a/tests/data/tractionPacbioPools.json
+++ b/tests/data/tractionPacbioPools.json
@@ -38,7 +38,7 @@
             },
             "data": [
               {
-                "type": "libraries",
+                "type": "library_pools",
                 "id": "1"
               }
             ]
@@ -99,7 +99,7 @@
             },
             "data": [
               {
-                "type": "libraries",
+                "type": "library_pools",
                 "id": "2"
               }
             ]
@@ -130,7 +130,7 @@
       },
       {
         "id": "1",
-        "type": "libraries",
+        "type": "library_pools",
         "links": {
           "self": "http://localhost:3100/v1/pacbio/libraries/1"
         },
@@ -165,7 +165,7 @@
       },
       {
         "id": "2",
-        "type": "libraries",
+        "type": "library_pools",
         "links": {
           "self": "http://localhost:3100/v1/pacbio/libraries/2"
         },

--- a/tests/e2e/fixtures/pacbioPool.json
+++ b/tests/e2e/fixtures/pacbioPool.json
@@ -37,7 +37,7 @@
           },
           "data": [
             {
-              "type": "libraries",
+              "type": "library_pools",
               "id": "1"
             }
           ]
@@ -58,7 +58,7 @@
     },
     {
       "id": "1",
-      "type": "libraries",
+      "type": "library_pools",
       "links": {
         "self": "http://localhost:3100/v1/pacbio/libraries/1"
       },

--- a/tests/e2e/fixtures/tractionPacbioPool.json
+++ b/tests/e2e/fixtures/tractionPacbioPool.json
@@ -32,7 +32,7 @@
         },
         "data": [
           {
-            "type": "libraries",
+            "type": "library_pools",
             "id": "242"
           }
         ]
@@ -42,7 +42,7 @@
   "included": [
     {
       "id": "242",
-      "type": "libraries",
+      "type": "library_pools",
       "links": {
         "self": "http://localhost:3100/v1/pacbio/libraries/242"
       },

--- a/tests/e2e/fixtures/tractionPacbioPools.json
+++ b/tests/e2e/fixtures/tractionPacbioPools.json
@@ -37,7 +37,7 @@
           },
           "data": [
             {
-              "type": "libraries",
+              "type": "library_pools",
               "id": "1"
             }
           ]
@@ -81,7 +81,7 @@
           },
           "data": [
             {
-              "type": "libraries",
+              "type": "library_pools",
               "id": "2"
             }
           ]
@@ -112,7 +112,7 @@
     },
     {
       "id": "1",
-      "type": "libraries",
+      "type": "library_pools",
       "attributes": {
         "run_suitability": {
           "ready_for_run": true,
@@ -147,7 +147,7 @@
     },
     {
       "id": "2",
-      "type": "libraries",
+      "type": "library_pools",
       "attributes": {
         "run_suitability": {
           "ready_for_run": true,

--- a/tests/e2e/fixtures/tractionPacbioRevioRun.json
+++ b/tests/e2e/fixtures/tractionPacbioRevioRun.json
@@ -198,7 +198,7 @@
           },
           "data": [
             {
-              "type": "libraries",
+              "type": "library_pools",
               "id": "19"
             }
           ]
@@ -243,7 +243,7 @@
     },
     {
       "id": "19",
-      "type": "libraries",
+      "type": "library_pools",
       "links": {
         "self": "http://localhost:3100/v1/pacbio/libraries/19"
       },

--- a/tests/e2e/fixtures/tractionPacbioSequelIIeRun.json
+++ b/tests/e2e/fixtures/tractionPacbioSequelIIeRun.json
@@ -131,7 +131,7 @@
           },
           "data": [
             {
-              "type": "libraries",
+              "type": "library_pools",
               "id": "19"
             }
           ]
@@ -176,7 +176,7 @@
     },
     {
       "id": "19",
-      "type": "libraries",
+      "type": "library_pools",
       "links": {
         "self": "http://localhost:3100/v1/pacbio/libraries/19"
       },

--- a/tests/unit/store/traction/pacbio/pools/getters.spec.js
+++ b/tests/unit/store/traction/pacbio/pools/getters.spec.js
@@ -13,7 +13,7 @@ const pools = [
         id: '1',
         sample_name: 'Sample48',
         group_id: 'bc1019',
-        type: 'libraries',
+        type: 'library_pools',
         run_suitability: {
           ready_for_run: true,
           errors: [],
@@ -43,7 +43,7 @@ const pools = [
         id: '2',
         sample_name: 'Sample47',
         group_id: 'bc1011_BAK8A_OA',
-        type: 'libraries',
+        type: 'library_pools',
         run_suitability: {
           ready_for_run: false,
           errors: [
@@ -107,7 +107,7 @@ describe('getters', () => {
       id: '1',
       request: '1',
       tag: '',
-      type: 'libraries',
+      type: 'library_pools',
       run_suitability: { ready_for_run: true, errors: [] },
     }
     const pools = getters.pools(state)

--- a/tests/unit/stores/pacbioRunCreate.spec.js
+++ b/tests/unit/stores/pacbioRunCreate.spec.js
@@ -35,7 +35,7 @@ describe('usePacbioRunCreateStore', () => {
             id: '1',
             sample_name: 'Sample48',
             group_id: 'bc1019',
-            type: 'libraries',
+            type: 'library_pools',
             run_suitability: {
               ready_for_run: true,
               errors: [],
@@ -65,7 +65,7 @@ describe('usePacbioRunCreateStore', () => {
             id: '2',
             sample_name: 'Sample47',
             group_id: 'bc1011_BAK8A_OA',
-            type: 'libraries',
+            type: 'library_pools',
             run_suitability: {
               ready_for_run: false,
               errors: [
@@ -168,7 +168,7 @@ describe('usePacbioRunCreateStore', () => {
           id: '1',
           request: '1',
           tag: '',
-          type: 'libraries',
+          type: 'library_pools',
           run_suitability: { ready_for_run: true, errors: [] },
         }
         expect(store.poolsArray[0].libraries[0].group_id).toEqual(undefined)


### PR DESCRIPTION
Required due to changes in the service around LibraryResource and LibraryPoolResource

#### Changes proposed in this pull request

- Update stores to use library_pools type when getting libraries via pools

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
