### PR TITLE
Y24-227 - Removed feature flags for volume tracking

### DIFF
--- a/src/components/pacbio/PacbioPoolEdit.vue
+++ b/src/components/pacbio/PacbioPoolEdit.vue
@@ -51,40 +51,26 @@
                   />
                 </traction-field-error>
               </fieldset>
-              <flagged-feature name="y24_154_enable_used_volume_display_pool_edit">
-                <template #disabled>
-                  <fieldset class="flex flex-col">
-                    <traction-label class="h-full">Volume</traction-label>
-                    <traction-field-error
-                      data-attribute="pool-volume-error"
-                      :error="poolErrorsFor('volume')"
-                      :with-icon="!!pool.errors?.volume"
-                    >
-                      <traction-input v-model="volume" data-attribute="volume" />
-                    </traction-field-error>
-                  </fieldset>
-                </template>
-                <fieldset class="flex flex-col">
-                  <div class="flex flex-row pb-6">
-                    <traction-label class="h-full">Volume</traction-label>
-                    <traction-tooltip
-                      v-if="pool.used_volume != null && persisted"
-                      :tooltip-text="'Used volume is ' + pool.used_volume"
-                    >
-                      <traction-badge id="pool-used-volume" colour="sanger-pink"
-                        ><TractionInfoIcon class="mr-2" />{{ pool.used_volume }}</traction-badge
-                      >
-                    </traction-tooltip>
-                  </div>
-                  <traction-field-error
-                    data-attribute="pool-volume-error"
-                    :error="poolErrorsFor('volume')"
-                    :with-icon="!!pool.errors?.volume"
+              <fieldset class="flex flex-col">
+                <div class="flex flex-row pb-6">
+                  <traction-label class="h-full">Volume</traction-label>
+                  <traction-tooltip
+                    v-if="pool.used_volume != null && persisted"
+                    :tooltip-text="'Used volume is ' + pool.used_volume"
                   >
-                    <traction-input v-model="volume" data-attribute="volume" />
-                  </traction-field-error>
-                </fieldset>
-              </flagged-feature>
+                    <traction-badge id="pool-used-volume" colour="sanger-pink"
+                      ><TractionInfoIcon class="mr-2" />{{ pool.used_volume }}</traction-badge
+                    >
+                  </traction-tooltip>
+                </div>
+                <traction-field-error
+                  data-attribute="pool-volume-error"
+                  :error="poolErrorsFor('volume')"
+                  :with-icon="!!pool.errors?.volume"
+                >
+                  <traction-input v-model="volume" data-attribute="volume" />
+                </traction-field-error>
+              </fieldset>
               <fieldset class="flex flex-col">
                 <traction-label class="h-full">Concentration</traction-label>
                 <traction-field-error

--- a/src/components/pacbio/PacbioRunWellEdit.vue
+++ b/src/components/pacbio/PacbioRunWellEdit.vue
@@ -45,7 +45,6 @@
             @update:model-value="updateUsedAliquotVolume(row, $event)"
           ></traction-input>
           <div
-            v-if="showAvailableVolume(row.item)"
             class="flex items-center"
             data-attribute="available-volume-div"
           >
@@ -149,9 +148,6 @@ const validLocalUsedAliquots = computed(() => {
 })
 
 // Computed property to show the available volume badge unless the aliquot is a pool and the feature flag is disabled
