### PR TITLE
DPL-683 - Added page origin + timestamp to traction alerts

### DIFF
--- a/src/components/TractionMessage.vue
+++ b/src/components/TractionMessage.vue
@@ -17,10 +17,10 @@
   >
     <div class="w-full">
       {{ message }}
-      <div class="text-xs text-gray-500 flex justify-between items-center">
-        <span class="mr-1">{{ page }}</span>
-        <span>&#9679;</span>
-        <span class="ml-1">{{ time }}</span>
+      <div class="text-xs text-gray-500 flex items-left">
+      <span>{{ page }}</span>
+      <span style="margin: 0 6px;"> - </span>
+      <span>{{ time }}</span>
       </div>
     </div>
     <div class="flex justify-end">

--- a/src/components/TractionMessage.vue
+++ b/src/components/TractionMessage.vue
@@ -18,7 +18,7 @@
     <div class="w-full">
       {{ message }}
       <div class="text-xs text-gray-500 flex items-left">
-      <span>{{ page }}</span>
+      <span>{{ origin }}</span>
       <span style="margin: 0 6px;"> - </span>
       <span>{{ time }}</span>
       </div>
@@ -67,13 +67,15 @@ export default {
       type: String,
       required: true,
     },
-    page: {
+    origin: {
       type: String,
       required: false,
+      default: 'Unknown Origin',
     },
     time: {
       type: String,
       required: false,
+      default: new Date().toLocaleTimeString(),
     },
   },
   emits: ['dismissed'],

--- a/src/components/TractionMessage.vue
+++ b/src/components/TractionMessage.vue
@@ -10,19 +10,21 @@
     data-attribute="message"
     :data-type="dataType"
     :class="[
-      'flex flex-row rounded rounded-md px-5 py-1 space-x-4 mb-2', // padding
+      'flex flex-col rounded rounded-md px-4 py-3 space-x-4 mb-2', // padding
       `text-base leading-0`, // text style
       `${color.message}`, // font color, background color
     ]"
   >
-    <div class="inline-block flex-grow">
-      <div>{{ message }}</div>
-      <div class="text-xs text-gray-500">{{ origin }} - {{ time }}</div>
-    </div>
     <div class="flex justify-end items-center">
-      <button data-attribute="close" @click="dismiss">
+      <button data-attribute="dismiss" @click="dismiss">
         <traction-close-icon :class-names="`${color.icon}`" />
       </button>
+    </div>
+    <div class="inline-block flex-grow text-end" style="margin-bottom: 3px">
+      {{ message }}
+      <div class="text-xs text-gray-500 text-end border-t-2 border-gray-300">
+        {{ origin }} - {{ time }}
+      </div>
     </div>
   </div>
 </template>

--- a/src/components/TractionMessage.vue
+++ b/src/components/TractionMessage.vue
@@ -5,7 +5,7 @@
    * 
    */
    -->
-<template>
+  <template>
   <div
     data-attribute="message"
     :data-type="dataType"
@@ -15,18 +15,18 @@
       `${color.message}`, // font color, background color
     ]"
   >
-    <div class="inline-block">
+    <div class="inline-block flex-grow">
       <div>{{ message }}</div>
       <div class="text-xs text-gray-500">{{ origin }} - {{ time }}</div>
     </div>
-    <div class="flex justify-end">
+    <div class="flex justify-end items-center">
       <button data-attribute="close" @click="dismiss">
         <traction-close-icon :class-names="`${color.icon}`" />
       </button>
     </div>
   </div>
 </template>
