### PR TITLE
refactor: Update API to create v1 and v2 and move existing to imports to use v1 requests.

### DIFF
--- a/src/api/v2/ApiBuilder.js
+++ b/src/api/v2/ApiBuilder.js
@@ -1,4 +1,4 @@
-import createRequest from '@/api/v1/createRequest.js'
+import createRequest from '@/api/v2/createRequest.js'
 
 /*
   This will construct the api based on any config that has been passed

--- a/src/components/qcResultsUpload/QcResultsUploadForm.vue
+++ b/src/components/qcResultsUpload/QcResultsUploadForm.vue
@@ -75,7 +75,7 @@ export default {
   },
   computed: {
     api() {
-      return this.$store.getters.api
+      return this.$store.getters.api.v1
     },
     qcResultUploadsRequest: ({ api }) => api.traction.qc_results_uploads.create,
     border() {

--- a/src/components/saphyr/SaphyrEnzymeModal.vue
+++ b/src/components/saphyr/SaphyrEnzymeModal.vue
@@ -42,7 +42,7 @@ export default {
   },
   computed: {
     api() {
-      return this.$store.getters.api
+      return this.$store.getters.api.v1
     },
     enzymeRequest() {
       return this.api.traction.saphyr.enzymes

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -60,14 +60,18 @@
 
 import { createStore } from 'vuex'
 import config from '@/api/Config'
-import build from '@/api/v1/ApiBuilder'
+import buildV1 from '@/api/v1/ApiBuilder'
+import buildV2 from '@/api/v2/ApiBuilder'
 import traction from '@/store/traction'
 import PlateMap from '@/config/PlateMap'
 import printMyBarcode from '@/store/printMyBarcode'
 
 const store = createStore({
   state: {
-    api: build({ config }),
+    api: {
+      v1: buildV1({ config }),
+      v2: buildV2({ config }),
+    },
     plateMap: PlateMap,
   },
   mutations: {},

--- a/src/store/printMyBarcode/actions.js
+++ b/src/store/printMyBarcode/actions.js
@@ -20,7 +20,7 @@ const createPrintJob = async (
   { printerName, labels, copies },
 ) => {
   // extract the request from the rootState
-  const request = rootState.api.printMyBarcode.print_jobs
+  const request = rootState.api.v1.printMyBarcode.print_jobs
 
   const payload = {
     printer_name: printerName,

--- a/src/store/printMyBarcode/getters.js
+++ b/src/store/printMyBarcode/getters.js
@@ -1,5 +1,5 @@
 const getters = {
-  printJobRequest: (state, getters, rootState) => rootState.api.printMyBarcode.print_jobs,
+  printJobRequest: (state, getters, rootState) => rootState.api.v1.printMyBarcode.print_jobs,
   tubeLabelTemplateName: (state) => state.tubeLabelTemplateName,
 }
 export default getters

--- a/src/store/traction/getters.js
+++ b/src/store/traction/getters.js
@@ -1,5 +1,5 @@
 const getters = {
-  tagsRequest: (state, getters, rootState) => rootState.api.traction.tags,
+  tagsRequest: (state, getters, rootState) => rootState.api.v1.traction.tags,
   tractionTags: (state) => state.tractionTags,
   messages: (state) => state.messages,
 }

--- a/src/store/traction/ont/actions.js
+++ b/src/store/traction/ont/actions.js
@@ -9,7 +9,7 @@ export default {
    * @param commit the vuex commit object. Provides access to mutations
    */
   fetchOntRuns: async ({ commit, rootState }, filter, page) => {
-    const request = rootState.api.traction.ont.runs
+    const request = rootState.api.v1.traction.ont.runs
     const promise = request.get({ page, filter, include: 'instrument' })
 
     const response = await handleResponse(promise)
@@ -25,7 +25,7 @@ export default {
     return { success, errors, meta }
   },
   setInstruments: async ({ commit, rootState }) => {
-    const request = rootState.api.traction.ont.instruments
+    const request = rootState.api.v1.traction.ont.instruments
     const promise = request.get()
     const response = await handleResponse(promise)
     const { success, data: { data } = {}, errors = [] } = response

--- a/src/store/traction/ont/pools/actions.js
+++ b/src/store/traction/ont/pools/actions.js
@@ -151,7 +151,7 @@ export default {
       return { success: true, errors: [] }
     }
 
-    const request = rootState.api.traction.ont.pools
+    const request = rootState.api.v1.traction.ont.pools
     const promise = request.find({
       id: id,
       include:
@@ -204,7 +204,7 @@ export default {
       }
     }
 
-    const request = rootState.api.traction.ont.plates
+    const request = rootState.api.v1.traction.ont.plates
     const promise = request.get({ filter: filter, include: 'wells.requests' })
     const response = await handleResponse(promise)
     let { success, data: { data, included = [] } = {}, errors = [] } = response
@@ -244,7 +244,7 @@ export default {
       }
     }
 
-    const request = rootState.api.traction.ont.tubes
+    const request = rootState.api.v1.traction.ont.tubes
     const promise = request.get({ filter: filter, include: 'requests' })
     const response = await handleResponse(promise)
     let { success, data: { data, included = [] } = {}, errors = [] } = response
@@ -290,7 +290,7 @@ export default {
    * @param commit the vuex commit object. Provides access to mutations
    */
   fetchOntRequests: async ({ commit, rootState }, filter, page) => {
-    const request = rootState.api.traction.ont.requests
+    const request = rootState.api.v1.traction.ont.requests
     const promise = request.get({ page, filter })
     const response = await handleResponse(promise)
 
@@ -317,7 +317,7 @@ export default {
       }
     }
 
-    const request = rootState.api.traction.ont.pools
+    const request = rootState.api.v1.traction.ont.pools
     const promise = request.get({ filter: { barcode } })
     const response = await handleResponse(promise)
     let { success, data: { data } = {} } = response
@@ -336,7 +336,7 @@ export default {
    * @param commit the vuex commit object. Provides access to mutations
    */
   fetchOntPools: async ({ commit, rootState }, filter, page) => {
-    const request = rootState.api.traction.ont.pools
+    const request = rootState.api.v1.traction.ont.pools
     const promise = request.get({
       page,
       filter,
@@ -367,7 +367,7 @@ export default {
   // For the component, the included relationships are not required
   // However, the functionality does not appear to work without them
   populateOntPools: async ({ commit, rootState }, filter) => {
-    const request = rootState.api.traction.ont.pools
+    const request = rootState.api.v1.traction.ont.pools
     const promise = request.get({
       filter: filter,
       include: 'tube,libraries.tag,libraries.request',
@@ -394,7 +394,7 @@ export default {
    * @param commit the vuex commit object. Provides access to mutations
    */
   fetchOntTagSets: async ({ commit, rootState }) => {
-    const request = rootState.api.traction.ont.tag_sets
+    const request = rootState.api.v1.traction.ont.tag_sets
     const promise = request.get({ include: 'tags' })
     const response = await handleResponse(promise)
 
@@ -420,7 +420,7 @@ export default {
   }) => {
     validate({ libraries })
     if (!valid({ libraries })) return { success: false, errors: 'The pool is invalid' }
-    const request = rootState.api.traction.ont.pools
+    const request = rootState.api.v1.traction.ont.pools
     const promise = request.create({ data: payload({ libraries, pool }), include: 'tube' })
     const { success, data: { included = [] } = {}, errors } = await handleResponse(promise)
     const { tubes: [tube = {}] = [] } = groupIncludedByResource(included)
@@ -439,7 +439,7 @@ export default {
   }) => {
     validate({ libraries })
     if (!valid({ libraries })) return { success: false, errors: 'The pool is invalid' }
-    const request = rootState.api.traction.ont.pools
+    const request = rootState.api.v1.traction.ont.pools
     const promise = request.update(payload({ libraries, pool }))
     const { success, errors } = await handleResponse(promise)
     return { success, errors }

--- a/src/store/traction/pacbio/plates/getters.js
+++ b/src/store/traction/pacbio/plates/getters.js
@@ -1,5 +1,5 @@
 const getters = {
-  getPlates: (state, getters, rootState) => rootState.api.traction.pacbio.plates,
+  getPlates: (state, getters, rootState) => rootState.api.v1.traction.pacbio.plates,
   plates: (state) => Object.values(state.plates),
 }
 

--- a/src/store/traction/pacbio/requests/getters.js
+++ b/src/store/traction/pacbio/requests/getters.js
@@ -1,6 +1,6 @@
 const getters = {
   requests: (state) => Object.values(state.requests),
-  requestsRequest: (state, getters, rootState) => rootState.api.traction.pacbio.requests,
+  requestsRequest: (state, getters, rootState) => rootState.api.v1.traction.pacbio.requests,
 }
 
 export default getters

--- a/src/store/traction/saphyr/requests/getters.js
+++ b/src/store/traction/saphyr/requests/getters.js
@@ -1,6 +1,6 @@
 const getters = {
   requests: (state) => state.requests,
-  requestsRequest: (state, getters, rootState) => rootState.api.traction.saphyr.requests,
+  requestsRequest: (state, getters, rootState) => rootState.api.v1.traction.saphyr.requests,
 }
 
 export default getters

--- a/src/store/traction/saphyr/runs/getters.js
+++ b/src/store/traction/saphyr/runs/getters.js
@@ -1,11 +1,11 @@
 const getters = {
   runs: (state) => state.runs,
-  runRequest: (state, getters, rootState) => rootState.api.traction.saphyr.runs,
+  runRequest: (state, getters, rootState) => rootState.api.v1.traction.saphyr.runs,
   run: (state) => (id) => {
     return state.runs.find((run) => run.id == id)
   },
   currentRun: (state) => state.currentRun,
-  saphyrRequests: (state, getters, rootState) => rootState.api.traction.saphyr,
+  saphyrRequests: (state, getters, rootState) => rootState.api.v1.traction.saphyr,
 }
 
 export default getters

--- a/src/store/traction/saphyr/tubes/getters.js
+++ b/src/store/traction/saphyr/tubes/getters.js
@@ -1,10 +1,10 @@
 const getters = {
   tractionTubes: (state) => state.tractionTubes,
-  tubeRequest: (state, getters, rootState) => rootState.api.traction.saphyr.tubes,
-  requestsRequest: (state, getters, rootState) => rootState.api.traction.saphyr.requests,
+  tubeRequest: (state, getters, rootState) => rootState.api.v1.traction.saphyr.tubes,
+  requestsRequest: (state, getters, rootState) => rootState.api.v1.traction.saphyr.requests,
   tractionTubesWithInfo: (state) =>
     state.tractionTubes.map((i) => Object.assign(i.material, { barcode: i.barcode })),
-  libraryRequest: (state, getters, rootState) => rootState.api.traction.saphyr.libraries,
+  libraryRequest: (state, getters, rootState) => rootState.api.v1.traction.saphyr.libraries,
   libraries: (state) => state.libraries,
 }
 

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -1,58 +1,23 @@
 import config from '@/api/Config.js'
-import build from '@/api/v1/ApiBuilder.js'
+import buildV1 from '@/api/v1/ApiBuilder.js'
+import buildV2 from '@/api/v2/ApiBuilder.js'
 import PlateMap from '@/config/PlateMap.json'
 import { defineStore } from 'pinia'
 import { handleResponse } from '@/api/v1/ResponseHelper.js'
 import { dataToObjectById } from '@/api/JsonApi.js'
 import store from '@/store'
-import { createRequest } from '@/api/v2/createRequest.js'
 
 export const errorFor = ({ lines, records }, message) =>
   `Library ${records} on line ${lines}: ${message}`
 
-/**
- *
- * @param {*} api
- * @returns {Object} api
- * Currently, we are using fetch for traction printing and printMyBarcode.
- * We are using axios for everything else.
- * When the api is created we create requests up front as axios request.
- * We need to create requests for traction and printMyBarcode as fetch requests.
- * This function merges the traction and printMyBarcode apis with the rest of the api.
- * TODO: We need to v1 and v2 the api in the config so we can slowly move from axios.
- */
-const mergeApis = (api) => {
-  // Destructure the api object to get the traction object
-  const { traction } = api
-  // Create the printMyBarcode object as a fetch request
-  const printMyBarcode = {
-    print_jobs: createRequest({
-      rootURL: import.meta.env['VITE_PRINTMYBARCODE_BASE_URL'],
-      apiNamespace: 'v2',
-      resource: 'print_jobs',
-    }),
-  }
-  // Create the printers object as a fetch request
-  const printers = createRequest({
-    rootURL: import.meta.env['VITE_TRACTION_BASE_URL'],
-    apiNamespace: 'v1',
-    resource: 'printers',
-  })
-  // merge the api object with the traction object and the printMyBarcode object
-  return {
-    ...api,
-    traction: {
-      ...traction,
-      printers,
-    },
-    printMyBarcode,
-  }
-}
-
 const useRootStore = defineStore('root', {
   state: () => ({
     //Build an API instance using the config
-    api: mergeApis(build({ config })),
+    // api: mergeApis(build({ config })),
+    api: {
+      v1: buildV1({ config }),
+      v2: buildV2({ config }),
+    },
 
     //Get plateMap state from the PlateMap.json file
     plateMap: PlateMap,

--- a/src/stores/ontRoot.js
+++ b/src/stores/ontRoot.js
@@ -69,7 +69,7 @@ const useOntRootStore = defineStore('ontRoot', {
      */
     async fetchOntRuns(filter, page) {
       const rootStore = useRootStore()
-      const request = rootStore.api.traction.ont.runs
+      const request = rootStore.api.v1.traction.ont.runs
       const promise = request.get({ page, filter, include: 'instrument' })
 
       const response = await handleResponse(promise)
@@ -86,7 +86,7 @@ const useOntRootStore = defineStore('ontRoot', {
     },
     async setInstruments() {
       const rootStore = useRootStore()
-      const request = rootStore.api.traction.ont.instruments
+      const request = rootStore.api.v1.traction.ont.instruments
       const promise = request.get()
       const response = await handleResponse(promise)
       const { success, data: { data } = {}, errors = [] } = response

--- a/src/stores/ontRuns.js
+++ b/src/stores/ontRuns.js
@@ -55,7 +55,7 @@ export const useOntRunsStore = defineStore('ontRuns', {
   getters: {
     runRequest: () => {
       const rootStore = useRootStore()
-      return rootStore.api.traction.ont.runs
+      return rootStore.api.v1.traction.ont.runs
     },
     getFlowCell: (state) => (position) => {
       return state.currentRun.flowcell_attributes.find((fc) => fc.position == position)

--- a/src/stores/pacbioLibraries.js
+++ b/src/stores/pacbioLibraries.js
@@ -104,7 +104,7 @@ export const usePacbioLibrariesStore = defineStore('pacbioLibraries', {
      */
     async createLibraryInTraction(library) {
       const rootState = useRootStore()
-      const request = rootState.api.traction.pacbio.libraries
+      const request = rootState.api.v1.traction.pacbio.libraries
       const body = {
         data: {
           type: 'libraries',
@@ -146,7 +146,7 @@ export const usePacbioLibrariesStore = defineStore('pacbioLibraries', {
      */
     async deleteLibraries(libraryIds) {
       const rootStore = useRootStore()
-      const promises = rootStore.api.traction.pacbio.libraries.destroy(libraryIds)
+      const promises = rootStore.api.v1.traction.pacbio.libraries.destroy(libraryIds)
       const responses = await Promise.all(promises.map((promise) => handleResponse(promise)))
       return responses
     },
@@ -159,7 +159,7 @@ export const usePacbioLibrariesStore = defineStore('pacbioLibraries', {
      */
     async fetchLibraries(filter, page) {
       const rootStore = useRootStore()
-      const pacbioLibraries = rootStore.api.traction.pacbio.libraries
+      const pacbioLibraries = rootStore.api.v1.traction.pacbio.libraries
       const promise = pacbioLibraries.get({
         page,
         filter,
@@ -194,7 +194,7 @@ export const usePacbioLibrariesStore = defineStore('pacbioLibraries', {
       }
 
       const rootStore = useRootStore()
-      const request = rootStore.api.traction.pacbio.libraries
+      const request = rootStore.api.v1.traction.pacbio.libraries
       const body = {
         data: {
           type: 'libraries',

--- a/src/stores/pacbioPoolCreate.js
+++ b/src/stores/pacbioPoolCreate.js
@@ -538,7 +538,7 @@ export const usePacbioPoolCreateStore = defineStore('pacbioPoolCreate', {
       if (!validate({ used_aliquots, pool }))
         return { success: false, errors: 'The pool is invalid' }
       const rootStore = useRootStore()
-      const request = rootStore.api.traction.pacbio.pools
+      const request = rootStore.api.v1.traction.pacbio.pools
       const promise = request.create({
         data: payload({ used_aliquots, pool }),
         include: 'tube',
@@ -570,7 +570,7 @@ export const usePacbioPoolCreateStore = defineStore('pacbioPoolCreate', {
       if (!validate({ used_aliquots, pool }))
         return { success: false, errors: 'The pool is invalid' }
       const rootStore = useRootStore()
-      const request = rootStore.api.traction.pacbio.pools
+      const request = rootStore.api.v1.traction.pacbio.pools
       const promise = request.update(payload({ used_aliquots, pool }))
       const { success, errors } = await handleResponse(promise)
       return { success, errors }
@@ -593,7 +593,7 @@ export const usePacbioPoolCreateStore = defineStore('pacbioPoolCreate', {
      */
     async populateUsedAliquotsFromPool(poolId) {
       const rootStore = useRootStore()
-      const request = rootStore.api.traction.pacbio.pools
+      const request = rootStore.api.v1.traction.pacbio.pools
       const promise = request.find({
         id: poolId,
         include:
@@ -816,7 +816,7 @@ export const usePacbioPoolCreateStore = defineStore('pacbioPoolCreate', {
         }
       }
       const rootStore = useRootStore()
-      const request = rootStore.api.traction.pacbio.plates
+      const request = rootStore.api.v1.traction.pacbio.plates
       const promise = request.get({ filter: filter, include: 'wells.requests' })
       const response = await handleResponse(promise)
       let { success, data: { data, included = [] } = {}, errors = [] } = response
@@ -877,7 +877,7 @@ export const usePacbioPoolCreateStore = defineStore('pacbioPoolCreate', {
         }
       }
       const rootStore = useRootStore()
-      const request = rootStore.api.traction.pacbio.tubes
+      const request = rootStore.api.v1.traction.pacbio.tubes
       const promise = request.get({ filter: filter, include: 'requests,libraries.request' })
       let {
         success,

--- a/src/stores/pacbioPools.js
+++ b/src/stores/pacbioPools.js
@@ -84,7 +84,7 @@ export const usePacbioPoolsStore = defineStore('pacbioPools', {
      */
     async fetchPools(filter, page) {
       const rootStore = useRootStore()
-      const request = rootStore.api.traction.pacbio.pools
+      const request = rootStore.api.v1.traction.pacbio.pools
       const promise = request.get({
         page,
         filter,

--- a/src/stores/pacbioRoot.js
+++ b/src/stores/pacbioRoot.js
@@ -78,7 +78,7 @@ export const usePacbioRootStore = defineStore('pacbioRoot', {
      */
     async fetchPacbioTagSets() {
       const rootStore = useRootStore()
-      const promise = rootStore.api.traction.pacbio.tag_sets.get({ include: 'tags' })
+      const promise = rootStore.api.v1.traction.pacbio.tag_sets.get({ include: 'tags' })
       const response = await handleResponse(promise)
       const { success, data: { data, included = [] } = {}, errors = [] } = response
       if (success && data.length > 0) {

--- a/src/stores/pacbioRunCreate.js
+++ b/src/stores/pacbioRunCreate.js
@@ -238,7 +238,7 @@ export const usePacbioRunCreateStore = defineStore('pacbioRunCreate', {
      */
     async fetchSmrtLinkVersions() {
       const rootStore = useRootStore()
-      const request = rootStore.api.traction.pacbio.smrt_link_versions
+      const request = rootStore.api.v1.traction.pacbio.smrt_link_versions
       const promise = request.get({})
       const response = await handleResponse(promise)
 
@@ -261,7 +261,7 @@ export const usePacbioRunCreateStore = defineStore('pacbioRunCreate', {
       }
 
       const rootStore = useRootStore()
-      const request = rootStore.api.traction.pacbio.tubes
+      const request = rootStore.api.v1.traction.pacbio.tubes
       // used_aliquots could have a library instead of a request in the future but for the time being its just requests
       // so we only look for request in the includes
       const promise = request.get({
@@ -303,7 +303,7 @@ export const usePacbioRunCreateStore = defineStore('pacbioRunCreate', {
      */
     async fetchRun({ id }) {
       const rootStore = useRootStore()
-      const request = rootStore.api.traction.pacbio.runs
+      const request = rootStore.api.v1.traction.pacbio.runs
       const promise = request.find({
         id,
         include:
@@ -388,7 +388,7 @@ export const usePacbioRunCreateStore = defineStore('pacbioRunCreate', {
      */
     async saveRun() {
       const rootStore = useRootStore()
-      const request = rootStore.api.traction.pacbio.runs
+      const request = rootStore.api.v1.traction.pacbio.runs
 
       // based on the runType create the payload and the promise
       const payload = this.runType.payload({

--- a/src/stores/pacbioRuns.js
+++ b/src/stores/pacbioRuns.js
@@ -11,7 +11,7 @@ export const usePacbioRunsStore = defineStore('pacbioRuns', {
     runsArray: (state) => Object.values(state.runs),
     /*Pinia_migration_todo: This is migrated from the VueX store now, but it can be changed to a Pinia store, 
      once the VueX root store is converted to Pinia*/
-    runRequest: () => store.state.api.traction.pacbio.runs,
+    runRequest: () => store.state.api.v1.traction.pacbio.runs,
   },
 
   actions: {

--- a/src/stores/printing.js
+++ b/src/stores/printing.js
@@ -43,7 +43,7 @@ export const usePrintingStore = defineStore('printing', {
     }) {
       const rootStore = useRootStore()
 
-      const request = rootStore.api.printMyBarcode.print_jobs
+      const request = rootStore.api.v2.printMyBarcode.print_jobs
 
       const payload = {
         printer_name: printerName,
@@ -73,7 +73,7 @@ export const usePrintingStore = defineStore('printing', {
     async fetchPrinters() {
       const rootStore = useRootStore()
 
-      const request = rootStore.api.traction.printers
+      const request = rootStore.api.v2.traction.printers
 
       const promise = request.get()
       const response = await handleResponse(promise)

--- a/src/views/GeneralReception.vue
+++ b/src/views/GeneralReception.vue
@@ -287,7 +287,7 @@ export default {
     // ...mapState(useRootStore, ['api']),
     reception: ({ receptions, source }) => receptions[source],
     api() {
-      return useRootStore().api
+      return useRootStore().api.v1
     }, // can't use this in arrow function
     receptionRequest: ({ api }) => api.traction.receptions.create,
     barcodeArray: ({ barcodes }) => [...new Set(barcodes.split(/\s/).filter(Boolean))],

--- a/tests/unit/api/v2/ApiBuilder.spec.js
+++ b/tests/unit/api/v2/ApiBuilder.spec.js
@@ -95,7 +95,7 @@ describe('ApiBuilder', () => {
     expect(request1.rootURL).toEqual(import.meta.env.VITE_API1_BASE_URL)
     expect(request1.apiNamespace).toEqual('api/v1')
     expect(request1.resource).toEqual('resource1')
-    expect(request1.headers).toEqual({
+    expect(request1.api.headers).toEqual({
       'Content-Type': 'application/vnd.api+json',
       Accept: 'application/vnd.api+json',
     })
@@ -104,7 +104,7 @@ describe('ApiBuilder', () => {
     expect(request2.rootURL).toEqual(import.meta.env.VITE_API2_BASE_URL)
     expect(request2.apiNamespace).toEqual('v2')
     expect(request2.resource).toEqual('resource1')
-    expect(request2.headers).toEqual({
+    expect(request2.api.headers).toEqual({
       'Content-Type': 'application/vnd.api+json',
       Accept: 'application/vnd.api+json',
     })
@@ -113,7 +113,7 @@ describe('ApiBuilder', () => {
     expect(request3.rootURL).toEqual(import.meta.env.VITE_API2_BASE_URL)
     expect(request3.apiNamespace).toEqual('v2')
     expect(request3.resource).toEqual('resource2')
-    expect(request3.headers).toEqual({
+    expect(request3.api.headers).toEqual({
       'Content-Type': 'application/vnd.api+json',
       Accept: 'application/vnd.api+json',
     })
@@ -122,7 +122,7 @@ describe('ApiBuilder', () => {
     expect(request4.rootURL).toEqual(import.meta.env.VITE_API3_BASE_URL)
     expect(request4.apiNamespace).toEqual('v3')
     expect(request4.resource).toEqual('samples')
-    expect(request4.headers).toEqual({
+    expect(request4.api.headers).toEqual({
       'Content-Type': 'application/vnd.api+json',
       Accept: 'application/vnd.api+json',
       'custom-header': 'test',

--- a/tests/unit/components/labelPrinting/LabelPrintingForm.spec.js
+++ b/tests/unit/components/labelPrinting/LabelPrintingForm.spec.js
@@ -29,7 +29,7 @@ const printerRequestFactory = RequestFactory('printers', false)
 const plugins = [
   ({ store }) => {
     if (store.$id === 'root') {
-      store.api.traction.printers.get = vi.fn().mockResolvedValue(printerRequestFactory.response)
+      store.api.v2.traction.printers.get = vi.fn().mockResolvedValue(printerRequestFactory.response)
     }
   },
 ]

--- a/tests/unit/components/labelPrinting/PrinterModal.spec.js
+++ b/tests/unit/components/labelPrinting/PrinterModal.spec.js
@@ -13,7 +13,7 @@ const printerRequestFactory = RequestFactory('printers', false)
 const plugins = [
   ({ store }) => {
     if (store.$id === 'root') {
-      store.api.traction.printers.get = vi.fn().mockResolvedValue(printerRequestFactory.response)
+      store.api.v2.traction.printers.get = vi.fn().mockResolvedValue(printerRequestFactory.response)
     }
   },
 ]

--- a/tests/unit/components/pacbio/PacbioLibraryForm.spec.js
+++ b/tests/unit/components/pacbio/PacbioLibraryForm.spec.js
@@ -62,7 +62,7 @@ describe('PacbioLibraryForm.vue', () => {
     const plugins = [
       ({ store }) => {
         if (store.$id === 'root') {
-          store.api.traction.pacbio.tag_sets.get = vi.fn(() => Data.TractionPacbioTagSets)
+          store.api.v1.traction.pacbio.tag_sets.get = vi.fn(() => Data.TractionPacbioTagSets)
         }
       },
     ]
@@ -124,7 +124,7 @@ describe('PacbioLibraryForm.vue', () => {
     const plugins = [
       ({ store }) => {
         if (store.$id === 'root') {
-          store.api.traction.pacbio.tag_sets.get = vi.fn().mockRejectedValue('Error')
+          store.api.v1.traction.pacbio.tag_sets.get = vi.fn().mockRejectedValue('Error')
         }
       },
     ]
@@ -141,7 +141,7 @@ describe('PacbioLibraryForm.vue', () => {
       const plugins = [
         ({ store }) => {
           if (store.$id === 'root') {
-            store.api.traction.pacbio.tag_sets.get = vi.fn(() => Data.TractionPacbioTagSets)
+            store.api.v1.traction.pacbio.tag_sets.get = vi.fn(() => Data.TractionPacbioTagSets)
           }
         },
       ]

--- a/tests/unit/components/qcResultsUpload/QcResultsUploadForm.spec.js
+++ b/tests/unit/components/qcResultsUpload/QcResultsUploadForm.spec.js
@@ -68,7 +68,7 @@ describe('QcResultsUploadForm.vue', () => {
   describe('#computed', () => {
     it('gets the api request', () => {
       expect(form.qcResultUploadsRequest).toEqual(
-        store.getters.api.traction.qc_results_uploads.create,
+        store.getters.api.v1.traction.qc_results_uploads.create,
       )
     })
 
@@ -106,7 +106,7 @@ describe('QcResultsUploadForm.vue', () => {
       })
       form.showAlert = vi.fn()
 
-      create = store.getters.api.traction.qc_results_uploads.create
+      create = store.getters.api.v1.traction.qc_results_uploads.create
     })
 
     it('handles a successful import', async () => {

--- a/tests/unit/lib/receptions/SamplesExtraction.spec.js
+++ b/tests/unit/lib/receptions/SamplesExtraction.spec.js
@@ -10,7 +10,7 @@ describe('SamplesExtraction', () => {
       statusText: 'Internal Server Error',
     }
     let request
-    const requests = store.getters.api
+    const requests = store.getters.api.v1
 
     beforeEach(() => {
       request = vi.spyOn(requests.sampleExtraction.assets, 'get')

--- a/tests/unit/lib/receptions/Sequencescape.spec.js
+++ b/tests/unit/lib/receptions/Sequencescape.spec.js
@@ -9,7 +9,7 @@ describe('Sequencescape', () => {
       status: 500,
       statusText: 'Internal Server Error',
     }
-    const requests = store.getters.api
+    const requests = store.getters.api.v1
     let request
 
     beforeEach(() => {

--- a/tests/unit/lib/receptions/SequencescapeTubes.spec.js
+++ b/tests/unit/lib/receptions/SequencescapeTubes.spec.js
@@ -9,7 +9,7 @@ describe('SequencescapeTubes', () => {
       status: 500,
       statusText: 'Internal Server Error',
     }
-    const requests = store.getters.api
+    const requests = store.getters.api.v1
     let request
 
     beforeEach(() => {

--- a/tests/unit/lib/receptions/sequencescapeUtils.spec.js
+++ b/tests/unit/lib/receptions/sequencescapeUtils.spec.js
@@ -88,7 +88,7 @@ describe('sequencescapeUtils', () => {
       },
     }
 
-    const requests = store.getters.api
+    const requests = store.getters.api.v1
     let request
 
     beforeEach(() => {

--- a/tests/unit/store/index.spec.js
+++ b/tests/unit/store/index.spec.js
@@ -9,8 +9,10 @@ describe('index', () => {
 
     describe('api', () => {
       it('contains multiple resources', () => {
-        expect(Store.state.api.traction).toBeDefined()
-        expect(Store.state.api.printMyBarcode).toBeDefined()
+        expect(Store.state.api.v1.traction).toBeDefined()
+        expect(Store.state.api.v1.printMyBarcode).toBeDefined()
+        expect(Store.state.api.v2.traction).toBeDefined()
+        expect(Store.state.api.v2.printMyBarcode).toBeDefined()
       })
     })
 

--- a/tests/unit/store/printMyBarcode/actions.spec.js
+++ b/tests/unit/store/printMyBarcode/actions.spec.js
@@ -22,7 +22,7 @@ describe('actions', () => {
 
     it('successful', async () => {
       const create = vi.fn()
-      const rootState = { api: { printMyBarcode: { print_jobs: { create } } } }
+      const rootState = { api: { v1: { printMyBarcode: { print_jobs: { create } } } } }
       const mockResponse = {
         status: '201',
       }
@@ -45,7 +45,7 @@ describe('actions', () => {
 
     it('unsuccessful', async () => {
       const create = vi.fn()
-      const rootState = { api: { printMyBarcode: { print_jobs: { create } } } }
+      const rootState = { api: { v1: { printMyBarcode: { print_jobs: { create } } } } }
       const mockResponse = {
         status: '422',
         response: {

--- a/tests/unit/store/printMyBarcode/getters.spec.js
+++ b/tests/unit/store/printMyBarcode/getters.spec.js
@@ -4,8 +4,10 @@ describe('getters', () => {
   it('"printJobRequest" returns "rootState.api.printMyBarcode.print_jobs"', () => {
     const rootState = {
       api: {
-        printMyBarcode: {
-          print_jobs: 'aPrintJobsRequestURL',
+        v1: {
+          printMyBarcode: {
+            print_jobs: 'aPrintJobsRequestURL',
+          },
         },
       },
     }

--- a/tests/unit/store/traction/ont/pools/actions.spec.js
+++ b/tests/unit/store/traction/ont/pools/actions.spec.js
@@ -28,7 +28,7 @@ describe('actions.js', () => {
       const commit = vi.fn()
       // mock dependencies
       const get = vi.fn()
-      const rootState = { api: { traction: { ont: { requests: { get } } } } }
+      const rootState = { api: { v1: { traction: { ont: { requests: { get } } } } } }
       get.mockResolvedValue(Data.TractionOntRequests)
       // apply action
       const { success } = await actions.fetchOntRequests({ commit, rootState })
@@ -45,7 +45,7 @@ describe('actions.js', () => {
       const commit = vi.fn()
       // mock dependencies
       const get = vi.fn()
-      const rootState = { api: { traction: { ont: { requests: { get } } } } }
+      const rootState = { api: { v1: { traction: { ont: { requests: { get } } } } } }
       get.mockRejectedValue({
         data: { data: [] },
         status: 500,
@@ -65,7 +65,7 @@ describe('actions.js', () => {
       const commit = vi.fn()
       // mock dependencies
       const get = vi.fn()
-      const rootState = { api: { traction: { ont: { pools: { get } } } } }
+      const rootState = { api: { v1: { traction: { ont: { pools: { get } } } } } }
       get.mockResolvedValue(Data.TractionOntPools)
       // apply action
       const { success } = await actions.fetchOntPools({ commit, rootState })
@@ -95,7 +95,7 @@ describe('actions.js', () => {
       const commit = vi.fn()
       // mock dependencies
       const get = vi.fn()
-      const rootState = { api: { traction: { ont: { pools: { get } } } } }
+      const rootState = { api: { v1: { traction: { ont: { pools: { get } } } } } }
       get.mockRejectedValue({
         data: { data: [] },
         status: 500,
@@ -115,7 +115,7 @@ describe('actions.js', () => {
       const commit = vi.fn()
       // mock dependencies
       const get = vi.fn()
-      const rootState = { api: { traction: { ont: { tag_sets: { get } } } } }
+      const rootState = { api: { v1: { traction: { ont: { tag_sets: { get } } } } } }
       get.mockResolvedValue(Data.TractionOntTagSets)
       // apply action
       const { success } = await fetchOntTagSets({ commit, rootState })
@@ -133,7 +133,7 @@ describe('actions.js', () => {
       const commit = vi.fn()
       // mock dependencies
       const get = vi.fn()
-      const rootState = { api: { traction: { ont: { tag_sets: { get } } } } }
+      const rootState = { api: { v1: { traction: { ont: { tag_sets: { get } } } } } }
       get.mockRejectedValue({
         data: { data: [] },
         status: 500,
@@ -267,7 +267,7 @@ describe('actions.js', () => {
       }
       // mock dependencies
       const create = vi.fn()
-      const rootState = { api: { traction: { ont: { pools: { create } } } } }
+      const rootState = { api: { v1: { traction: { ont: { pools: { create } } } } } }
       const libraries = { 1: library1, 2: library2 }
       create.mockResolvedValue(mockResponse)
       const { success, barcode } = await createPool({
@@ -290,7 +290,7 @@ describe('actions.js', () => {
       }
       // mock dependencies
       const update = vi.fn(() => Promise.reject({ response: mockResponse }))
-      const rootState = { api: { traction: { ont: { pools: { update } } } } }
+      const rootState = { api: { v1: { traction: { ont: { pools: { update } } } } } }
       const libraries = { 1: library1, 2: library2 }
       const expectedResponse = newResponse({ ...mockResponse, success: false })
       const { success, errors } = await updatePool({
@@ -309,7 +309,7 @@ describe('actions.js', () => {
       const commit = vi.fn()
       // mock dependencies
       const create = vi.fn()
-      const rootState = { api: { traction: { ont: { pools: { create } } } } }
+      const rootState = { api: { v1: { traction: { ont: { pools: { create } } } } } }
       const libraries = { 1: library1, 2: { ...library2, concentration: '' } }
       const { success, errors } = await createPool({
         commit,
@@ -360,7 +360,7 @@ describe('actions.js', () => {
       }
       // mock dependencies
       const update = vi.fn()
-      const rootState = { api: { traction: { ont: { pools: { update } } } } }
+      const rootState = { api: { v1: { traction: { ont: { pools: { update } } } } } }
       const libraries = { 1: library1, 2: library2 }
       update.mockResolvedValue(mockResponse)
       const { success } = await updatePool({ rootState, state: { pooling: { libraries, pool } } })
@@ -376,7 +376,7 @@ describe('actions.js', () => {
       }
       // mock dependencies
       const update = vi.fn(() => Promise.reject({ response: mockResponse }))
-      const rootState = { api: { traction: { ont: { pools: { update } } } } }
+      const rootState = { api: { v1: { traction: { ont: { pools: { update } } } } } }
       const libraries = { 1: library1, 2: library2 }
       const expectedResponse = newResponse({ ...mockResponse, success: false })
       const { success, errors } = await updatePool({
@@ -395,7 +395,7 @@ describe('actions.js', () => {
       const commit = vi.fn()
       // mock dependencies
       const update = vi.fn()
-      const rootState = { api: { traction: { ont: { pools: { update } } } } }
+      const rootState = { api: { v1: { traction: { ont: { pools: { update } } } } } }
       const libraries = { 1: library1, 2: { ...library2, concentration: '' } }
       const { success, errors } = await updatePool({
         commit,
@@ -766,7 +766,7 @@ describe('actions.js', () => {
       const commit = vi.fn()
       // mock dependencies
       const find = vi.fn()
-      const rootState = { api: { traction: { ont: { pools: { find } } } } }
+      const rootState = { api: { v1: { traction: { ont: { pools: { find } } } } } }
       find.mockResolvedValue(Data.TractionOntPool)
       // apply action
       const { success } = await setPoolData({ commit, rootState }, 3)
@@ -811,7 +811,7 @@ describe('actions.js', () => {
       const commit = vi.fn()
       // mock dependencies
       const find = vi.fn()
-      const rootState = { api: { traction: { ont: { pools: { find } } } } }
+      const rootState = { api: { v1: { traction: { ont: { pools: { find } } } } } }
       find.mockResolvedValue(Data.TractionOntPool)
 
       const { success, errors } = await setPoolData({ commit, rootState }, 'new')
@@ -828,7 +828,7 @@ describe('actions.js', () => {
       const commit = vi.fn()
       // mock dependencies
       const get = vi.fn()
-      const rootState = { api: { traction: { ont: { plates: { get } } } } }
+      const rootState = { api: { v1: { traction: { ont: { plates: { get } } } } } }
 
       get.mockResolvedValue(Data.OntPlateRequest)
 
@@ -853,7 +853,7 @@ describe('actions.js', () => {
       const commit = vi.fn()
       // mock dependencies
       const get = vi.fn()
-      const rootState = { api: { traction: { ont: { plates: { get } } } } }
+      const rootState = { api: { v1: { traction: { ont: { plates: { get } } } } } }
 
       get.mockResolvedValue({ data: { data: [] } })
 
@@ -869,7 +869,7 @@ describe('actions.js', () => {
       const commit = vi.fn()
       // mock dependencies
       const get = vi.fn()
-      const rootState = { api: { traction: { ont: { plates: { get } } } } }
+      const rootState = { api: { v1: { traction: { ont: { plates: { get } } } } } }
 
       const { success, errors } = await findOntPlate({ commit, rootState }, { barcode: '' })
       expect(errors).toEqual(['Please provide a plate barcode'])
@@ -883,7 +883,7 @@ describe('actions.js', () => {
       const commit = vi.fn()
       // mock dependencies
       const get = vi.fn()
-      const rootState = { api: { traction: { ont: { tubes: { get } } } } }
+      const rootState = { api: { v1: { traction: { ont: { tubes: { get } } } } } }
 
       get.mockResolvedValue(Data.OntTubeRequest)
 
@@ -904,7 +904,7 @@ describe('actions.js', () => {
       const commit = vi.fn()
       // mock dependencies
       const get = vi.fn()
-      const rootState = { api: { traction: { ont: { tubes: { get } } } } }
+      const rootState = { api: { v1: { traction: { ont: { tubes: { get } } } } } }
 
       get.mockResolvedValue({ data: { data: [] } })
 
@@ -920,7 +920,7 @@ describe('actions.js', () => {
       const commit = vi.fn()
       // mock dependencies
       const get = vi.fn()
-      const rootState = { api: { traction: { ont: { tubes: { get } } } } }
+      const rootState = { api: { v1: { traction: { ont: { tubes: { get } } } } } }
 
       const { success, errors } = await findOntTube({ commit, rootState }, { barcode: '' })
       expect(errors).toEqual(['Please provide a tube barcode'])

--- a/tests/unit/stores/index.spec.js
+++ b/tests/unit/stores/index.spec.js
@@ -2,6 +2,7 @@ import { createPinia, setActivePinia } from 'pinia'
 import useRootStore from '@/stores'
 import rootVuexStore from '@/store/index.js'
 import PlateMap from '@/config/PlateMap.json'
+import { expect } from 'vitest'
 
 describe('index', () => {
   beforeEach(() => {
@@ -14,13 +15,17 @@ describe('index', () => {
     it('has api state', () => {
       const store = useRootStore()
       expect(store.api).toBeDefined()
+      expect(store.api.v1).toBeDefined()
+      expect(store.api.v2).toBeDefined()
     })
 
     describe('api', () => {
       it('contains multiple resources', () => {
         const store = useRootStore()
-        expect(store.api.traction).toBeDefined()
-        expect(store.api.printMyBarcode).toBeDefined()
+        expect(store.api.v1.traction).toBeDefined()
+        expect(store.api.v1.printMyBarcode).toBeDefined()
+        expect(store.api.v2.traction).toBeDefined()
+        expect(store.api.v2.printMyBarcode).toBeDefined()
       })
     })
 

--- a/tests/unit/stores/ontRoot.spec.js
+++ b/tests/unit/stores/ontRoot.spec.js
@@ -74,7 +74,7 @@ describe('useOntRootStore', () => {
         const rootStore = useRootStore()
         const get = vi.fn()
         get.mockResolvedValue(Data.OntRuns)
-        rootStore.api = { traction: { ont: { runs: { get } } } }
+        rootStore.api.v1 = { traction: { ont: { runs: { get } } } }
 
         const store = useOntRootStore()
         const { success } = await store.fetchOntRuns()
@@ -97,7 +97,7 @@ describe('useOntRootStore', () => {
         const rootStore = useRootStore()
         const get = vi.fn()
         get.mockRejectedValue(failedResponse)
-        rootStore.api = { traction: { ont: { runs: { get } } } }
+        rootStore.api.v1 = { traction: { ont: { runs: { get } } } }
 
         const store = useOntRootStore()
 
@@ -113,7 +113,7 @@ describe('useOntRootStore', () => {
         const rootStore = useRootStore()
         const get = vi.fn()
         get.mockResolvedValue(Data.OntInstruments)
-        rootStore.api = { traction: { ont: { instruments: { get } } } }
+        rootStore.api.v1 = { traction: { ont: { instruments: { get } } } }
 
         const store = useOntRootStore()
         const { success } = await store.setInstruments()
@@ -131,7 +131,7 @@ describe('useOntRootStore', () => {
         const rootStore = useRootStore()
         const get = vi.fn()
         get.mockRejectedValue(failedResponse)
-        rootStore.api = { traction: { ont: { instruments: { get } } } }
+        rootStore.api.v1 = { traction: { ont: { instruments: { get } } } }
 
         const store = useOntRootStore()
 

--- a/tests/unit/stores/ontRuns.spec.js
+++ b/tests/unit/stores/ontRuns.spec.js
@@ -41,7 +41,7 @@ describe('useOntRunsStore', () => {
       const rootStore = useRootStore()
       const get = vi.fn()
       get.mockResolvedValue(Data.OntRuns)
-      rootStore.api = {
+      rootStore.api.v1 = {
         traction: { ont: { runs: 'aRunRequest' } },
       }
       const actual = store.runRequest

--- a/tests/unit/stores/pacbioLibraries.spec.js
+++ b/tests/unit/stores/pacbioLibraries.spec.js
@@ -103,7 +103,7 @@ describe('usePacbioLibrariesStore', () => {
         rootStore = useRootStore()
         store = usePacbioLibrariesStore()
 
-        rootStore.api = {
+        rootStore.api.v1 = {
           traction: {
             pacbio: {
               libraries: { create },
@@ -175,7 +175,7 @@ describe('usePacbioLibrariesStore', () => {
 
       beforeEach(() => {
         destroy = vi.fn()
-        rootStore.api.traction.pacbio.libraries = { destroy: destroy }
+        rootStore.api.v1.traction.pacbio.libraries = { destroy: destroy }
         libraryIds = [1, 2]
       })
 
@@ -209,7 +209,7 @@ describe('usePacbioLibrariesStore', () => {
 
       beforeEach(() => {
         get = vi.fn()
-        rootStore.api.traction.pacbio.libraries.get = get
+        rootStore.api.v1.traction.pacbio.libraries.get = get
         failedResponse = {
           data: { data: { errors: { error1: ['There was an error'] } } },
           status: 500,
@@ -301,8 +301,8 @@ describe('usePacbioLibrariesStore', () => {
         rootStore = useRootStore()
         store = usePacbioLibrariesStore()
 
-        rootStore.api.traction.pacbio.libraries.get = get
-        rootStore.api.traction.pacbio.libraries.update = update
+        rootStore.api.v1.traction.pacbio.libraries.get = get
+        rootStore.api.v1.traction.pacbio.libraries.update = update
         await store.fetchLibraries()
         libraryBeforeUpdate = {
           id: '1',

--- a/tests/unit/stores/pacbioPoolCreate.spec.js
+++ b/tests/unit/stores/pacbioPoolCreate.spec.js
@@ -557,7 +557,7 @@ describe('usePacbioPoolCreateStore', () => {
 
       beforeEach(() => {
         create = vi.fn()
-        rootStore.api = { traction: { pacbio: { pools: { create } } } }
+        rootStore.api.v1 = { traction: { pacbio: { pools: { create } } } }
       })
 
       const used_aliquot1 = createUsedAliquot({
@@ -686,7 +686,7 @@ describe('usePacbioPoolCreateStore', () => {
 
       beforeEach(() => {
         update = vi.fn()
-        rootStore.api = { traction: { pacbio: { pools: { update } } } }
+        rootStore.api.v1 = { traction: { pacbio: { pools: { update } } } }
         used_aliquots = { _1: used_aliquot1, _2: used_aliquot2 }
         store.used_aliquots = used_aliquots
         store.pool = pool
@@ -745,7 +745,7 @@ describe('usePacbioPoolCreateStore', () => {
 
       beforeEach(() => {
         find = vi.fn()
-        rootStore.api = { traction: { pacbio: { pools: { find } } } }
+        rootStore.api.v1 = { traction: { pacbio: { pools: { find } } } }
         const pacbioRootStore = usePacbioRootStore()
         pacbioRootStore.tagSets = Data.TractionPacbioTagSets.data.data
         pacbioRootStore.tags = Data.TractionPacbioTagSets.data.included
@@ -1060,7 +1060,7 @@ describe('usePacbioPoolCreateStore', () => {
       const get = vi.fn()
 
       beforeEach(() => {
-        rootStore.api = { traction: { pacbio: { plates: { get } } } }
+        rootStore.api.v1 = { traction: { pacbio: { plates: { get } } } }
         store.selectPlate = vi.fn()
       })
 
@@ -1107,7 +1107,7 @@ describe('usePacbioPoolCreateStore', () => {
       const get = vi.fn()
 
       beforeEach(() => {
-        rootStore.api = { traction: { pacbio: { tubes: { get } } } }
+        rootStore.api.v1 = { traction: { pacbio: { tubes: { get } } } }
         store.selectPlate = vi.fn()
       })
 
@@ -1221,7 +1221,7 @@ describe('usePacbioPoolCreateStore', () => {
       ]
       beforeEach(() => {
         const create = vi.fn()
-        rootStore.api = { traction: { pacbio: { pools: { create } } } }
+        rootStore.api.v1 = { traction: { pacbio: { pools: { create } } } }
       })
       it('selects a request by default', () => {
         store.used_aliquots = {

--- a/tests/unit/stores/pacbioPools.spec.js
+++ b/tests/unit/stores/pacbioPools.spec.js
@@ -173,7 +173,7 @@ describe('usePacbioPools', () => {
         get = vi.fn()
         store = usePacbioPoolsStore()
         rootStore = useRootStore()
-        rootStore.api.traction.pacbio.pools.get = get
+        rootStore.api.v1.traction.pacbio.pools.get = get
         failedResponse = { data: { data: [] }, status: 500, statusText: 'Internal Server Error' }
       })
 

--- a/tests/unit/stores/pacbioRoot.spec.js
+++ b/tests/unit/stores/pacbioRoot.spec.js
@@ -92,7 +92,7 @@ describe('usePacbioRootStore', () => {
       beforeEach(() => {
         rootStore = useRootStore()
         store = usePacbioRootStore()
-        rootStore.api.traction.pacbio.tag_sets = { get }
+        rootStore.api.v1.traction.pacbio.tag_sets = { get }
       })
       it('handles success', async () => {
         // mock dependencies
@@ -111,7 +111,7 @@ describe('usePacbioRootStore', () => {
       it('handles failure', async () => {
         // mock dependencies
         const get = vi.fn()
-        rootStore.api.traction.pacbio.tag_sets = { get }
+        rootStore.api.v1.traction.pacbio.tag_sets = { get }
         get.mockRejectedValue({
           data: { data: [] },
           status: 500,

--- a/tests/unit/stores/pacbioRunCreate.spec.js
+++ b/tests/unit/stores/pacbioRunCreate.spec.js
@@ -271,7 +271,7 @@ describe('usePacbioRunCreateStore', () => {
         const rootStore = useRootStore()
         const get = vi.fn()
         get.mockResolvedValue(Data.TractionPacbioSmrtLinkVersions)
-        rootStore.api = { traction: { pacbio: { smrt_link_versions: { get } } } }
+        rootStore.api.v1 = { traction: { pacbio: { smrt_link_versions: { get } } } }
 
         const store = usePacbioRunCreateStore()
 
@@ -289,7 +289,7 @@ describe('usePacbioRunCreateStore', () => {
         const rootStore = useRootStore()
         const get = vi.fn()
         get.mockRejectedValue(failedResponse)
-        rootStore.api = { traction: { pacbio: { smrt_link_versions: { get } } } }
+        rootStore.api.v1 = { traction: { pacbio: { smrt_link_versions: { get } } } }
 
         const store = usePacbioRunCreateStore()
 
@@ -306,7 +306,7 @@ describe('usePacbioRunCreateStore', () => {
         const rootStore = useRootStore()
         const find = vi.fn()
         find.mockResolvedValue(Data.PacbioRun)
-        rootStore.api = { traction: { pacbio: { runs: { find } } } }
+        rootStore.api.v1 = { traction: { pacbio: { runs: { find } } } }
 
         //Mock splitDataByParent
         const mockApiSplitData = vi.spyOn(jsonapi, 'splitDataByParent')
@@ -385,7 +385,7 @@ describe('usePacbioRunCreateStore', () => {
         const rootStore = useRootStore()
         const find = vi.fn()
         find.mockRejectedValue(failedResponse)
-        rootStore.api = { traction: { pacbio: { runs: { find } } } }
+        rootStore.api.v1 = { traction: { pacbio: { runs: { find } } } }
 
         //Mock splitDataByParent
         const mockApiSplitData = vi.spyOn(jsonapi, 'splitDataByParent')
@@ -423,7 +423,7 @@ describe('usePacbioRunCreateStore', () => {
         const rootStore = useRootStore()
         const get = vi.fn()
         get.mockResolvedValue(response)
-        rootStore.api = { traction: { pacbio: { tubes: { get } } } }
+        rootStore.api.v1 = { traction: { pacbio: { tubes: { get } } } }
 
         const store = usePacbioRunCreateStore()
 
@@ -468,7 +468,7 @@ describe('usePacbioRunCreateStore', () => {
           const rootStore = useRootStore()
           const create = vi.fn()
           create.mockResolvedValue(mockResponse)
-          rootStore.api = { traction: { pacbio: { runs: { create } } } }
+          rootStore.api.v1 = { traction: { pacbio: { runs: { create } } } }
 
           const store = usePacbioRunCreateStore()
           store.$state = {
@@ -490,7 +490,7 @@ describe('usePacbioRunCreateStore', () => {
           const rootStore = useRootStore()
           const create = vi.fn()
           create.mockRejectedValue(failedResponse)
-          rootStore.api = { traction: { pacbio: { runs: { create } } } }
+          rootStore.api.v1 = { traction: { pacbio: { runs: { create } } } }
           const store = usePacbioRunCreateStore()
           //Initilaize the store state
           store.$state = {
@@ -518,7 +518,7 @@ describe('usePacbioRunCreateStore', () => {
           const rootStore = useRootStore()
           const update = vi.fn()
           update.mockResolvedValue(mockResponse)
-          rootStore.api = { traction: { pacbio: { runs: { update } } } }
+          rootStore.api.v1 = { traction: { pacbio: { runs: { update } } } }
 
           const store = usePacbioRunCreateStore()
           //Initilaize the store state
@@ -540,7 +540,7 @@ describe('usePacbioRunCreateStore', () => {
           //Mock useRootStore
           const rootStore = useRootStore()
           update.mockRejectedValue(failedResponse)
-          rootStore.api = { traction: { pacbio: { runs: { update } } } }
+          rootStore.api.v1 = { traction: { pacbio: { runs: { update } } } }
 
           const store = usePacbioRunCreateStore()
           //Initilaize the store state

--- a/tests/unit/stores/printing.spec.js
+++ b/tests/unit/stores/printing.spec.js
@@ -50,7 +50,7 @@ describe('usePrintingStore', () => {
         const printerRequestFactory = RequestFactory('printers', false)
 
         get.mockResolvedValue(printerRequestFactory.response)
-        rootStore.api = { traction: { printers: { get } } }
+        rootStore.api.v2 = { traction: { printers: { get } } }
 
         const store = usePrintingStore()
 
@@ -68,7 +68,7 @@ describe('usePrintingStore', () => {
         const rootStore = useRootStore()
         const get = vi.fn()
         get.mockRejectedValue('Internal Server Error')
-        rootStore.api = { traction: { printers: { get } } }
+        rootStore.api.v2 = { traction: { printers: { get } } }
 
         const store = usePrintingStore()
 
@@ -107,7 +107,7 @@ describe('usePrintingStore', () => {
 
         const rootStore = useRootStore()
         const create = vi.fn()
-        rootStore.api = { printMyBarcode: { print_jobs: { create } } }
+        rootStore.api.v2 = { printMyBarcode: { print_jobs: { create } } }
         create.mockResolvedValue(mockResponse)
 
         const { success, message } = await store.createPrintJob({ ...printJobOptions })
@@ -140,7 +140,7 @@ describe('usePrintingStore', () => {
 
         const create = vi.fn()
         const rootStore = useRootStore()
-        rootStore.api = { printMyBarcode: { print_jobs: { create } } }
+        rootStore.api.v2 = { printMyBarcode: { print_jobs: { create } } }
         create.mockResolvedValue(mockResponse)
 
         // eslint-disable-next-line no-unused-vars

--- a/tests/unit/views/ont/ONTPoolCreate.spec.js
+++ b/tests/unit/views/ont/ONTPoolCreate.spec.js
@@ -7,8 +7,10 @@ describe('OntPoolCreate', () => {
     const {
       state: {
         api: {
-          traction: {
-            ont: { tag_sets: tagSetsRequest, pools: poolsRequest },
+          v1: {
+            traction: {
+              ont: { tag_sets: tagSetsRequest, pools: poolsRequest },
+            },
           },
         },
       },
@@ -46,8 +48,10 @@ describe('OntPoolCreate', () => {
     const {
       state: {
         api: {
-          traction: {
-            ont: { tag_sets: tagSetsRequest, pools: poolsRequest },
+          v1: {
+            traction: {
+              ont: { tag_sets: tagSetsRequest, pools: poolsRequest },
+            },
           },
         },
       },

--- a/tests/unit/views/ont/ONTPoolIndex.spec.js
+++ b/tests/unit/views/ont/ONTPoolIndex.spec.js
@@ -6,7 +6,7 @@ describe('OntPoolIndex', () => {
   let wrapper, pools
 
   beforeEach(async () => {
-    const get = vi.spyOn(store.state.api.traction.ont.pools, 'get')
+    const get = vi.spyOn(store.state.api.v1.traction.ont.pools, 'get')
     get.mockResolvedValue(Data.TractionOntPools)
     wrapper = mount(ONTPoolIndex, {
       store,

--- a/tests/unit/views/ont/ONTRun.spec.js
+++ b/tests/unit/views/ont/ONTRun.spec.js
@@ -12,7 +12,7 @@ import { useOntRunsStore } from '@/stores/ontRuns'
  * props - props to pass to the component
  */
 function mountWithStore(props) {
-  vi.spyOn(store.state.api.traction.ont.pools, 'get').mockResolvedValue(Data.TractionOntPools)
+  vi.spyOn(store.state.api.v1.traction.ont.pools, 'get').mockResolvedValue(Data.TractionOntPools)
   const wrapperObj = mount(ONTRun, {
     global: {
       plugins: [
@@ -21,7 +21,7 @@ function mountWithStore(props) {
           plugins: [
             ({ store }) => {
               if (store.$id === 'root') {
-                store.api.traction.ont.instruments.get = vi
+                store.api.v1.traction.ont.instruments.get = vi
                   .fn()
                   .mockReturnValue(Data.OntInstruments)
               }

--- a/tests/unit/views/ont/ONTRuns.spec.js
+++ b/tests/unit/views/ont/ONTRuns.spec.js
@@ -8,7 +8,7 @@ describe('ONTRuns.vue', () => {
   beforeEach(async () => {
     mockRuns = new Response(Data.OntRuns).deserialize.runs
 
-    const get = vi.spyOn(store.state.api.traction.ont.runs, 'get')
+    const get = vi.spyOn(store.state.api.v1.traction.ont.runs, 'get')
     get.mockResolvedValue(Data.OntRuns)
 
     wrapper = await mount(ONTRuns, { store, router })

--- a/tests/unit/views/ont/ONTSampleIndex.spec.js
+++ b/tests/unit/views/ont/ONTSampleIndex.spec.js
@@ -6,7 +6,7 @@ describe('OntSampleIndex', () => {
   let wrapper
 
   beforeEach(async () => {
-    const get = vi.spyOn(store.state.api.traction.ont.requests, 'get')
+    const get = vi.spyOn(store.state.api.v1.traction.ont.requests, 'get')
     get.mockReturnValue(Data.TractionOntRequests)
 
     wrapper = mount(ONTSampleIndex, {

--- a/tests/unit/views/pacbio/PacbioLibraryIndex.spec.js
+++ b/tests/unit/views/pacbio/PacbioLibraryIndex.spec.js
@@ -43,7 +43,7 @@ describe('Libraries.vue', () => {
     const plugins = [
       ({ store }) => {
         if (store.$id === 'root') {
-          store.api.traction.pacbio.libraries.get = vi
+          store.api.v1.traction.pacbio.libraries.get = vi
             .fn()
             .mockResolvedValue(Data.TractionPacbioLibraries)
         }

--- a/tests/unit/views/pacbio/PacbioPlateIndex.spec.js
+++ b/tests/unit/views/pacbio/PacbioPlateIndex.spec.js
@@ -5,7 +5,7 @@ describe('PacbioPlates.vue', () => {
   let wrapper, plates
 
   beforeEach(async () => {
-    const get = vi.spyOn(store.state.api.traction.pacbio.plates, 'get')
+    const get = vi.spyOn(store.state.api.v1.traction.pacbio.plates, 'get')
     get.mockResolvedValue(Data.PacbioPlatesRequest)
 
     wrapper = mount(PacbioPlates, {

--- a/tests/unit/views/pacbio/PacbioPoolIndex.spec.js
+++ b/tests/unit/views/pacbio/PacbioPoolIndex.spec.js
@@ -43,7 +43,9 @@ describe('PacbioPoolIndex.vue', () => {
     const plugins = [
       ({ store }) => {
         if (store.$id === 'root') {
-          store.api.traction.pacbio.pools.get = vi.fn().mockResolvedValue(Data.TractionPacbioPools)
+          store.api.v1.traction.pacbio.pools.get = vi
+            .fn()
+            .mockResolvedValue(Data.TractionPacbioPools)
         }
       },
     ]

--- a/tests/unit/views/pacbio/PacbioRunIndex.spec.js
+++ b/tests/unit/views/pacbio/PacbioRunIndex.spec.js
@@ -55,8 +55,8 @@ function factory(options, dataProps) {
                 store.runRequest.get = spy
               }
               if (store.$id === 'root') {
-                store.api.traction.pacbio.smrt_link_versions.get = spy2
-                store.api.traction.pacbio.runs = vi.fn().mockReturnValue(Data.PacbioRuns)
+                store.api.v1.traction.pacbio.smrt_link_versions.get = spy2
+                store.api.v1.traction.pacbio.runs = vi.fn().mockReturnValue(Data.PacbioRuns)
               }
             },
           ],

--- a/tests/unit/views/pacbio/PacbioRunShow.spec.js
+++ b/tests/unit/views/pacbio/PacbioRunShow.spec.js
@@ -32,9 +32,9 @@ function mountWithStore(props) {
           plugins: [
             ({ store }) => {
               if (store.$id === 'root') {
-                ;(store.api.traction.pacbio.smrt_link_versions.get = vi.fn()),
-                  (store.api.traction.pacbio.runs.find = vi.fn(() => Data.PacbioRun)),
-                  (store.api.traction.pacbio.tubes.get = vi.fn(
+                ;(store.api.v1.traction.pacbio.smrt_link_versions.get = vi.fn()),
+                  (store.api.v1.traction.pacbio.runs.find = vi.fn(() => Data.PacbioRun)),
+                  (store.api.v1.traction.pacbio.tubes.get = vi.fn(
                     () => Data.PacbioTubesWithPoolsAndLibraries,
                   ))
               }

--- a/tests/unit/views/pacbio/PacbioSampleIndex.spec.js
+++ b/tests/unit/views/pacbio/PacbioSampleIndex.spec.js
@@ -46,11 +46,11 @@ describe('PacbioSamples.vue', () => {
     PacbioRequestsRequest.data.included = []
 
     // DataFetcher calls requests get on render so we need to mock the call
-    const requestGet = vi.spyOn(store.state.api.traction.pacbio.requests, 'get')
+    const requestGet = vi.spyOn(store.state.api.v1.traction.pacbio.requests, 'get')
     requestGet.mockReturnValue(PacbioRequestsRequest)
 
     // PacbioLibraryCreate calls tags get on render so we need to mock the call
-    const tagGet = vi.spyOn(store.state.api.traction.tags, 'get')
+    const tagGet = vi.spyOn(store.state.api.v1.traction.tags, 'get')
     tagGet.mockReturnValue(Data.TactionTags)
 
     const { wrapperObj } = mountWithStore()

--- a/tests/unit/views/saphyr/SaphyrSamples.spec.js
+++ b/tests/unit/views/saphyr/SaphyrSamples.spec.js
@@ -15,7 +15,7 @@ describe('Samples.vue', () => {
       Data.TractionSaphyrRequests,
     )
     // Here we mock enzymes as they are loaded in the modal
-    vi.spyOn(store.getters.api.traction.saphyr.enzymes, 'get').mockResolvedValue({
+    vi.spyOn(store.getters.api.v1.traction.saphyr.enzymes, 'get').mockResolvedValue({
       data: Data.Enzymes,
     })
     wrapper = mount(Samples, {


### PR DESCRIPTION

Closes #

#### Changes proposed in this pull request

- modify build in v1 and v2 to create a v1 and v2 api
- move all current request over to v1 api except printing and anything using print my barcode v2

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
