### PR TITLE
 Github token access using Github App 

### DIFF
--- a/.github/workflows/add_to_project.yml
+++ b/.github/workflows/add_to_project.yml
@@ -6,12 +6,21 @@ on:
       - labeled
 
 jobs:
-  add-to-project:
-    name: Add pull request to project
+ add-to-project:
+    name: Add pull request to project using github app
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v0.5.0
+      - name: Get Token
+        id: get_workflow_token
+        uses: peter-murray/workflow-application-token-action@v3
         with:
-          project-url: https://github.com/orgs/sanger/projects/12
-          github-token: ${{ secrets.ADD_TO_PROJECT_PAT_ORG_WIDE }}
+          application_id: ${{ vars.ADD_TO_PROJECT_APP_ID_PSD }}
+          application_private_key: ${{ secrets.ADD_TO_PROJECT_APP_KEY_PSD }}
+
+      - name: Use Application Token to add to project
+        uses: actions/add-to-project@v0.5.0
+        with:
+          project-url: https://github.com/orgs/sanger/projects/13
+          github-token: ${{ steps.get_workflow_token.outputs.token }}
           labeled: depfu
+  

--- a/.github/workflows/add_to_project_copy.yml
+++ b/.github/workflows/add_to_project_copy.yml
@@ -1,0 +1,12 @@
+name: Add dependencies to technical debt project
+
+on:
+  pull_request:
+    types:
+      - labeled
+
+jobs:
+ call-add-to-project:
+    uses: ./.github/workflows/test.yml
+    
+  


### PR DESCRIPTION
The add_to_project.yml file has been updated to use the Github token generated from the Github App (PSD-AddToProject) instead of a Personal Access Token (PAT).