-
+  
 <script>
 const colorStyles = {
   success: {

--- a/src/components/TractionMessage.vue
+++ b/src/components/TractionMessage.vue
@@ -5,7 +5,7 @@
    * 
    */
    -->
-  <template>
+<template>
   <div
     data-attribute="message"
     :data-type="dataType"
@@ -26,7 +26,7 @@
     </div>
   </div>
 </template>
-  
+
 <script>
 const colorStyles = {
   success: {

--- a/src/components/TractionMessage.vue
+++ b/src/components/TractionMessage.vue
@@ -17,6 +17,11 @@
   >
     <div class="w-full">
       {{ message }}
+      <div class="text-xs text-gray-500 flex justify-between items-center">
+        <span class="mr-1">{{ page }}</span>
+        <span>&#9679;</span>
+        <span class="ml-1">{{ time }}</span>
+      </div>
     </div>
     <div class="flex justify-end">
       <button data-attribute="close" @click="dismiss">
@@ -61,6 +66,14 @@ export default {
     message: {
       type: String,
       required: true,
+    },
+    page: {
+      type: String,
+      required: false,
+    },
+    time: {
+      type: String,
+      required: false,
     },
   },
   emits: ['dismissed'],

--- a/src/components/TractionMessage.vue
+++ b/src/components/TractionMessage.vue
@@ -23,7 +23,7 @@
     <div class="inline-block flex-grow text-end mb-[3px]">
       {{ message }}
       <div class="text-xs text-gray-500 text-end border-t-2 border-gray-300">
-        {{ origin }} - {{ time }}
+        {{ origin }}{{ time }}
       </div>
     </div>
   </div>
@@ -68,7 +68,7 @@ export default {
     origin: {
       type: String,
       required: false,
-      default: 'Unknown Origin',
+      default: '',
     },
     time: {
       type: String,

--- a/src/components/TractionMessage.vue
+++ b/src/components/TractionMessage.vue
@@ -20,7 +20,7 @@
         <traction-close-icon :class-names="`${color.icon}`" />
       </button>
     </div>
-    <div class="inline-block flex-grow text-end" style="margin-bottom: 3px">
+    <div class="inline-block flex-grow text-end mb-[3px]">
       {{ message }}
       <div class="text-xs text-gray-500 text-end border-t-2 border-gray-300">
         {{ origin }} - {{ time }}

--- a/src/components/TractionMessage.vue
+++ b/src/components/TractionMessage.vue
@@ -10,18 +10,14 @@
     data-attribute="message"
     :data-type="dataType"
     :class="[
-      'flex flex-row rounded rounded-md px-5 py-3 space-x-4 mb-4', // padding
-      `text-base leading-6`, // text style
+      'flex flex-row rounded rounded-md px-5 py-1 space-x-4 mb-1', // padding
+      `text-base leading-0`, // text style
       `${color.message}`, // font color, background color
     ]"
   >
-    <div class="w-full">
-      {{ message }}
-      <div class="text-xs text-gray-500 flex items-left">
-      <span>{{ origin }}</span>
-      <span style="margin: 0 6px;"> - </span>
-      <span>{{ time }}</span>
-      </div>
+    <div class="inline-block">
+      <div>{{ message }}</div>
+      <div class="text-xs text-gray-500">{{ origin }} - {{ time }}</div>
     </div>
     <div class="flex justify-end">
       <button data-attribute="close" @click="dismiss">

--- a/src/components/TractionMessage.vue
+++ b/src/components/TractionMessage.vue
@@ -10,7 +10,7 @@
     data-attribute="message"
     :data-type="dataType"
     :class="[
-      'flex flex-row rounded rounded-md px-5 py-1 space-x-4 mb-1', // padding
+      'flex flex-row rounded rounded-md px-5 py-1 space-x-4 mb-2', // padding
       `text-base leading-0`, // text style
       `${color.message}`, // font color, background color
     ]"

--- a/src/composables/useAlert.js
+++ b/src/composables/useAlert.js
@@ -15,7 +15,7 @@ export default function useAlert() {
     const page = route.name
     const time = new Date().toLocaleString()
 
-    // Commit the mutation to the Vuex store
+    // Commit the mutation  to the Vuex store
     store.commit('traction/addMessage', { type, message, dataType, page, time })
   }
 

--- a/src/composables/useAlert.js
+++ b/src/composables/useAlert.js
@@ -12,7 +12,7 @@ export default function useAlert() {
   const route = useRoute()
 
   const showAlert = (message, type, dataType) => {
-    const origin = route?.name || 'Unknown Origin'
+    const origin = route?.name + " - " || ''
     const time = new Date().toLocaleTimeString()
 
     // Commit the mutation  to the Vuex store

--- a/src/composables/useAlert.js
+++ b/src/composables/useAlert.js
@@ -12,7 +12,7 @@ export default function useAlert() {
   const route = useRoute()
 
   const showAlert = (message, type, dataType) => {
-    const origin = route?.name + " - " || ''
+    const origin = route?.name + ' - ' || ''
     const time = new Date().toLocaleTimeString()
 
     // Commit the mutation  to the Vuex store

--- a/src/composables/useAlert.js
+++ b/src/composables/useAlert.js
@@ -1,4 +1,6 @@
 import store from '@/store'
+import { useRoute } from 'vue-router'
+
 /**
  * A composable function to commit a mutation to the Vuex store.
  * @returns {Function} .showAlert A method that shows an alert. It commits a mutation to the Vuex store.
@@ -7,10 +9,16 @@ import store from '@/store'
  * @param {string} dataType - The data type of the alert.
  */
 export default function useAlert() {
+  const route = useRoute()
+
   const showAlert = (message, type, dataType) => {
-    //TODO: This need to be refactored to use the Pinia root store once we have converted all components to use useAlert
-    store.commit('traction/addMessage', { type, message, dataType })
+    const page = route.name
+    const time = new Date().toLocaleString()
+
+    // Commit the mutation to the Vuex store
+    store.commit('traction/addMessage', { type, message, dataType, page, time })
   }
+
   // Return the showAlert method
   return {
     showAlert,

--- a/src/composables/useAlert.js
+++ b/src/composables/useAlert.js
@@ -12,11 +12,11 @@ export default function useAlert() {
   const route = useRoute()
 
   const showAlert = (message, type, dataType) => {
-    const page = route.name
+    const origin = route?.name || 'Unknown Origin'
     const time = new Date().toLocaleString()
 
     // Commit the mutation  to the Vuex store
-    store.commit('traction/addMessage', { type, message, dataType, page, time })
+    store.commit('traction/addMessage', { type, message, dataType, origin, time })
   }
 
   // Return the showAlert method

--- a/src/composables/useAlert.js
+++ b/src/composables/useAlert.js
@@ -13,7 +13,7 @@ export default function useAlert() {
 
   const showAlert = (message, type, dataType) => {
     const origin = route?.name || 'Unknown Origin'
-    const time = new Date().toLocaleString()
+    const time = new Date().toLocaleTimeString()
 
     // Commit the mutation  to the Vuex store
     store.commit('traction/addMessage', { type, message, dataType, origin, time })

--- a/tests/e2e/specs/pacbio/pacbio_run_create.cy.js
+++ b/tests/e2e/specs/pacbio/pacbio_run_create.cy.js
@@ -114,7 +114,7 @@ describe('Pacbio Run Create view', () => {
     cy.get('[data-attribute="message"]').within(() => {
       cy.get('[data-attribute="dismiss"]').click()
     })
-    
+
     // Add the plate metadata
     cy.get('[data-attribute="sequencing-kit-box-barcode-2"]').type('Lxxxxx101826100123199')
     // Get the pool being searched

--- a/tests/e2e/specs/pacbio/pacbio_run_create.cy.js
+++ b/tests/e2e/specs/pacbio/pacbio_run_create.cy.js
@@ -111,6 +111,10 @@ describe('Pacbio Run Create view', () => {
     cy.get('[data-attribute="library-concentration"]').type('0.75')
     cy.get('#update').click()
 
+    cy.get('[data-attribute="message"]').within(() => {
+      cy.get('[data-attribute="dismiss"]').click()
+    })
+    
     // Add the plate metadata
     cy.get('[data-attribute="sequencing-kit-box-barcode-2"]').type('Lxxxxx101826100123199')
     // Get the pool being searched
@@ -131,6 +135,7 @@ describe('Pacbio Run Create view', () => {
     cy.get('[data-attribute="include-base-kinetics"]').select('True')
     cy.get('[data-attribute="polymerase-kit"]').type('12345')
     cy.get('[data-attribute="library-concentration"]').type('0.75')
+
     cy.get('#update').click()
 
     cy.get('button').contains('Create').click()
@@ -171,6 +176,10 @@ describe('Pacbio Run Create view', () => {
     cy.get('[data-attribute="polymerase-kit"]').type('12345')
     cy.get('[data-attribute="library-concentration"]').type('0.75')
     cy.get('#update').click()
+
+    cy.get('[data-attribute="message"]').within(() => {
+      cy.get('[data-attribute="dismiss"]').click()
+    })
 
     // Add the plate metadata
     cy.get('[data-attribute="sequencing-kit-box-barcode-2"]').type('Lxxxxx101826100123199')

--- a/tests/unit/composables/useAlert.spec.js
+++ b/tests/unit/composables/useAlert.spec.js
@@ -18,7 +18,7 @@ describe('#useAlert', () => {
       type: 'success',
       message: 'show this message',
       dataType: undefined,
-      origin: 'Unknown Origin',
+      origin: 'undefined - ',
       time: expect.any(String),
     })
   })

--- a/tests/unit/composables/useAlert.spec.js
+++ b/tests/unit/composables/useAlert.spec.js
@@ -18,6 +18,8 @@ describe('#useAlert', () => {
       type: 'success',
       message: 'show this message',
       dataType: undefined,
+      origin: 'Unknown Origin',
+      time: expect.any(String),
     })
   })
 })


### PR DESCRIPTION
Closes #1082 

#### Changes proposed in this pull request

- A footer with the page origin and timestamp for traction alerts

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
