### PR TITLE
Y24-343 - Pacbio runs store migration from Axios to fetch

### DIFF
--- a/src/stores/pacbioRuns.js
+++ b/src/stores/pacbioRuns.js
@@ -15,7 +15,7 @@ export const usePacbioRunsStore = defineStore('pacbioRuns', {
   },
 
   actions: {
-    async fetchPacbioRuns(filter, page) {
+    async fetchPacbioRuns(filter = {}, page = {}) {
       const promise = this.runRequest.get({ page, filter, include: 'plates' })
       const response = await handleResponse(promise)
       const { success, body: { data, included = [], meta = {} } = {}, errors = [] } = response

--- a/src/stores/pacbioRuns.js
+++ b/src/stores/pacbioRuns.js
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia'
-import { handleResponse } from '@/api/v1/ResponseHelper'
+import { handleResponse } from '@/api/v2/ResponseHelper'
 import { dataToObjectById, extractAttributes } from '@/api/JsonApi'
 import store from '@/store'
 
@@ -11,20 +11,22 @@ export const usePacbioRunsStore = defineStore('pacbioRuns', {
     runsArray: (state) => Object.values(state.runs),
     /*Pinia_migration_todo: This is migrated from the VueX store now, but it can be changed to a Pinia store, 
      once the VueX root store is converted to Pinia*/
-    runRequest: () => store.state.api.v1.traction.pacbio.runs,
+    runRequest: () => store.state.api.v2.traction.pacbio.runs,
   },
 
   actions: {
     async fetchPacbioRuns(filter, page) {
       const promise = this.runRequest.get({ page, filter, include: 'plates' })
       const response = await handleResponse(promise)
-      const { success, data: { data, included = [], meta = {} } = {}, errors = [] } = response
+      const { success, body: { data, included = [], meta = {} } = {}, errors = [] } = response
 
       //TODO:- Two calls to dataToObjectById method - optimization or refactoring required?
       const platesById = dataToObjectById({ data: included })
 
       if (success) {
         // Concatenate SKBB info for a run
+        // this is a bit of a code smell. We shoud either do this in the API or in the view.
+        // It is difficult to use the factories to do this.
         data.map((run) => {
           const runPlateIds = run.relationships.plates.data.map((p) => p.id)
           const sequencing_kit_box_barcodes = runPlateIds.map((plateId) => {
@@ -54,7 +56,7 @@ export const usePacbioRunsStore = defineStore('pacbioRuns', {
       const promise = this.runRequest.update(payload)
       const response = await handleResponse(promise)
 
-      const { success, data: { data } = {}, errors = [] } = response
+      const { success, body: { data } = {}, errors = [] } = response
 
       if (success) {
         // This updates the store to reflect the state change

--- a/tests/e2e/specs/pacbio/pacbio_runs_view.cy.js
+++ b/tests/e2e/specs/pacbio/pacbio_runs_view.cy.js
@@ -14,11 +14,6 @@ describe('Pacbio Runs view', () => {
         body: pacbioRunFactory.content,
       })
     })
-    // cy.intercept('/v1/pacbio/runs?page[size]=25&page[number]=1&include=plates', {
-    //   // has a record which has a run with no smrt link version
-    //   // probably best to fix when moving to factory
-    //   fixture: 'tractionPacbioRuns.json',
-    // })
     cy.get('@pacbioSmrtLinkVersionFactory').then((pacbioSmrtLinkVersionFactory) => {
       cy.intercept('GET', '/v1/pacbio/smrt_link_versions', {
         statusCode: 200,

--- a/tests/e2e/specs/pacbio/pacbio_runs_view.cy.js
+++ b/tests/e2e/specs/pacbio/pacbio_runs_view.cy.js
@@ -1,16 +1,24 @@
 import PacbioSmrtLinkVersionFactory from '../../../factories/PacbioSmrtLinkVersionFactory.js'
+import PacbioRunFactory from '../../../factories/PacbioRunFactory.js'
 
 describe('Pacbio Runs view', () => {
   beforeEach(() => {
     cy.wrap(PacbioSmrtLinkVersionFactory()).as('pacbioSmrtLinkVersionFactory')
+    cy.wrap(PacbioRunFactory()).as('pacbioRunFactory')
   })
 
   it('Visits the pacbio runs url', () => {
-    cy.intercept('/v1/pacbio/runs?page[size]=25&page[number]=1&include=plates', {
-      // has a record which has a run with no smrt link version
-      // probably best to fix when moving to factory
-      fixture: 'tractionPacbioRuns.json',
+    cy.get('@pacbioRunFactory').then((pacbioRunFactory) => {
+      cy.intercept('GET', '/v1/pacbio/runs?page[size]=25&page[number]=1&include=plates', {
+        statusCode: 200,
+        body: pacbioRunFactory.content,
+      })
     })
+    // cy.intercept('/v1/pacbio/runs?page[size]=25&page[number]=1&include=plates', {
+    //   // has a record which has a run with no smrt link version
+    //   // probably best to fix when moving to factory
+    //   fixture: 'tractionPacbioRuns.json',
+    // })
     cy.get('@pacbioSmrtLinkVersionFactory').then((pacbioSmrtLinkVersionFactory) => {
       cy.intercept('GET', '/v1/pacbio/smrt_link_versions', {
         statusCode: 200,
@@ -23,9 +31,9 @@ describe('Pacbio Runs view', () => {
     cy.get('#filterValue').should('be.visible')
     cy.get('#filterValue').children().and('contain', 'Name')
     cy.get('#run-index').contains('tr', '5')
-    cy.get('#startRun-12')
-    cy.get('#editRun-12')
-    cy.get('#generate-sample-sheet-12')
+    cy.get('#completeRun-2')
+    cy.get('#editRun-2')
+    cy.get('#generate-sample-sheet-2')
     cy.get('#run-index')
       .first()
       .within(() => {

--- a/tests/factories/PacbioRunFactory.js
+++ b/tests/factories/PacbioRunFactory.js
@@ -1,4 +1,9 @@
 import BaseFactory from './BaseFactory.js'
+import { extractAttributes } from './../../src/api/JsonApi'
+
+const createStoreData = (data) => {
+  return data.map((item) => extractAttributes(item))
+}
 
 /*
  * Factory for creating a list of runs
@@ -255,7 +260,9 @@ const PacbioRunFactory = () => {
     },
   }
 
-  return BaseFactory(data)
+  // return BaseFactory(data)
+
+  return { ...BaseFactory(data), storeData: createStoreData(data.data) }
 }
 
 export default PacbioRunFactory

--- a/tests/support/testHelper.js
+++ b/tests/support/testHelper.js
@@ -46,6 +46,49 @@ const findByText = (wrapper, text) => {
   return results.at(0)
 }
 
+/**
+ *
+ * @param {String} statusCode - status code of the response. Should be in the 200 range.
+ * @param {Object} data - data to be returned in the response
+ * @param {Array} included - included data to be returned in the response
+ * @returns {Object} - a successful response object (fetch)
+ * A standard response object that can be used to mock a successful fetch response.
+ */
+const successfulResponse = ({ statusCode = 201, data = {}, included = [] } = {}) => {
+  return {
+    status: statusCode,
+    statusText: 'OK',
+    json: () =>
+      Promise.resolve({
+        data,
+        included,
+      }),
+    ok: true,
+  }
+}
+
+/**
+ *
+ * @param {String} statusCode - status code of the response. Should be in the 400 or 500 range.
+ * @returns {Object} - a failed response object (fetch)
+ * A standard response object that can be used to mock a failed fetch response.
+ */
+const failedResponse = (statusCode = 500) => {
+  const statusTypes = {
+    422: { status: 422, statusText: 'Unprocessable Entity' },
+    500: { status: 500, statusText: 'Internal Server Error' },
+  }
+  return {
+    ...statusTypes[statusCode],
+    json: () =>
+      Promise.resolve({
+        errors: [{ title: 'error1', detail: 'There was an error.' }],
+      }),
+    ok: false,
+    errorSummary: 'error1 There was an error.',
+  }
+}
+
 export {
   mount,
   store,
@@ -59,4 +102,6 @@ export {
   createTestingPinia,
   findAllByText,
   findByText,
+  successfulResponse,
+  failedResponse,
 }

--- a/tests/unit/store/traction/ont/pools/actions.spec.js
+++ b/tests/unit/store/traction/ont/pools/actions.spec.js
@@ -7,7 +7,8 @@ import OntRequestFactory from '@tests/factories/OntRequestFactory.js'
 import OntPoolFactory from '@tests/factories/OntPoolFactory.js'
 import OntPlateFactory from '@tests/factories/OntPlateFactory.js'
 import OntTubeFactory from '@tests/factories/OntTubeFactory.js'
-import OntAutoTagFactory from '../../../../../factories/OntAutoTagFactory'
+import OntAutoTagFactory from '@tests/factories/OntAutoTagFactory'
+import { successfulResponse, failedResponse } from '@tests/support/testHelper'
 
 const ontTagSetFactory = OntTagSetFactory()
 const ontRequestFactory = OntRequestFactory()
@@ -19,35 +20,6 @@ const singleOntPoolFactory = OntPoolFactory({ all: false, first: 1 })
 const ontPlateFactory = OntPlateFactory({ all: false, first: 1 })
 const ontTubeFactory = OntTubeFactory({ all: false, first: 1 })
 const ontAutoTagFactory = OntAutoTagFactory()
-
-const successResponse = ({ status = '201', data = {}, included = [] } = {}) => {
-  return {
-    status,
-    statusText: 'OK',
-    json: () =>
-      Promise.resolve({
-        data,
-        included,
-      }),
-    ok: true,
-  }
-}
-
-const failureResponse = (statusCode = 500) => {
-  const statusTypes = {
-    422: { status: 422, statusText: 'Unprocessable Entity' },
-    500: { status: 500, statusText: 'Internal Server Error' },
-  }
-  return {
-    ...statusTypes[statusCode],
-    json: () =>
-      Promise.resolve({
-        errors: [{ title: 'error1', detail: 'There was an error.' }],
-      }),
-    ok: false,
-    errorSummary: 'error1 There was an error.',
-  }
-}
 
 describe('actions.js', () => {
   const {
@@ -86,7 +58,7 @@ describe('actions.js', () => {
       // mock dependencies
       const get = vi.fn()
       const rootState = { api: { v2: { traction: { ont: { requests: { get } } } } } }
-      get.mockRejectedValue(failureResponse)
+      get.mockResolvedValue(failedResponse)
 
       // apply action
       const { success } = await fetchOntRequests({ commit, rootState })
@@ -122,7 +94,7 @@ describe('actions.js', () => {
       // mock dependencies
       const get = vi.fn()
       const rootState = { api: { v2: { traction: { ont: { pools: { get } } } } } }
-      get.mockRejectedValue(failureResponse)
+      get.mockResolvedValue(failedResponse)
       // apply action
       const { success } = await fetchOntPools({ commit, rootState })
       // assert result (Might make sense to pull these into separate tests)
@@ -153,7 +125,7 @@ describe('actions.js', () => {
       // mock dependencies
       const get = vi.fn()
       const rootState = { api: { v2: { traction: { ont: { tag_sets: { get } } } } } }
-      get.mockRejectedValue(failureResponse)
+      get.mockResolvedValue(failedResponse)
       // apply action
       const { success } = await fetchOntTagSets({ commit, rootState })
       // assert result
@@ -274,7 +246,7 @@ describe('actions.js', () => {
 
     // pool should be successfully created
     it('when the pool is valid', async () => {
-      const mockResponse = successResponse({
+      const mockResponse = successfulResponse({
         data: {},
         included: [{ type: 'tubes', attributes: { barcode: 'TRAC-1' } }],
       })
@@ -297,7 +269,7 @@ describe('actions.js', () => {
     })
 
     it('when there is an error', async () => {
-      const mockResponse = failureResponse(422)
+      const mockResponse = failedResponse(422)
 
       // mock dependencies
       const update = vi.fn(() => Promise.resolve(mockResponse))
@@ -365,7 +337,7 @@ describe('actions.js', () => {
     // pool should be successfully created
     it('when the pool is valid', async () => {
       // mock response
-      const mockResponse = successResponse({
+      const mockResponse = successfulResponse({
         data: {},
         included: [{ type: 'tubes', attributes: { barcode: 'TRAC-1' } }],
       })
@@ -382,7 +354,7 @@ describe('actions.js', () => {
 
     it('when there is an error', async () => {
       // mock response
-      const mockResponse = failureResponse(422)
+      const mockResponse = failedResponse(422)
       // mock dependencies
       const update = vi.fn(() => Promise.resolve(mockResponse))
       const rootState = { api: { v2: { traction: { ont: { pools: { update } } } } } }
@@ -856,7 +828,7 @@ describe('actions.js', () => {
       const get = vi.fn()
       const rootState = { api: { v2: { traction: { ont: { plates: { get } } } } } }
 
-      get.mockResolvedValue(successResponse({ status: '200' }))
+      get.mockResolvedValue(successfulResponse({ statusCode: 200 }))
 
       const { success, errors } = await findOntPlate(
         { commit, rootState },
@@ -910,7 +882,7 @@ describe('actions.js', () => {
       const get = vi.fn()
       const rootState = { api: { v2: { traction: { ont: { tubes: { get } } } } } }
 
-      get.mockResolvedValue(successResponse({ status: '200' }))
+      get.mockResolvedValue(successfulResponse({ statusCode: 200 }))
 
       const { success, errors } = await findOntTube(
         { commit, rootState },

--- a/tests/unit/stores/pacbioRuns.spec.js
+++ b/tests/unit/stores/pacbioRuns.spec.js
@@ -1,8 +1,7 @@
 import { usePacbioRunsStore } from '@/stores/pacbioRuns'
-import { createPinia, setActivePinia } from '@support/testHelper'
+import { createPinia, setActivePinia, failedResponse } from '@support/testHelper'
 import { beforeEach, describe } from 'vitest'
 import api from '@/api/JsonApi'
-import { newResponse } from '@/api/v1/ResponseHelper'
 import { extractAttributes } from '@/api/JsonApi'
 import PacbioRunFactory from '@tests/factories/PacbioRunFactory.js'
 
@@ -37,7 +36,7 @@ describe('usePacbioRunsStore', () => {
       it('runs successfully', async () => {
         const store = usePacbioRunsStore()
         store.runs = []
-        store.runRequest.get = vi.fn().mockReturnValue(pacbioRunsFactory.responses.axios)
+        store.runRequest.get = vi.fn().mockReturnValue(pacbioRunsFactory.responses.fetch)
         const data = pacbioRunsFactory.content.data
         api.dataToObjectById = vi.fn().mockReturnValue(data)
         const { success, errors } = await store.fetchPacbioRuns()
@@ -50,18 +49,15 @@ describe('usePacbioRunsStore', () => {
         const store = usePacbioRunsStore()
         store.runs = []
 
-        const failedResponse = {
-          data: { data: { errors: { error1: ['There was an error'] } } },
-          status: 500,
-          statusText: 'Internal Server Error',
-        }
-        store.runRequest.get = vi.fn().mockRejectedValue({ response: failedResponse })
-        const expectedResponse = newResponse({ ...failedResponse, success: false })
+        const failureResponse = failedResponse()
+
+        // fetch does not reject the promise.
+        store.runRequest.get = vi.fn().mockResolvedValue(failureResponse)
         const { success, errors } = await store.fetchPacbioRuns()
 
         expect(store.runs.length).toEqual(0)
         expect(success).toEqual(false)
-        expect(errors).toEqual(expectedResponse.errors)
+        expect(errors).toEqual(failureResponse.errorSummary)
       })
     })
     describe('updateRun', () => {
@@ -72,7 +68,7 @@ describe('usePacbioRunsStore', () => {
       it('runs successfully', async () => {
         const store = usePacbioRunsStore()
         store.runs = []
-        store.runRequest.update = vi.fn().mockReturnValue(pacbioRunsFactory.responses.axios)
+        store.runRequest.update = vi.fn().mockReturnValue(pacbioRunsFactory.responses.fetch)
         const updatedRun = pacbioRunsFactory.content.data
 
         const { success, errors } = await store.updateRun({ ...updatedRun })
@@ -82,20 +78,16 @@ describe('usePacbioRunsStore', () => {
       })
       it(' runs unsuccessfully', async () => {
         const store = usePacbioRunsStore()
+        const failureResponse = failedResponse()
         store.runs = []
-        const failedResponse = {
-          data: { data: { errors: { error1: ['There was an error'] } } },
-          status: 500,
-          statusText: 'Internal Server Error',
-        }
-        store.runRequest.update = vi.fn().mockRejectedValue({ response: failedResponse })
-        const expectedResponse = newResponse({ ...failedResponse, success: false })
+        // const failedResponse = {
+        store.runRequest.update = vi.fn().mockResolvedValue(failureResponse)
 
         const { success, errors } = await store.updateRun({ ...updatedRun })
 
         expect(store.runs.length).toEqual(0)
         expect(success).toEqual(false)
-        expect(errors).toEqual(expectedResponse.errors)
+        expect(errors).toEqual(failureResponse.errorSummary)
       })
     })
   })


### PR DESCRIPTION
- Added a new method called createStoreData to PacbioRunFactory.js
- The method takes an array of data and extracts the attributes using the extractAttributes function from JsonApi.js
- The extracted attributes are then returned as a new array
- The createStoreData method is used to create the storeData property in the returned object from PacbioRunFactory

Fix e2e test in pacbio_runs_view.cy.js

- Updated the intercept request in pacbio_runs_view.cy.js to use the PacbioRunFactory to generate the response body
- Removed the fixture and replaced it with the content property from the PacbioRunFactory

Update pacbioRuns.js to use v2 API response handling

- Updated the import statement in pacbioRuns.js to use the handleResponse function from the v2 ResponseHelper
- Updated the references to the API endpoints in pacbioRuns.js to use the v2 endpoints

Update PacbioRunIndex.spec.js to use PacbioRunFactory and PacbioSmrtLinkVersionFactory

- Updated the import statements in PacbioRunIndex.spec.js to use the PacbioRunFactory and PacbioSmrtLinkVersionFactory
- Updated the mockRuns variable to use the storeData property from the PacbioRunFactory
- Updated the spy2 function to use the responses.fetch property from the PacbioSmrtLinkVersionFactory
- Updated the initialState in the factory function to use the storeData properties from the PacbioRunFactory and PacbioSmrtLinkVersionFactory

Closes #

#### Changes proposed in this pull request

- 

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
