### PR TITLE
Y24-050 - library volume check on UI

### DIFF
--- a/src/components/pacbio/PacbioLibraryForm.vue
+++ b/src/components/pacbio/PacbioLibraryForm.vue
@@ -26,12 +26,34 @@
         />
       </fieldset>
       <fieldset id="input-group-volume">
-        <traction-label class="ml-1">Volume</traction-label>
+        <div class="relative flex flex-row">
+          <traction-label class="ml-1 w-full">Volume</traction-label>
+          <div
+            v-if="formLibrary.used_volume"
+            class="justify-end contents-end px-1 relative"
+            @mouseover="hover = true"
+            @mouseleave="hover = false"
+            id="library-used-volume-div"
+          >
+            <div
+              v-if="hover"
+              class="text-sm px-1 bg-gray-700 text-gray-100 absolute rounded bg-opacity-50 shadow-xl left-0"
+              id="library-used-volume-tooltip"
+              :style="{ top: '-25px' }"
+            >
+              Used volume is {{ formLibrary.used_volume }}
+            </div>
+            <traction-badge colour="green" id="library-used-volume"
+              ><TractionInfoIcon class="mr-2" />{{ formLibrary.used_volume }}</traction-badge
+            >
+          </div>
+        </div>
+
         <traction-input
           id="library-volume"
           v-model="formLibrary.volume"
           type="number"
-          min="0"
+          :min="formLibrary.used_volume"
           step="any"
           placeholder="Example: 1.0"
         >
@@ -115,9 +137,11 @@
  * PacbioLibraryForm component can be used to create or edit a library.
  * @param {Object} library - The library to be  edited or created
  */
-import { computed, ref } from 'vue'
+import { computed, ref, watch, nextTick } from 'vue'
 import { usePacbioRootStore } from '@/stores/pacbioRoot.js'
 import useAlert from '@/composables/useAlert.js'
+import TractionBadge from '@/components/shared/TractionBadge.vue'
+import TractionInfoIcon from '@/components/shared/icons/TractionInfoIcon.vue'
 
 // useAlert is a composable function that is used to create an alert.It is used to show a success or failure message.
 const { showAlert } = useAlert()
@@ -136,7 +160,8 @@ const props = defineProps({
     },
   },
 })
-
+debugger
+const hover = ref(false)
 /*
 formLibrary is a reactive variable, so it will update when the library prop changes
 initialize formLibrary with the library prop
@@ -203,6 +228,21 @@ const provider = async () => {
     showAlert(`Failed to find tags in Traction: ${error}`, 'danger')
   }
 }
+
+/**
+ * Watches for changes in the volume property of the formLibrary object.
+ * If the new volume is less than the used_volume, it resets the volume to the used_volume.*/
+watch(
+  () => formLibrary.value.volume,
+  (newVal) => {
+    if (newVal < formLibrary.value.used_volume) {
+      nextTick(() => {
+        debugger
+        formLibrary.value.volume = formLibrary.value.used_volume
+      })
+    }
+  },
+)
 
 provider()
 /**

--- a/src/components/pacbio/PacbioLibraryForm.vue
+++ b/src/components/pacbio/PacbioLibraryForm.vue
@@ -30,20 +30,20 @@
           <traction-label class="ml-1 w-full">Volume</traction-label>
           <div
             v-if="formLibrary.used_volume"
+            id="library-used-volume-div"
             class="justify-end contents-end px-1 relative"
             @mouseover="hover = true"
             @mouseleave="hover = false"
-            id="library-used-volume-div"
           >
             <div
               v-if="hover"
-              class="text-sm px-1 bg-gray-700 text-gray-100 absolute rounded bg-opacity-50 shadow-xl left-0"
               id="library-used-volume-tooltip"
+              class="text-sm px-1 bg-gray-700 text-gray-100 absolute rounded bg-opacity-50 shadow-xl left-0"
               :style="{ top: '-25px' }"
             >
               Used volume is {{ formLibrary.used_volume }}
             </div>
-            <traction-badge colour="green" id="library-used-volume"
+            <traction-badge id="library-used-volume" colour="green"
               ><TractionInfoIcon class="mr-2" />{{ formLibrary.used_volume }}</traction-badge
             >
           </div>
@@ -160,8 +160,12 @@ const props = defineProps({
     },
   },
 })
-debugger
+
+/* A reactive reference to a boolean value indicating whether the element is being hovered over.
+  This will be used to show the used volume tooltip when the user hovers over the used volume badge.
+ */
 const hover = ref(false)
