### PR TITLE
1606 y24 045 ont pool creation page improvement on usability

### DIFF
--- a/src/components/InfoFooter.vue
+++ b/src/components/InfoFooter.vue
@@ -68,6 +68,14 @@ export default {
       defaultRelease: 'https://github.com/sanger/traction-ui/releases',
     }
   },
+  computed: {
+    footerClasses() {
+      return [
+        'border border-t-2 pt-5 pb-3 flex-shrink-0 border-sdb-100',
+        bgColorClass[this.environment],
+      ]
+    },
+  },
   created() {
     this.provider()
   },
@@ -92,14 +100,6 @@ export default {
       } catch (err) {
         console.error(err)
       }
-    },
-  },
-  computed: {
-    footerClasses() {
-      return [
-        'border border-t-2 pt-5 pb-3 flex-shrink-0 border-sdb-100',
-        bgColorClass[this.environment],
-      ]
     },
   },
 }

--- a/src/components/ont/OntTubeSelectedList.vue
+++ b/src/components/ont/OntTubeSelectedList.vue
@@ -80,8 +80,8 @@ export default {
     ...mapMutations(['selectTube', 'selectRequest']),
     ...mapActions(['selectWellRequests', 'deselectTubeAndContents']),
 
-    isButtonDisabled(id){     
-      return this.selectedRequests.find( (request) => request.id === id )
+    isButtonDisabled(id) {
+      return this.selectedRequests.find((request) => request.id === id)
     },
 
     requestClicked({ id, selected }) {

--- a/src/components/ont/OntTubeSelectedList.vue
+++ b/src/components/ont/OntTubeSelectedList.vue
@@ -12,7 +12,7 @@
             size="sm"
             class="mr-2"
             theme="default"
-            :disabled="disabledButtons[row.item.id]"
+            :disabled="isButtonDisabled(row.item.id)"
             @click="addTubeToPool(row.item.id)"
           >
             +
@@ -22,7 +22,7 @@
             size="sm"
             class="mr-2"
             theme="default"
-            :disabled="!disabledButtons[row.item.id]"
+            :disabled="!isButtonDisabled(row.item.id)"
             @click="removeTubeFromPool(row.item.id)"
           >
             -
@@ -32,7 +32,7 @@
             size="sm"
             class="mr-2"
             theme="default"
-            @click="DeselectTube(row.item.id, row.item.source_identifier)"
+            @click="DeselectTube(row.item.source_identifier)"
           >
             Remove
           </traction-button>
@@ -66,11 +66,10 @@ export default {
         { key: 'number_of_flowcells', label: 'Number of flowcells' },
         { key: 'action', label: 'Action' },
       ],
-      disabledButtons: {},
     }
   },
   computed: {
-    ...mapGetters(['selectedTubes', 'requestList']),
+    ...mapGetters(['selectedTubes', 'requestList', 'selectedRequests']),
     selectedTubeRequests() {
       return this.selectedTubes.flatMap((tube) => {
         return this.requestList(tube.requests || [])
@@ -80,29 +79,26 @@ export default {
   methods: {
     ...mapMutations(['selectTube', 'selectRequest']),
     ...mapActions(['selectWellRequests', 'deselectTubeAndContents']),
+    ...mapGetters(['selectedTubes', 'requestList', 'selectedRequests']),
+
+    isButtonDisabled(id){     
+      return this.selectedRequests.find( (request) => request.id === id )
+    },
+
     requestClicked({ id, selected }) {
       this.selectRequest({ id, selected: !selected })
     },
 
     addTubeToPool(id) {
       this.selectRequest({ id })
-      this.disabledButtons = {
-        ...this.disabledButtons,
-        [id]: true,
-      }
     },
 
     removeTubeFromPool(id) {
       this.selectRequest({ id, selected: false })
-      this.disabledButtons = {
-        ...this.disabledButtons,
-        [id]: false,
-      }
     },
 
-    DeselectTube(id, barcode) {
+    DeselectTube(barcode) {
       this.deselectTubeAndContents(barcode)
-      delete this.disabledButtons[id]
     },
 
     rowClass(item) {

--- a/src/components/ont/OntTubeSelectedList.vue
+++ b/src/components/ont/OntTubeSelectedList.vue
@@ -32,7 +32,7 @@
             size="sm"
             class="mr-2"
             theme="default"
-            @click="DeselectTube(row.item.source_identifier)"
+            @click="deselectTubeAndContents(row.item.source_identifier)"
           >
             Remove
           </traction-button>
@@ -94,10 +94,6 @@ export default {
 
     removeTubeFromPool(id) {
       this.selectRequest({ id, selected: false })
-    },
-
-    DeselectTube(barcode) {
-      this.deselectTubeAndContents(barcode)
     },
 
     rowClass(item) {

--- a/src/components/ont/OntTubeSelectedList.vue
+++ b/src/components/ont/OntTubeSelectedList.vue
@@ -26,7 +26,6 @@
           >
             Remove
           </traction-button>
-
         </template>
       </traction-table>
     </traction-section>
@@ -73,8 +72,8 @@ export default {
     requestClicked({ id, selected }) {
       this.selectRequest({ id, selected: !selected })
     },
-    addTubeToPool(id){
-      this.selectRequest({id})
+    addTubeToPool(id) {
+      this.selectRequest({ id })
     },
     rowClass(item) {
       if (item && item.selected) {

--- a/src/components/ont/OntTubeSelectedList.vue
+++ b/src/components/ont/OntTubeSelectedList.vue
@@ -18,13 +18,23 @@
             +
           </traction-button>
           <traction-button
+            :id="'del-btn-' + row.item.id"
+            size="sm"
+            class="mr-2"
+            theme="default"
+            :disabled="!disabledButtons[row.item.id]"
+            @click="removeTubeFromPool(row.item.id)"
+          >
+            -
+          </traction-button>
+          <traction-button
             :id="'remove-btn-' + row.item.id"
             size="sm"
             class="mr-2"
             theme="default"
-            @click="removeTubeFromPool(row.item.id, row.item.source_identifier)"
+            @click="DeselectTube(row.item.id, row.item.source_identifier)"
           >
-            -
+            Remove
           </traction-button>
         </template>
       </traction-table>
@@ -82,12 +92,17 @@ export default {
       }
     },
 
-    removeTubeFromPool(id, barcode) {
-      this.deselectTubeAndContents(barcode)
+    removeTubeFromPool(id) {
+      this.selectRequest({ id, selected: false })
       this.disabledButtons = {
         ...this.disabledButtons,
         [id]: false,
       }
+    },
+
+    DeselectTube(id, barcode) {
+      this.deselectTubeAndContents(barcode)
+      delete this.disabledButtons[id]
     },
 
     rowClass(item) {

--- a/src/components/ont/OntTubeSelectedList.vue
+++ b/src/components/ont/OntTubeSelectedList.vue
@@ -84,10 +84,6 @@ export default {
       return this.selectedRequests.find((request) => request.id === id)
     },
 
-    requestClicked({ id, selected }) {
-      this.selectRequest({ id, selected: !selected })
-    },
-
     addTubeToPool(id) {
       this.selectRequest({ id })
     },

--- a/src/components/ont/OntTubeSelectedList.vue
+++ b/src/components/ont/OntTubeSelectedList.vue
@@ -5,7 +5,6 @@
         :items="selectedTubeRequests"
         :fields="requestFields"
         empty-text="No tubes selected"
-        @row-clicked="requestClicked"
       >
         <template #cell(action)="row">
           <traction-button
@@ -16,16 +15,16 @@
             :disabled="disabledButtons[row.item.id]"
             @click="addTubeToPool(row.item.id)"
           >
-            Add
+            +
           </traction-button>
           <traction-button
             :id="'remove-btn-' + row.item.id"
             size="sm"
             class="mr-2"
             theme="default"
-            @click="deselectTubeAndContents(row.item.source_identifier)"
+            @click="removeTubeFromPool(row.item.id, row.item.source_identifier)"
           >
-            Remove
+            -
           </traction-button>
         </template>
       </traction-table>
@@ -82,6 +81,15 @@ export default {
         [id]: true,
       }
     },
+
+    removeTubeFromPool(id, barcode) {
+      this.deselectTubeAndContents(barcode)
+      this.disabledButtons = {
+        ...this.disabledButtons,
+        [id]: false,
+      }
+    },
+
     rowClass(item) {
       if (item && item.selected) {
         return 'bg-gray-400'

--- a/src/components/ont/OntTubeSelectedList.vue
+++ b/src/components/ont/OntTubeSelectedList.vue
@@ -9,6 +9,15 @@
       >
         <template #cell(action)="row">
           <traction-button
+            :id="'add-btn-' + row.item.id"
+            size="sm"
+            class="mr-2"
+            theme="default"
+            @click="addTubeToPool(row.item.id)"
+          >
+            Add
+          </traction-button>
+          <traction-button
             :id="'remove-btn-' + row.item.id"
             size="sm"
             class="mr-2"
@@ -17,6 +26,7 @@
           >
             Remove
           </traction-button>
+
         </template>
       </traction-table>
     </traction-section>
@@ -62,6 +72,9 @@ export default {
     ...mapActions(['selectWellRequests', 'deselectTubeAndContents']),
     requestClicked({ id, selected }) {
       this.selectRequest({ id, selected: !selected })
+    },
+    addTubeToPool(id){
+      this.selectRequest({id})
     },
     rowClass(item) {
       if (item && item.selected) {

--- a/src/components/ont/OntTubeSelectedList.vue
+++ b/src/components/ont/OntTubeSelectedList.vue
@@ -79,7 +79,6 @@ export default {
   methods: {
     ...mapMutations(['selectTube', 'selectRequest']),
     ...mapActions(['selectWellRequests', 'deselectTubeAndContents']),
-    ...mapGetters(['selectedTubes', 'requestList', 'selectedRequests']),
 
     isButtonDisabled(id){     
       return this.selectedRequests.find( (request) => request.id === id )

--- a/src/components/ont/OntTubeSelectedList.vue
+++ b/src/components/ont/OntTubeSelectedList.vue
@@ -13,6 +13,7 @@
             size="sm"
             class="mr-2"
             theme="default"
+            :disabled="disabledButtons[row.item.id]"
             @click="addTubeToPool(row.item.id)"
           >
             Add
@@ -56,6 +57,7 @@ export default {
         { key: 'number_of_flowcells', label: 'Number of flowcells' },
         { key: 'action', label: 'Action' },
       ],
+      disabledButtons: {},
     }
   },
   computed: {
@@ -72,8 +74,13 @@ export default {
     requestClicked({ id, selected }) {
       this.selectRequest({ id, selected: !selected })
     },
+
     addTubeToPool(id) {
       this.selectRequest({ id })
+      this.disabledButtons = {
+        ...this.disabledButtons,
+        [id]: true,
+      }
     },
     rowClass(item) {
       if (item && item.selected) {

--- a/tests/unit/components/ont/OntTubeSelectedList.spec.js
+++ b/tests/unit/components/ont/OntTubeSelectedList.spec.js
@@ -97,17 +97,16 @@ describe('OntTubeSelectedList', () => {
       expect(wrapper.vm.disabledButtons[191]).toBe(true)
       addTubeToPoolSpy.mockRestore()
     }),
-
-    it('deselects the tube and request when the remove button is clicked', async () => {
-      const dispatch = vi.fn()
-      store.dispatch = dispatch
-      await nextTick()
-      const button = wrapper.find('#remove-btn-191')
-      button.trigger('click')
-      expect(dispatch).toHaveBeenCalledWith(
-        'traction/ont/pools/deselectTubeAndContents',
-        'GEN-1668092750-3',
-      )
-    })
+      it('deselects the tube and request when the remove button is clicked', async () => {
+        const dispatch = vi.fn()
+        store.dispatch = dispatch
+        await nextTick()
+        const button = wrapper.find('#remove-btn-191')
+        button.trigger('click')
+        expect(dispatch).toHaveBeenCalledWith(
+          'traction/ont/pools/deselectTubeAndContents',
+          'GEN-1668092750-3',
+        )
+      })
   })
 })

--- a/tests/unit/components/ont/OntTubeSelectedList.spec.js
+++ b/tests/unit/components/ont/OntTubeSelectedList.spec.js
@@ -97,16 +97,17 @@ describe('OntTubeSelectedList', () => {
       expect(wrapper.vm.disabledButtons[191]).toBe(true)
       addTubeToPoolSpy.mockRestore()
     }),
-      it('deselects the tube and request when the remove button is clicked', async () => {
-        const dispatch = vi.fn()
-        store.dispatch = dispatch
-        await nextTick()
-        const button = wrapper.find('#remove-btn-191')
-        button.trigger('click')
-        expect(dispatch).toHaveBeenCalledWith(
-          'traction/ont/pools/deselectTubeAndContents',
-          'GEN-1668092750-3',
-        )
-      })
+
+    it('deselects the tube and request when the remove button is clicked', async () => {
+      const dispatch = vi.fn()
+      store.dispatch = dispatch
+      await nextTick()
+      const button = wrapper.find('#remove-btn-191')
+      button.trigger('click')
+      expect(dispatch).toHaveBeenCalledWith(
+        'traction/ont/pools/deselectTubeAndContents',
+        'GEN-1668092750-3',
+      )
+    })
   })
 })

--- a/tests/unit/components/ont/OntTubeSelectedList.spec.js
+++ b/tests/unit/components/ont/OntTubeSelectedList.spec.js
@@ -96,8 +96,7 @@ describe('OntTubeSelectedList', () => {
       expect(removeTubeFromPoolSpy).toHaveBeenCalledWith('191')
       removeTubeFromPoolSpy.mockRestore()
     }),
-      
-    it('deselects the tube and request when the remove button is clicked', async () => {
+      it('deselects the tube and request when the remove button is clicked', async () => {
         const dispatch = vi.fn()
         store.dispatch = dispatch
         await nextTick()

--- a/tests/unit/components/ont/OntTubeSelectedList.spec.js
+++ b/tests/unit/components/ont/OntTubeSelectedList.spec.js
@@ -96,7 +96,8 @@ describe('OntTubeSelectedList', () => {
       expect(removeTubeFromPoolSpy).toHaveBeenCalledWith('191')
       removeTubeFromPoolSpy.mockRestore()
     }),
-      it('deselects the tube and request when the remove button is clicked', async () => {
+      
+    it('deselects the tube and request when the remove button is clicked', async () => {
         const dispatch = vi.fn()
         store.dispatch = dispatch
         await nextTick()

--- a/tests/unit/components/ont/OntTubeSelectedList.spec.js
+++ b/tests/unit/components/ont/OntTubeSelectedList.spec.js
@@ -58,7 +58,7 @@ describe('OntTubeSelectedList', () => {
       expect(wrapper.find('tbody').findAll('td')[3].text()).toEqual('basecalls')
       expect(wrapper.find('tbody').findAll('td')[4].text()).toEqual('ONT_PromethIon')
       expect(wrapper.find('tbody').findAll('td')[5].text()).toEqual('1')
-      expect(wrapper.find('tbody').findAll('td')[6].text()).toEqual('Add   Remove')
+      expect(wrapper.find('tbody').findAll('td')[6].text()).toEqual('+   -')
     })
 
     it('deselects the tube and request when the remove button is clicked', async () => {

--- a/tests/unit/components/ont/OntTubeSelectedList.spec.js
+++ b/tests/unit/components/ont/OntTubeSelectedList.spec.js
@@ -88,16 +88,25 @@ describe('OntTubeSelectedList', () => {
       expect(del_button.element.disabled).toBe(false)
     })
 
-    it('deselects the tube and request when the remove button is clicked', async () => {
-      const dispatch = vi.fn()
-      store.dispatch = dispatch
-      await nextTick()
-      const button = wrapper.find('#remove-btn-191')
-      button.trigger('click')
-      expect(dispatch).toHaveBeenCalledWith(
-        'traction/ont/pools/deselectTubeAndContents',
-        'GEN-1668092750-3',
-      )
-    })
+    it('call addTubeToPool when the + button is clicked', async () => {
+      const addTubeToPoolSpy = vi.spyOn(wrapper.vm, 'addTubeToPool')
+      const button = wrapper.find('#add-btn-191')
+      await button.trigger('click')
+
+      expect(addTubeToPoolSpy).toHaveBeenCalledWith('191')
+      expect(wrapper.vm.disabledButtons[191]).toBe(true)
+      addTubeToPoolSpy.mockRestore()
+    }),
+      it('deselects the tube and request when the remove button is clicked', async () => {
+        const dispatch = vi.fn()
+        store.dispatch = dispatch
+        await nextTick()
+        const button = wrapper.find('#remove-btn-191')
+        button.trigger('click')
+        expect(dispatch).toHaveBeenCalledWith(
+          'traction/ont/pools/deselectTubeAndContents',
+          'GEN-1668092750-3',
+        )
+      })
   })
 })

--- a/tests/unit/components/ont/OntTubeSelectedList.spec.js
+++ b/tests/unit/components/ont/OntTubeSelectedList.spec.js
@@ -58,7 +58,24 @@ describe('OntTubeSelectedList', () => {
       expect(wrapper.find('tbody').findAll('td')[3].text()).toEqual('basecalls')
       expect(wrapper.find('tbody').findAll('td')[4].text()).toEqual('ONT_PromethIon')
       expect(wrapper.find('tbody').findAll('td')[5].text()).toEqual('1')
-      expect(wrapper.find('tbody').findAll('td')[6].text()).toEqual('+   -')
+    })
+
+    it('it has a + button', () => {
+      const button = wrapper.findComponent('#add-btn-191')
+      expect(button.element).toBeTruthy()
+      expect(button.element.disabled).toBe(false)
+    })
+
+    it('it has a - button', () => {
+      const button = wrapper.findComponent('#del-btn-191')
+      expect(button.element).toBeTruthy()
+      expect(button.element.disabled).toBe(true)
+    })
+
+    it('it has a Remove button', () => {
+      const button = wrapper.findComponent('#remove-btn-191')
+      expect(button.element).toBeTruthy()
+      expect(button.element.disabled).toBe(false)
     })
 
     it('deselects the tube and request when the remove button is clicked', async () => {

--- a/tests/unit/components/ont/OntTubeSelectedList.spec.js
+++ b/tests/unit/components/ont/OntTubeSelectedList.spec.js
@@ -78,6 +78,16 @@ describe('OntTubeSelectedList', () => {
       expect(button.element.disabled).toBe(false)
     })
 
+    it('disable + button, enable - button after + is clicked', async () => {
+      const add_button = wrapper.find('#add-btn-191')
+      const del_button = wrapper.find('#del-btn-191')
+      expect(add_button.element).toBeTruthy()
+      expect(del_button.element).toBeTruthy()
+      await add_button.trigger('click')
+      expect(add_button.element.disabled).toBe(true)
+      expect(del_button.element.disabled).toBe(false)
+    })
+
     it('deselects the tube and request when the remove button is clicked', async () => {
       const dispatch = vi.fn()
       store.dispatch = dispatch

--- a/tests/unit/components/ont/OntTubeSelectedList.spec.js
+++ b/tests/unit/components/ont/OntTubeSelectedList.spec.js
@@ -58,7 +58,7 @@ describe('OntTubeSelectedList', () => {
       expect(wrapper.find('tbody').findAll('td')[3].text()).toEqual('basecalls')
       expect(wrapper.find('tbody').findAll('td')[4].text()).toEqual('ONT_PromethIon')
       expect(wrapper.find('tbody').findAll('td')[5].text()).toEqual('1')
-      expect(wrapper.find('tbody').findAll('td')[6].text()).toEqual('Remove')
+      expect(wrapper.find('tbody').findAll('td')[6].text()).toEqual('Add   Remove')
     })
 
     it('deselects the tube and request when the remove button is clicked', async () => {

--- a/tests/unit/components/ont/OntTubeSelectedList.spec.js
+++ b/tests/unit/components/ont/OntTubeSelectedList.spec.js
@@ -63,13 +63,13 @@ describe('OntTubeSelectedList', () => {
     it('it has a + button', () => {
       const button = wrapper.findComponent('#add-btn-191')
       expect(button.element).toBeTruthy()
-      expect(button.element.disabled).toBe(false)
+      expect(button.element.disabled).toBe(true)
     })
 
     it('it has a - button', () => {
       const button = wrapper.findComponent('#del-btn-191')
       expect(button.element).toBeTruthy()
-      expect(button.element.disabled).toBe(true)
+      expect(button.element.disabled).toBe(false)
     })
 
     it('it has a Remove button', () => {
@@ -88,14 +88,13 @@ describe('OntTubeSelectedList', () => {
       expect(del_button.element.disabled).toBe(false)
     })
 
-    it('call addTubeToPool when the + button is clicked', async () => {
-      const addTubeToPoolSpy = vi.spyOn(wrapper.vm, 'addTubeToPool')
-      const button = wrapper.find('#add-btn-191')
+    it('call removeTubeFromPool when the - button is clicked', async () => {
+      const removeTubeFromPoolSpy = vi.spyOn(wrapper.vm, 'removeTubeFromPool')
+      const button = wrapper.find('#del-btn-191')
       await button.trigger('click')
 
-      expect(addTubeToPoolSpy).toHaveBeenCalledWith('191')
-      expect(wrapper.vm.disabledButtons[191]).toBe(true)
-      addTubeToPoolSpy.mockRestore()
+      expect(removeTubeFromPoolSpy).toHaveBeenCalledWith('191')
+      removeTubeFromPoolSpy.mockRestore()
     }),
       it('deselects the tube and request when the remove button is clicked', async () => {
         const dispatch = vi.fn()


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request
adding a '+' & '-' button to the 'Actions' column of the selected tubes table, replacing the row 'click' function for adding/remove tube to pool
- 

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
