### PR TITLE
Bug fix param error when updating run sr 14409

### DIFF
--- a/src/stores/utilities/run.js
+++ b/src/stores/utilities/run.js
@@ -99,9 +99,18 @@ const existingRunType = {
   action: 'update',
   label: 'Update Run',
   payload({ run, plates, wells, smrtLinkVersion, instrumentType }) {
-    const { id, ...attributes } = run
+    // the type should not be in the attributes.
+    const { id, type, ...attributes } = run
 
-    return createPayload({ id, run: attributes, plates, wells, smrtLinkVersion, instrumentType })
+    return createPayload({
+      id,
+      type,
+      run: attributes,
+      plates,
+      wells,
+      smrtLinkVersion,
+      instrumentType,
+    })
   },
   // the function handle should be the same for create and update
   promise({ payload, request }) {

--- a/src/stores/utilities/run.js
+++ b/src/stores/utilities/run.js
@@ -100,6 +100,7 @@ const existingRunType = {
   label: 'Update Run',
   payload({ run, plates, wells, smrtLinkVersion, instrumentType }) {
     // the type should not be in the attributes.
+    //might need further refactoring but this is enough for a hot fix
     const { id, type, ...attributes } = run
 
     return createPayload({

--- a/tests/unit/stores/utilities/run.spec.js
+++ b/tests/unit/stores/utilities/run.spec.js
@@ -202,8 +202,9 @@ describe('run.js', () => {
 
       it('will create the correct payload', () => {
         const runType = createRunType({ id: 1 })
-        const aRun = newRun()
-        const { id, ...attributes } = aRun
+        // type should not be in attributes. Bug fix
+        const aRun = { ...newRun(), type: 'runs' }
+        const { id, type, ...attributes } = aRun
 
         expect(
           runType.payload({
@@ -216,6 +217,7 @@ describe('run.js', () => {
         ).toEqual(
           createPayload({
             id,
+            type,
             plates: plates.existing,
             wells: wells.existing,
             run: attributes,


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

- remove type from run attributes when updating a run. Prevents param error 400 bad request.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