+
 /*
 formLibrary is a reactive variable, so it will update when the library prop changes
 initialize formLibrary with the library prop
@@ -237,7 +241,6 @@ watch(
   (newVal) => {
     if (newVal < formLibrary.value.used_volume) {
       nextTick(() => {
-        debugger
         formLibrary.value.volume = formLibrary.value.used_volume
       })
     }

--- a/src/components/shared/TractionBadge.vue
+++ b/src/components/shared/TractionBadge.vue
@@ -33,6 +33,7 @@ const colourClasses = {
     'sanger-dark-blue': 'bg-sdb-200 text-gray-300',
     sp: 'bg-sp-400 text-white',
     'sanger-pink': 'bg-sp-400 text-white',
+    green: 'bg-green-400 text-white',
   },
   statuses: {
     success: 'bg-success-dark text-success-light',

--- a/src/components/shared/icons/TractionInfoIcon.vue
+++ b/src/components/shared/icons/TractionInfoIcon.vue
@@ -1,0 +1,18 @@
+<template>
+  <svg xmlns="http://www.w3.org/2000/svg" :height="size" viewBox="0 -960 960 960" :width="size">
+    <path
+      fill="currentColor"
+      d="M440-280h80v-240h-80v240Zm40-320q17 0 28.5-11.5T520-640q0-17-11.5-28.5T480-680q-17 0-28.5 11.5T440-640q0 17 11.5 28.5T480-600Zm0 520q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Zm0-80q134 0 227-93t93-227q0-134-93-227t-227-93q-134 0-227 93t-93 227q0 134 93 227t227 93Zm0-320Z"
+    />
+  </svg>
+</template>
+
+<script setup>
+defineProps({
+  size: {
+    type: Number,
+    default: 16,
+    required: false,
+  },
+})
+</script>

--- a/src/views/pacbio/PacbioLibraryIndex.vue
+++ b/src/views/pacbio/PacbioLibraryIndex.vue
@@ -54,7 +54,7 @@
           </traction-button>
         </template>
         <template #row-details="row">
-          <PacbioLibraryEdit :library="row.item" @edit-completed="row.toggleDetails" />
+          <PacbioLibraryEdit :library="getEditLibrary(row)" @edit-completed="row.toggleDetails" />
         </template>
       </traction-table>
     </div>
@@ -213,5 +213,18 @@ const printLabels = async (printerName) => {
 
 const fetchLibraries = async () => {
   return await fetchWithQueryParams(librariesStore.fetchLibraries, state.filterOptions)
+}
+/**
+ * This function takes a row object and returns the corresponding library from the libraries list.
+ * The row object is expected to have an item property which in turn should have an id property.
+ * The function uses this id to find the corresponding library.
+ *
+ * @param {Object} row - The row object from which the library id is to be extracted.
+ *
+ * @returns {Object} The library object that matches the id from the row object. If no match is found, returns undefined.
+ */
+const getEditLibrary = (row) => {
+  const value = libraries.value.find((library) => library.id === row.item.id)
+  return value
 }
 </script>

--- a/tests/unit/components/pacbio/PacbioLibraryForm.spec.js
+++ b/tests/unit/components/pacbio/PacbioLibraryForm.spec.js
@@ -140,10 +140,11 @@ describe('PacbioLibraryForm.vue', () => {
         isStatic: true,
         library: {
           tag_id: '113',
-          volume: '1',
+          volume: 15,
           concentration: '1',
           template_prep_kit_box_barcode: 'barcode',
           insert_size: '1',
+          used_volume: 10,
         },
       }
       const { wrapperObj } = mountWithStore({
@@ -155,12 +156,36 @@ describe('PacbioLibraryForm.vue', () => {
     })
     it('should display a form with the correct field values', async () => {
       await flushPromises()
-      expect(wrapper.find('#library-volume').element.value).toBe('1')
+      expect(wrapper.find('#library-volume').element.value).toBe('15')
       expect(wrapper.find('#library-concentration').element.value).toBe('1')
       expect(wrapper.find('#library-templatePrepKitBoxBarcode').element.value).toBe('barcode')
       expect(wrapper.find('#library-insertSize').element.value).toBe('1')
       expect(wrapper.find('#tag-set-input').element.value).toBe('3')
+      expect(wrapper.find('#library-used-volume').element).exist.toBeTruthy()
+      expect(wrapper.find('#library-used-volume').text()).toContain('10')
       expect(modal.selectedTagSetId).toBe('3')
+    })
+    it('shows and hides tooltip while hovering over used volume', async () => {
+      wrapper.find('#library-used-volume-div').trigger('mouseover')
+      await nextTick()
+      expect(wrapper.find('#library-used-volume-tooltip').element).toBeTruthy()
+      wrapper.find('#library-used-volume-div').trigger('mouseleave')
+      await nextTick()
+      expect(wrapper.find('#library-used-volume-tooltip').exists()).toBe(false)
+    })
+    it('resets volume to used_volume when entered volume is less than used_volume', async () => {
+      const input = wrapper.find('#library-volume')
+      await input.setValue('5')
+      await nextTick()
+      expect(wrapper.vm.formLibrary.volume).toBe(wrapper.vm.formLibrary.used_volume)
+      expect(wrapper.find('#library-volume').element.value).toBe('10')
+    })
+    it('sets volume to new value when entered volume is greater than used_volume', async () => {
+      const input = wrapper.find('#library-volume')
+      await input.setValue(25)
+      await nextTick()
+      expect(wrapper.vm.formLibrary.volume).toBe('25')
+      expect(wrapper.find('#library-volume').element.value).toBe('25')
     })
   })
 })


### PR DESCRIPTION
This PR includes
- Displaying a "used volume" label when the user edits a library.
- Preventing the user from entering a value for the library volume less than the used volume.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
