### PR TITLE
Updates for UAT feedback 

### DIFF
--- a/src/components/labware/PacbioTubeWell.vue
+++ b/src/components/labware/PacbioTubeWell.vue
@@ -37,7 +37,7 @@ const wellClassNames = computed(() => {
   return [
     getRequest.value ? 'bg-green-600' : 'bg-gray-500',
     getRequest.value.selected
-      ? 'border-2 border-solid border-yellow-400'
+      ? 'border-4 border-solid border-yellow-400'
       : 'border-1 border-solid border-gray-500',
     'flex flex-col md:w-32 justify-center mx-auto rounded-full text-xs font-semibold aspect-square select-none ',
   ]

--- a/src/components/pacbio/PacbioLabwareSelectedList.vue
+++ b/src/components/pacbio/PacbioLabwareSelectedList.vue
@@ -26,7 +26,7 @@
             <div
               :class="[
                 'bg-blue-100 rounded-lg p-1 mr-3 mt-2',
-                `${item.barcode === props.highlight?.labware.barcode ? 'border-2 border-purple-500' : 'border border-sdb '}`,
+                `${item.barcode === props.highlight?.labware.barcode ? 'border-4 border-purple-500' : 'border border-sdb '}`,
               ]"
             >
               <div class="flex w-full justify-end">
@@ -228,7 +228,7 @@ const onClose = (labware) => {
  */
 const tableRowColour = (row) => {
   return `${row.selected ? 'bg-yellow-300' : 'bg-gray-200'} ${
-    row.id === props.highlight?.request.id && 'border-2 border-purple-500'
+    row.id === props.highlight?.request.id && 'border-4 border-purple-500'
   } cursor-pointer`
 }
 

--- a/src/components/pacbio/PacbioPoolAliquotEdit.vue
+++ b/src/components/pacbio/PacbioPoolAliquotEdit.vue
@@ -1,7 +1,7 @@
 <template>
   <traction-table-row
     data-type="pool-aliquot-edit"
-    :class="['cursor-pointer', `${props.selected && 'border-2 border-purple-500'}`]"
+    :class="['cursor-pointer', `${props.selected && 'border-4 border-purple-500'}`]"
     @click="onTableRowClick"
   >
     <traction-table-column data-attribute="request-sample-name">

--- a/tests/e2e/specs/pacbio/pacbio_pool_edit.cy.js
+++ b/tests/e2e/specs/pacbio/pacbio_pool_edit.cy.js
@@ -48,7 +48,7 @@ describe('Pacbio Pool Edit', () => {
     cy.get('[data-type="pool-aliquot-edit"]')
       .first()
       .invoke('attr', 'class')
-      .should('contain', 'border-2 border-purple-500')
+      .should('contain', 'border-4 border-purple-500')
 
     //Deselect row requests
     cy.get('[data-attribute^="request-checkbox"]').eq(1).click()

--- a/tests/unit/components/labware/PacbioTubeWell.spec.js
+++ b/tests/unit/components/labware/PacbioTubeWell.spec.js
@@ -82,7 +82,7 @@ describe('PacbioTubeWell', () => {
     })
     it('should display the well color and well border as seleced', () => {
       const classes = wrapper.find('[data-attribute="traction-well"]').classes()
-      const expectedClasses = ['bg-green-600', 'border-solid', 'border-yellow-400', 'border-2']
+      const expectedClasses = ['bg-green-600', 'border-solid', 'border-yellow-400', 'border-4']
       expect(expectedClasses.every((expectedClass) => classes.includes(expectedClass))).toBe(true)
     })
   })

--- a/tests/unit/components/pacbio/PacbioPoolAliquotEdit.spec.js
+++ b/tests/unit/components/pacbio/PacbioPoolAliquotEdit.spec.js
@@ -221,7 +221,7 @@ describe('PacbioPoolAliquotEdit.vue', () => {
         props: { ...props, selected: true },
       })
       expect(wrapperObj.classes()).toContain('cursor-pointer')
-      expect(wrapperObj.classes()).toContain('border-2')
+      expect(wrapperObj.classes()).toContain('border-4')
       expect(wrapperObj.classes()).toContain('border-purple-500')
     })
 


### PR DESCRIPTION
Following the comment posted by James (_can the yellow border on the select sample 1b. section around the green circle be increased? Currently, it looks like .border-2 is 2px, something like 5px might be more noticeable as feedback is it is difficult to see (as long as the increase doesn't impact anything else_) , border width changed for labware and sample selection 