### PR TITLE
Y24-115 - Add a reusable workflow to automate the generation of issue title numbers

### DIFF
--- a/.github/workflows/assign_issue_number.yml
+++ b/.github/workflows/assign_issue_number.yml
@@ -1,0 +1,12 @@
+name: Assign Issue Number
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  call-add-to-project:
+    uses: sanger/.github/.github/workflows/generate_issue_number.yml@master
+    secrets:
+      app_id: ${{ secrets.ISSUE_GEN_APP_ID }}
+      app_key: ${{ secrets.ISSUE_GEN_APP_KEY }}


### PR DESCRIPTION
Closes https://github.com/sanger/General-Backlog-Items/issues/406

#### Changes proposed in this pull request

- A new workflow that will run when an issue is opened which will increment an organisation variable that tracks the number of issues across the organisation.
- The incremented value will be used to prefix the issue title when an issue number, e.g: Y24-056, Y24-1042.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_ 