### PR TITLE
Y24-312 fix pool aliquots from plates not persisted correctly

### DIFF
--- a/src/components/pacbio/PacbioWellItem.vue
+++ b/src/components/pacbio/PacbioWellItem.vue
@@ -104,7 +104,7 @@ const getRequest = computed(() => {
   return props.requests.length
     ? pacbioPoolCreateStore.requestList({
         requests: props.requests,
-        source_id: props.requests[0],
+        source_id: props.sourceId,
       })[0]
     : ''
 })

--- a/src/components/pacbio/PacbioWellItem.vue
+++ b/src/components/pacbio/PacbioWellItem.vue
@@ -102,7 +102,10 @@ const pacbioPoolCreateStore = usePacbioPoolCreateStore()
 
 const getRequest = computed(() => {
   return props.requests.length
-    ? pacbioPoolCreateStore.requestList({ requests: props.requests, source_id: props.sourceId })[0]
+    ? pacbioPoolCreateStore.requestList({
+        requests: props.requests,
+        source_id: props.requests[0],
+      })[0]
     : ''
 })
 

--- a/src/stores/pacbioPoolCreate.js
+++ b/src/stores/pacbioPoolCreate.js
@@ -515,7 +515,7 @@ export const usePacbioPoolCreateStore = defineStore('pacbioPoolCreate', {
       for (const requestId of requests) {
         this.selectRequestInSource({
           request: requestId,
-          source_id: tube.libraries? String(tube.source_id): requestId,
+          source_id: tube.libraries ? String(tube.source_id) : requestId,
           selected: false,
         })
       }
@@ -988,7 +988,7 @@ export const usePacbioPoolCreateStore = defineStore('pacbioPoolCreate', {
       const library = Object.values(this.resources.libraries).find(
         (library) => library.id == source_id,
       )
-      // Just to make sure the aliquot source id is library id if the request is from library otherwise request id
+      // Ensure the aliquot source id is library id if the request is from library otherwise request id
       const aliquot_source_id = library ? source_id : request
 
       if (selected) {

--- a/src/stores/pacbioPoolCreate.js
+++ b/src/stores/pacbioPoolCreate.js
@@ -442,8 +442,8 @@ export const usePacbioPoolCreateStore = defineStore('pacbioPoolCreate', {
       const { requests } = this.resources.wells[well_id]
       const selectedUsedAliquotRequests = this.used_aliquots
       for (const id of requests) {
-        const selected = !!selectedUsedAliquotRequests[`_${well_id}`]
-        this.selectRequestInSource({ request: id, source_id: String(well_id), selected: !selected })
+        const selected = !!selectedUsedAliquotRequests[`_${id}`]
+        this.selectRequestInSource({ request: id, source_id: id, selected: !selected })
       }
     },
 

--- a/src/views/pacbio/PacbioPoolCreate.vue
+++ b/src/views/pacbio/PacbioPoolCreate.vue
@@ -165,10 +165,11 @@ const handleAliquotSelection = (aliquot) => {
     aliquotSelectionHighlightLabware.value = null
     return
   }
-  let labware = pacbioPoolCreateStore.selectedTubes.find((tube) =>
-    aliquot.source_type === 'Pacbio::Request'
-      ? tube.requests[0] === aliquot.source_id //this is a sample tube
-      : tube.source_id === aliquot.source_id, //this is a library tube
+  let labware = pacbioPoolCreateStore.selectedTubes.find(
+    (tube) =>
+      aliquot.source_type === 'Pacbio::Request'
+        ? tube.requests[0] === aliquot.source_id //this is a sample tube
+        : tube.source_id === aliquot.source_id, //this is a library tube
   )
   if (!labware) {
     labware = pacbioPoolCreateStore.selectedPlates.find((plate) =>

--- a/src/views/pacbio/PacbioPoolCreate.vue
+++ b/src/views/pacbio/PacbioPoolCreate.vue
@@ -170,9 +170,9 @@ const handleAliquotSelection = (aliquot) => {
   )
   if (!labware) {
     labware = pacbioPoolCreateStore.selectedPlates.find((plate) =>
-      pacbioPoolCreateStore
-        .wellList(plate.wells || [])
-        .some((well) => well.id === aliquot.source_id),
+      Object.values(pacbioPoolCreateStore.resources.wells).some((well) => 
+         well.requests[0] === aliquot.source_id && well.plate === plate.id
+      ),
     )
   }
   aliquotSelectionHighlightLabware.value = { labware, aliquot }

--- a/src/views/pacbio/PacbioPoolCreate.vue
+++ b/src/views/pacbio/PacbioPoolCreate.vue
@@ -165,13 +165,15 @@ const handleAliquotSelection = (aliquot) => {
     aliquotSelectionHighlightLabware.value = null
     return
   }
-  let labware = pacbioPoolCreateStore.selectedTubes.find(
-    (tube) => tube.source_id === aliquot.source_id,
+  let labware = pacbioPoolCreateStore.selectedTubes.find((tube) =>
+    aliquot.source_type === 'Pacbio::Request'
+      ? tube.requests[0] === aliquot.source_id //this is a sample tube
+      : tube.source_id === aliquot.source_id, //this is a library tube
   )
   if (!labware) {
     labware = pacbioPoolCreateStore.selectedPlates.find((plate) =>
-      Object.values(pacbioPoolCreateStore.resources.wells).some((well) => 
-         well.requests[0] === aliquot.source_id && well.plate === plate.id
+      Object.values(pacbioPoolCreateStore.resources.wells).some(
+        (well) => well.requests[0] === aliquot.source_id && well.plate === plate.id,
       ),
     )
   }

--- a/tests/unit/components/pacbio/PacbioLabwareSelectedList.spec.js
+++ b/tests/unit/components/pacbio/PacbioLabwareSelectedList.spec.js
@@ -291,7 +291,7 @@ describe('PacbioLabwareSelectedList', () => {
           expect.objectContaining({
             request: '241',
             selected: false,
-            source_id: '1',
+            source_id: '241',
           }),
         )
       })
@@ -301,7 +301,7 @@ describe('PacbioLabwareSelectedList', () => {
         expect(store.selectRequestInSource).toHaveBeenCalledWith(
           expect.objectContaining({
             request: '40',
-            source_id: '4722',
+            source_id: '40',
             selected: true,
           }),
         )

--- a/tests/unit/stores/pacbioPoolCreate.spec.js
+++ b/tests/unit/stores/pacbioPoolCreate.spec.js
@@ -545,7 +545,7 @@ describe('usePacbioPoolCreateStore', () => {
         expect(store.selectRequestInSource).toBeCalledWith({
           selected: false,
           request: '98',
-          source_id: '2',
+          source_id: '98',
         })
       })
 


### PR DESCRIPTION
Closes #https://github.com/sanger/traction-ui/issues/1927

#### Changes proposed in this pull request
The bug was caused by passing the wrong source_id for plate wells and sample tubes. The following changes ensure that the source_id passed to create aliquots will be the request ID for all non-library tube and plate requests. For library tube requests, the source_id passed to create aliquots will be the library ID.

selectRequestInSource has been refactored to ensure that the source_id is set correctly.
requestList has been refactored to ensure that the correct source_id is retrieved.
Other updates related to selection have been made as a result of the above refactoring.
#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