-const showAvailableVolume = (aliquot) => {
-  return aliquot.source_type == 'Pacbio::Library' || aliquot.source_type == 'Pacbio::Pool'
-}
 
 // Define a computed property to determine the action for the modal which is either create or update
 const action = computed(() => {
@@ -323,9 +319,6 @@ const setupWell = async () => {
 const errorsFor = (aliquot, attribute) => {
   if (aliquot && attribute) {
     // If we aren't showing available volume we also don't need to validate the volume
-    if (!showAvailableVolume(aliquot)) {
-      return
-    }
     aliquot.validateField(attribute, aliquot[attribute])
     return aliquot.errors?.[attribute]
   }

--- a/src/components/pacbio/PacbioRunWellEdit.vue
+++ b/src/components/pacbio/PacbioRunWellEdit.vue
@@ -44,10 +44,7 @@
             placeholder="Pool/Library volume"
             @update:model-value="updateUsedAliquotVolume(row, $event)"
           ></traction-input>
-          <div
-            class="flex items-center"
-            data-attribute="available-volume-div"
-          >
+          <div class="flex items-center" data-attribute="available-volume-div">
             <traction-tooltip
               :tooltip-text="'Available volume is ' + row.item.available_volume"
               class="flex max-w-xs"

--- a/src/components/pacbio/PacbioRunWellEdit.vue
+++ b/src/components/pacbio/PacbioRunWellEdit.vue
@@ -95,7 +95,6 @@ import { usePacbioRunCreateStore } from '@/stores/pacbioRunCreate.js'
 import { ref, computed, reactive } from 'vue'
 import useAlert from '@/composables/useAlert.js'
 import { createUsedAliquot } from '@/stores/utilities/usedAliquot.js'
-import { checkFeatureFlag } from '@/api/FeatureFlag.js'
 
 // Create a store instance of the pacbioRunCreateStore
 const store = usePacbioRunCreateStore()
@@ -128,8 +127,6 @@ const isShow = ref(false)
 const position = ref('')
 // plateNumber ref to store the plate number of the well
 const plateNumber = ref('')
-// Feature flag to enable volume validation for pools
-const pool_volume_validation_flag = ref(false)
 
 /* Define a regex to validate the loading target value for the well
  * The regex validates the loading target value to be a decimal percentage with a maximum of 2 decimal places
@@ -153,10 +150,7 @@ const validLocalUsedAliquots = computed(() => {
 
 // Computed property to show the available volume badge unless the aliquot is a pool and the feature flag is disabled
 const showAvailableVolume = (aliquot) => {
-  return (
-    aliquot.source_type == 'Pacbio::Library' ||
-    (aliquot.source_type == 'Pacbio::Pool' && pool_volume_validation_flag.value)
-  )
+  return aliquot.source_type == 'Pacbio::Library' || aliquot.source_type == 'Pacbio::Pool'
 }
 
 // Define a computed property to determine the action for the modal which is either create or update
@@ -298,9 +292,6 @@ const updateUsedAliquotSource = async (row, barcode) => {
  * This function is called when the modal is shown for a specific position and plate number.
  */
 const setupWell = async () => {
-  pool_volume_validation_flag.value = await checkFeatureFlag(
-    'y24_155_pacbio_run_pool_volume_validation',
-  )
   // We clone the well as it gets binded to the form and we don't want to change the original object
   // without a confirmation action like the 'update' button
   Object.assign(well, await store.getOrCreateWell(position.value, plateNumber.value))

--- a/tests/e2e/specs/pacbio/pacbio_run_create.cy.js
+++ b/tests/e2e/specs/pacbio/pacbio_run_create.cy.js
@@ -34,10 +34,6 @@ describe('Pacbio Run Create view', () => {
         data: {},
       },
     })
-
-    cy.withFlags({
-      y24_155_pacbio_run_pool_volume_validation: { enabled: true },
-    })
   })
 
   it('Creates a Sequel IIe run successfully - v11', () => {

--- a/tests/e2e/specs/pacbio/pacbio_run_edit.cy.js
+++ b/tests/e2e/specs/pacbio/pacbio_run_edit.cy.js
@@ -9,9 +9,6 @@ describe('Pacbio Run Edit view', () => {
       statusCode: 200,
       body: PacbioSmrtLinkVersionFactory().content,
     })
-    cy.withFlags({
-      y24_155_pacbio_run_pool_volume_validation: { enabled: true },
-    })
   })
 
   it('Updates a Revio run successfully', () => {

--- a/tests/unit/components/pacbio/PacbioPoolEdit.spec.js
+++ b/tests/unit/components/pacbio/PacbioPoolEdit.spec.js
@@ -51,9 +51,7 @@ function mountWithStore({ state = {}, stubActions = false, plugins = [], props }
 vi.mock('swrv', () => ({
   default: vi.fn(() => ({
     data: {
-      features: {
-        y24_154_enable_used_volume_display_pool_edit: { enabled: true },
-      },
+      features: {},
     },
   })),
 }))

--- a/tests/unit/components/pacbio/PacbioRunWellEdit.spec.js
+++ b/tests/unit/components/pacbio/PacbioRunWellEdit.spec.js
@@ -570,15 +570,7 @@ describe('PacbioRunWellEdit', () => {
         expect(wrapper.find('[data-action=remove-row]').exists()).toBeTruthy()
       })
 
-      it('does not have an available volume badge if it is a pool aliquot and showAvailableVolume returns false', async () => {
-        wrapper.vm.showAvailableVolume = vi.fn().mockReturnValue(false)
-        // Refresh the component
-        await wrapper.vm.showModalForPositionAndPlate('A1', 1)
-
-        expect(wrapper.find('[data-attribute=available-volume-div]').exists()).toBeFalsy()
-      })
-
-      it('has an available volume badge if it is a pool and showAvailableVolume returns true', async () => {
+      it('has an available volume badge if it is a pool', async () => {
         wrapper.vm.localUsedAliquots[0].available_volume = 5
         await nextTick()
         expect(wrapper.find('[data-attribute=available-volume-div]').exists()).toBeTruthy()


### PR DESCRIPTION
Closes https://github.com/sanger/traction-service/issues/1376

#### Changes proposed in this pull request

- Removed feature flag for volume tracking: `y24_154_enable_used_volume_display_pool_edit`
- Removed feature flag for volume tracking: `y24_155_pacbio_run_pool_volume_validation`

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
