### PR TITLE
DPL-989 - Fix 0's giving false errors in pool create

### DIFF
--- a/src/store/traction/pacbio/poolCreate/pool.js
+++ b/src/store/traction/pacbio/poolCreate/pool.js
@@ -42,7 +42,7 @@ const validate = ({ libraries, pool }) => {
   for (const [key, library] of Object.entries(libraries)) {
     const errors = {}
     requiredLibraryAttributes(pooled).forEach((field) => {
-      if (!library[field]) {
+      if (!library[field] && library[field] !== 0) {
         isValid = false
         errors[field] = 'must be present'
       }
@@ -57,7 +57,8 @@ const validate = ({ libraries, pool }) => {
 
   pool.errors = {}
   requiredPoolAttrs.forEach((field) => {
-    if (!pool[field]) {
+    // We check its not 0 to prevent false errors as 0 is valid but !0 returns true
+    if (!pool[field] && pool[field] !== 0) {
       pool.errors[field] = 'must be present'
       isValid = false
     }

--- a/tests/unit/components/pacbio/PacbioPoolEdit.spec.js
+++ b/tests/unit/components/pacbio/PacbioPoolEdit.spec.js
@@ -123,7 +123,9 @@ describe('pacbioPoolEdit#new', () => {
 
       expect(wrapper.find('[data-attribute=volume-error]').exists()).toBe(false)
       expect(wrapper.find('[data-attribute=insert_size-error]').exists()).toBe(false)
-      expect(wrapper.find('[data-attribute=template_prep_kit_box_barcode-error]').exists()).toBe(false)
+      expect(wrapper.find('[data-attribute=template_prep_kit_box_barcode-error]').exists()).toBe(
+        false,
+      )
       expect(wrapper.find('[data-attribute=concentration-error]').exists()).toBe(false)
     })
   })

--- a/tests/unit/components/pacbio/PacbioPoolEdit.spec.js
+++ b/tests/unit/components/pacbio/PacbioPoolEdit.spec.js
@@ -111,6 +111,23 @@ describe('pacbioPoolEdit#new', () => {
     })
   })
 
+  describe('when inputs are valid', () => {
+    it('no errors are displayed', async () => {
+      store.state.traction.pacbio.poolCreate.pool = {
+        volume: 0,
+        insert_size: 100,
+        concentration: 2.4,
+        template_prep_kit_box_barcode: '017865101789500022821',
+      }
+      await nextTick()
+
+      expect(wrapper.find('[data-attribute=volume-error]').exists()).toBe(false)
+      expect(wrapper.find('[data-attribute=insert_size-error]').exists()).toBe(false)
+      expect(wrapper.find('[data-attribute=template_prep_kit_box_barcode-error]').exists()).toBe(false)
+      expect(wrapper.find('[data-attribute=concentration-error]').exists()).toBe(false)
+    })
+  })
+
   describe('submit button', () => {
     it('says Create pool', () => {
       const button = wrapper.find('[data-action=create-pool]')


### PR DESCRIPTION
#### Changes proposed in this pull request

- 0's are valid values for conc, volume and insert_size but we were checking !value which when value=0 returns true. 

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
