### PR TITLE
Y24-004 - Added confirmation modal for PacBio library deletion

### DIFF
--- a/src/views/pacbio/PacbioLibraryIndex.vue
+++ b/src/views/pacbio/PacbioLibraryIndex.vue
@@ -28,10 +28,7 @@
             <p class="mb-4">Are you sure you want to delete the selected libraries?</p>
             <div class="flex justify-center space-x-4">
               <button
-                @click="
-                  handleLibraryDelete(),
-                  showConfirmationModal = false
-                "
+                @click="handleLibraryDelete(), (showConfirmationModal = false)"
                 class="px-4 py-2 bg-red-500 text-white rounded hover:bg-red-600"
               >
                 Yes

--- a/src/views/pacbio/PacbioLibraryIndex.vue
+++ b/src/views/pacbio/PacbioLibraryIndex.vue
@@ -28,14 +28,14 @@
             <p class="mb-4">Are you sure you want to delete the selected libraries?</p>
             <div class="flex justify-center space-x-4">
               <button
-                @click="handleLibraryDelete(), (showConfirmationModal = false)"
                 class="px-4 py-2 bg-red-500 text-white rounded hover:bg-red-600"
+                @click="handleLibraryDelete(), (showConfirmationModal = false)"
               >
                 Yes
               </button>
               <button
-                @click="showConfirmationModal = false"
                 class="px-4 py-2 bg-gray-200 text-gray-700 rounded hover:bg-gray-300"
+                @click="showConfirmationModal = false"
               >
                 No
               </button>

--- a/src/views/pacbio/PacbioLibraryIndex.vue
+++ b/src/views/pacbio/PacbioLibraryIndex.vue
@@ -3,15 +3,6 @@
     <FilterCard :fetcher="fetchLibraries" :filter-options="state.filterOptions" />
     <div class="flex flex-col">
       <div class="clearfix">
-        <traction-button
-          id="deleteLibraries"
-          theme="delete"
-          class="float-left"
-          :disabled="state.selected.length === 0"
-          @click="handleLibraryDelete"
-        >
-          Delete Libraries
-        </traction-button>
         <printerModal
           ref="printerModal"
           class="float-left"
@@ -19,7 +10,41 @@
           @select-printer="printLabels($event)"
         >
         </printerModal>
-
+        <traction-button
+          id="deleteLibraries"
+          theme="delete"
+          class="float-left"
+          :disabled="state.selected.length === 0"
+          @click="showConfirmationModal = true"
+        >
+          Delete Libraries
+        </traction-button>
+        <!-- Confirmation Modal -->
+        <div
+          v-if="showConfirmationModal"
+          class="fixed top-0 left-0 w-full h-full flex items-center justify-center bg-black bg-opacity-50"
+        >
+          <div class="bg-white p-6 rounded shadow-lg">
+            <p class="mb-4">Are you sure you want to delete the selected libraries?</p>
+            <div class="flex justify-center space-x-4">
+              <button
+                @click="
+                  handleLibraryDelete(),
+                  showConfirmationModal = false
+                "
+                class="px-4 py-2 bg-red-500 text-white rounded hover:bg-red-600"
+              >
+                Yes
+              </button>
+              <button
+                @click="showConfirmationModal = false"
+                class="px-4 py-2 bg-gray-200 text-gray-700 rounded hover:bg-gray-300"
+              >
+                No
+              </button>
+            </div>
+          </div>
+        </div>
         <traction-pagination class="float-right" aria-controls="library-index" />
       </div>
 
@@ -165,6 +190,8 @@ const store = useStore()
 
 //computed
 const libraries = computed(() => librariesStore.librariesArray)
+
+const showConfirmationModal = ref(false)
 
 //methods
 const handleLibraryDelete = async () => {


### PR DESCRIPTION
Closes #1561 

#### Changes proposed in this pull request

- A confirmation is now shown when attempting to delete PacBio libraries.
- The delete button is now placed last to ensure it isn't accidentally clicked (I don't think it needs to be moved entirely)

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
