### PR TITLE
Y24-413 library batch create page

### DIFF
--- a/src/composables/usePacbioLibraryPrint.js
+++ b/src/composables/usePacbioLibraryPrint.js
@@ -1,0 +1,30 @@
+import { getCurrentDate } from '@/lib/DateHelpers.js'
+import { usePrintingStore } from '@/stores/printing.js'
+
+export default function usePacbioLibraryPrint() {
+  const createLabels = (printBarcodes) => {
+    const date = getCurrentDate()
+    return printBarcodes.map(({ barcode, source_identifier }) => {
+      return {
+        barcode,
+        first_line: 'Pacbio - Library',
+        second_line: date,
+        third_line: barcode,
+        fourth_line: source_identifier,
+        label_name: 'main_label',
+      }
+    })
+  }
+
+  const printLabels = async (printerName, printBarcodes) => {
+    const { createPrintJob } = usePrintingStore()
+    return await createPrintJob({
+      printerName,
+      labels: createLabels(printBarcodes),
+      copies: 1,
+    })
+  }
+  return {
+    printLabels,
+  }
+}

--- a/src/composables/usePacbioLibraryPrint.js
+++ b/src/composables/usePacbioLibraryPrint.js
@@ -1,6 +1,11 @@
 import { getCurrentDate } from '@/lib/DateHelpers.js'
 import { usePrintingStore } from '@/stores/printing.js'
 
+/**
+ * Composable function for handling Pacbio library printing.
+ * @returns {Object} - An object containing the printLabels function 
+ * 
+ */
 export default function usePacbioLibraryPrint() {
   const createLabels = (printBarcodes) => {
     const date = getCurrentDate()
@@ -16,6 +21,13 @@ export default function usePacbioLibraryPrint() {
     })
   }
 
+   /**
+   * Prints labels using the specified printer.
+   * @param {string} printerName - The name of the printer.
+   * @param {Array} printBarcodes - An array of objects containing barcode and source_identifier for each label to print.
+   * eg. [{barcode: 'TRAC-1', source_identifier: 'TRAC-1'}]
+   * @returns {Promise<Object>} - A promise that resolves to the result of the print job.
+   */
   const printLabels = async (printerName, printBarcodes) => {
     const { createPrintJob } = usePrintingStore()
     return await createPrintJob({

--- a/src/composables/usePacbioLibraryPrint.js
+++ b/src/composables/usePacbioLibraryPrint.js
@@ -3,8 +3,8 @@ import { usePrintingStore } from '@/stores/printing.js'
 
 /**
  * Composable function for handling Pacbio library printing.
- * @returns {Object} - An object containing the printLabels function 
- * 
+ * @returns {Object} - An object containing the printLabels function
+ *
  */
 export default function usePacbioLibraryPrint() {
   const createLabels = (printBarcodes) => {
@@ -21,7 +21,7 @@ export default function usePacbioLibraryPrint() {
     })
   }
 
-   /**
+  /**
    * Prints labels using the specified printer.
    * @param {string} printerName - The name of the printer.
    * @param {Array} printBarcodes - An array of objects containing barcode and source_identifier for each label to print.

--- a/src/config/PipelinesConfig.json
+++ b/src/config/PipelinesConfig.json
@@ -10,7 +10,7 @@
     "name": "pacbio",
     "title": "PacBio",
     "description": "A LIMS pipeline to support tracking for PacBio Long-Read Sequencing",
-    "routes": ["plates", "samples", "libraries", "pools", "runs", "pool/new"],
+    "routes": ["plates", "samples", "libraries", "pools", "runs", "pool/new","library-batch"],
     "active": true
   },
   {

--- a/src/config/PipelinesConfig.json
+++ b/src/config/PipelinesConfig.json
@@ -10,7 +10,7 @@
     "name": "pacbio",
     "title": "PacBio",
     "description": "A LIMS pipeline to support tracking for PacBio Long-Read Sequencing",
-    "routes": ["plates", "samples", "libraries", "pools", "runs", "pool/new","library-batch"],
+    "routes": ["plates", "samples", "libraries", "pools", "runs", "pool/new", "library-batch"],
     "active": true
   },
   {

--- a/src/lib/csv/pacbio.js
+++ b/src/lib/csv/pacbio.js
@@ -94,7 +94,7 @@ const eachRecord = (csv, callback, ...args) => {
 }
 /*
  * @param {string} csv - The CSV data as a string.
- * @param {number} column - The index of the column to extract values from.
+ * @param {number} column - The index of the column to extract values from. if column is undefined, return all columns
  * @param {boolean} [hasHeader=true] - Whether the CSV data includes a header row.
  * @returns {Array<string>} An array of values from the specified column.
  *
@@ -111,7 +111,7 @@ const getColumnValues = (csv, column, hasHeader = true) => {
 
   return data.map((line) => {
     const columns = line.split(',')
-    if(!column) return columns
+    if (column === null) return columns
     return column >= columns.length ? '' : columns[column]
   })
 }

--- a/src/lib/csv/pacbio.js
+++ b/src/lib/csv/pacbio.js
@@ -111,6 +111,7 @@ const getColumnValues = (csv, column, hasHeader = true) => {
 
   return data.map((line) => {
     const columns = line.split(',')
+    if(!column) return columns
     return column >= columns.length ? '' : columns[column]
   })
 }

--- a/src/router.js
+++ b/src/router.js
@@ -25,6 +25,7 @@ import ONTRunIndex from '@/views/ont/ONTRunIndex.vue'
 import ONTRun from '@/views/ont/ONTRun.vue'
 import ONTSampleIndex from '@/views/ont/ONTSampleIndex.vue'
 import LabwhereReception from '@/views/LabwhereReception.vue'
+import PacbioLibraryBatchCreate from '@/views/pacbio/PacbioLibraryBatchCreate.vue'
 
 // This function gets or sets the query param defaults on the route being navigated 'to'
 // This ensures DataFetcher has the correct query params when fetching initial data on page load
@@ -164,6 +165,13 @@ const router = createRouter({
           name: 'PacbioPoolCreate',
           component: PacbioPoolCreate,
           meta: { page: 'Pool' },
+        },
+        {
+          path: 'library-batch',
+          name: 'PacbioLibraryBatchCreate',
+          description: 'Create a new library batch',
+          component: PacbioLibraryBatchCreate,
+          meta: { page: 'Library Batch' },
         },
       ],
     },

--- a/src/stores/pacbioLibraryBatchCreate.js
+++ b/src/stores/pacbioLibraryBatchCreate.js
@@ -15,7 +15,7 @@ import { getColumnValues } from '@/lib/csv/pacbio.js'
  * usePacbioLibraryBatchesStore is a store to manage pacbio library batches.
  * @returns {Object} - The store object.
  */
-export const usePacbioLibraryBatchesStore = defineStore('pacbioLibraryBatches', {
+export const usePacbioLibraryBatchCreateStore = defineStore('pacbioLibraryBatchCreate', {
   state: () => ({
     /**
      * @property {Object} libraries - An object to store all libraries indexed by id.
@@ -59,7 +59,7 @@ export const usePacbioLibraryBatchesStore = defineStore('pacbioLibraryBatches', 
      * Creates a library batch from a CSV file and a tag set.
      *
      * @param {File} csvFile - The CSV file containing library batch data.
-     * @param {Object} tagSet - The tag set to validate against.
+     * @param {Object} tagSet - The tag set name to validate against.
      * @returns {Promise<Object>} - The result of the library batch creation.
      */
     async createLibraryBatch(csvFile, tagSet) {

--- a/src/stores/utilities/pacbioLibraryBatches.js
+++ b/src/stores/utilities/pacbioLibraryBatches.js
@@ -87,7 +87,7 @@ async function fetchTagsAndRequests(sources, tagSet) {
 
   promise = rootStore.api.v2.traction.pacbio.tag_sets.get({
     include: 'tags',
-    filter: { name: tagSet.name },
+    filter: { name: tagSet },
   })
   response = await handleResponse(promise)
 

--- a/src/views/pacbio/PacbioLibraryBatchCreate.vue
+++ b/src/views/pacbio/PacbioLibraryBatchCreate.vue
@@ -1,0 +1,298 @@
+<template>
+  <DataFetcher :fetcher="fetchData">
+    <div class="w-full h-screen px-4">
+      <div class="flex flex-row w-full h-full">
+        <div class="w-1/2 px-4">
+          <div class="flex flex-col space-y-4">
+            <traction-section
+              title="Create Library Batch"
+              number="1"
+              description="To get started, please select a tag set and csv file, then press Create Libraries button"
+            ></traction-section>
+            <div class="text-left px-4">
+              Select tag set
+              <traction-select
+                v-model="selectedTagSet"
+                data-type="tag-set-list"
+                :options="pacbioRootStore.tagSetChoices"
+              ></traction-select>
+            </div>
+            <div class="px-4">
+              <label class="flex text-left" for="csvFieInput">Select file</label>
+              <div class="flex flex-row space-x-2">
+                <div id="borderDiv" class="w-full">
+                  <input
+                    id="csvFileInput"
+                    ref="csvFileInput"
+                    class="block rounded border file:border-0 w-full"
+                    type="file"
+                    accept="text/csv, .csv"
+                    @change="onSelectFile"
+                  />
+                </div>
+                <traction-button
+                  data-type="csv-preview-btn"
+                  class="whitespace-nowrap"
+                  :disabled="isDisabledCSVPreview"
+                  @click="showCSVPreview = !showCSVPreview"
+                  >{{ showCSVPreview ? 'Hide CSV Data' : 'Show CSV Data' }}</traction-button
+                >
+              </div>
+            </div>
+            <div v-if="showCSVPreview" class="flex flex-row space-x-4">
+              <div class="w-full h-64 overflow-y-auto border-2" data-type="csv-preview">
+                <traction-table :fields="state.csvTableFields" :items="state.csvData" />
+              </div>
+            </div>
+            <div class="flex flex-row space-x-8 py-4">
+              <traction-button
+                id="reset"
+                full-width
+                theme="reset"
+                data-action="reset-form"
+                @click="onReset"
+              >
+                Reset
+              </traction-button>
+              <traction-button
+                id="create"
+                :disabled="isCreateDisabled"
+                full-width
+                theme="create"
+                data-action="create-libraries"
+                @click="createLibraryBatch"
+              >
+                Create Libraries
+              </traction-button>
+            </div>
+
+            <traction-section
+              title="View Created Libraries"
+              number="2"
+              description="All libraries created will be displayed here"
+            ></traction-section>
+            <div class="flex flex-row space-x-4">
+              <div class="w-full overflow-y-auto">
+                <traction-table
+                  id="library-batch-table"
+                  :fields="state.resultTableFields"
+                  :items="state.resultData"
+                />
+                <div
+                  v-show="!state.resultData.length"
+                  data-type="created-libraries"
+                  class="text-sm font-bold text-black"
+                >
+                  No Libraries Created Yet
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="w-1/2 px-4">
+          <div class="flex flex-col space-y-4">
+            <traction-section
+              title="Print Labels"
+              number="3"
+              description="Once the libraries are created, please select a printer and press the Print button"
+            ></traction-section>
+
+            <div class="text-left px-4 pb-4">
+              Select Printer
+              <traction-select
+                v-model="selectedPrinterName"
+                data-type="printer-options"
+                :options="printerOptions"
+              />
+            </div>
+
+            <div class="w-full h-full border-2">
+              <div class="w-full h-full p-4 space-y-4 rounded-md border-t-4">
+                <traction-heading level="4" show-border> Preview Barcodes </traction-heading>
+                <div class="h-full">
+                  <div class="space-x-4 pb-4 flex flex-row">
+                    <traction-button
+                      id="print-button"
+                      class="grow"
+                      :disabled="isPrintDisabled"
+                      theme="printRed"
+                      @click="onPrintAction"
+                    >
+                      Print Labels
+                    </traction-button>
+                  </div>
+
+                  <div tag="article" class="mb-2 text-black text-left">
+                    <div class="flex flex-col rounded p-4">
+                      <ul
+                        v-if="printBarcodes.length"
+                        id="list-barcodes-to-print"
+                        class="space-y-2 justify-center text-center"
+                      >
+                        <li
+                          v-for="barcode in printBarcodes"
+                          :key="barcode"
+                          class="text-sm text-sp font-bold"
+                        >
+                          {{ barcode }}
+                        </li>
+                      </ul>
+                      <div
+                        v-else
+                        data-type="empty-barcodes"
+                        class="justify-center text-center text-black text-sm font-bold"
+                      >
+                        No Barcodes to Print Yet
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </DataFetcher>
+</template>
+
+<script setup>
+import { usePacbioRootStore } from '@/stores/pacbioRoot.js'
+import { usePrintingStore } from '@/stores/printing.js'
+import { usePacbioLibraryBatchCreateStore } from '@/stores/pacbioLibraryBatchCreate.js'
+import { computed, ref, reactive } from 'vue'
+import DataFetcher from '@/components/DataFetcher.vue'
+import { eachRecord } from '@/lib/csv/pacbio.js'
+import useAlert from '@/composables/useAlert.js'
+import usePacbioLibraryPrint from '@/composables/usePacbioLibraryPrint.js'
+
+const pacbioRootStore = usePacbioRootStore()
+const pacbioLibraryBatchCreateStore = usePacbioLibraryBatchCreateStore()
+const { printers, fetchPrinters } = usePrintingStore()
+const { showAlert } = useAlert()
+const { printLabels } = usePacbioLibraryPrint()
+
+const defaultTagSetName = 'Pacbio_96_barcode_plate_v3'
+
+const selectedPrinterName = ref('') // selected printer id
+const showCSVPreview = ref(false) // Show preview of the csv file
+const selectedTagSet = ref('') // Chosen tag set
+const csvFileInput = ref('') //Reference to the csv file input
+const selectedCSVFile = ref('') //Reference to the selected csv file
+
+/**
+ * Set the default tag set
+ *
+ */
+const setDefaultTagSet = () => {
+  const defaultTagSet = pacbioRootStore.tagSetChoices.find(
+    (option) => option.text === defaultTagSetName,
+  )
+  if (defaultTagSet) {
+    selectedTagSet.value = defaultTagSet.value
+  }
+}
+
+async function fetchData() {
+  await pacbioRootStore.fetchPacbioTagSets()
+  setDefaultTagSet()
+  await fetchPrinters()
+  return { success: true }
+}
+
+const isDisabledCSVPreview = computed(() => !state.csvData.length)
+
+const isCreateDisabled = computed(() => !selectedTagSet.value || !selectedCSVFile.value)
+
+const printBarcodes = computed(() => state.resultData.map((item) => item.barcode))
+
+const isPrintDisabled = computed(() => !selectedPrinterName.value || !printBarcodes.value.length)
+
+/**
+ * Printer options
+ * @returns {Array} - Printer options
+ * @example [{ value: 1, text: 'Printer 1' }, { value: 2, text: 'Printer 2' }]
+ */
+// printerOptions is used to display the printers that are available to print to
+const printerOptions = computed(() => {
+  return printers('tube').map(({ name }) => ({
+    text: name,
+  }))
+})
+
+const csvTableFields = [
+  { key: 'source', label: 'Source' },
+  { key: 'tag', label: 'Tag' },
+  { key: 'template_prep_kit_box_barcode', label: 'Template prep kit box barcode' },
+  { key: 'volume', label: 'Volume' },
+  { key: 'concentration', label: 'Concentration' },
+  { key: 'insert_size', label: 'Insert size' },
+]
+//define reactive variables
+const state = reactive({
+  csvTableFields,
+  // Define fields for the table
+  resultTableFields: [{ key: 'barcode', label: 'Barcode' }, ...csvTableFields],
+  csvData: [],
+  resultData: [],
+})
+
+/**
+ * Handles the csv file selection
+ * @param evt - Event object
+ */
+const onSelectFile = async (evt) => {
+  if (evt?.target?.files?.length) {
+    selectedCSVFile.value = evt.target.files[0]
+    try {
+      const csv = await selectedCSVFile.value.text()
+      //Parse the csv file
+      const records = eachRecord(csv, () => {})
+      state.csvData = records.map((record) => record.record)
+    } catch (error) {
+      showAlert(error, 'danger')
+    }
+  }
+}
+
+/**
+ * Resets the form
+ */
+const onReset = () => {
+  state.csvData = []
+  state.resultData = []
+  csvFileInput.value.value = ''
+  selectedPrinterName.value = null
+  setDefaultTagSet()
+}
+
+/**
+ * Creates a library batch from the selected tag set and csv file
+ */
+const createLibraryBatch = async () => {
+  const selectedTagSetName = pacbioRootStore.tagSetChoices.find(
+    (tagset) => tagset.value === selectedTagSet.value,
+  )?.text
+  if (!selectedTagSetName) {
+    showAlert('Please select a tag set', 'danger')
+    return
+  }
+  const { success, errors, result } = await pacbioLibraryBatchCreateStore.createLibraryBatch(
+    selectedCSVFile.value,
+    selectedTagSetName,
+  )
+  if (success) {
+    state.resultData = result
+  } else {
+    showAlert(errors, 'danger')
+  }
+}
+
+const onPrintAction = async () => {
+  const { success, message = {} } = await printLabels(
+    selectedPrinterName.value,
+    state.resultData.map((item) => ({ barcode: item.barcode, source_identifier: item.source })),
+  )
+  showAlert(message, success ? 'success' : 'danger')
+}
+</script>

--- a/src/views/pacbio/PacbioLibraryBatchCreate.vue
+++ b/src/views/pacbio/PacbioLibraryBatchCreate.vue
@@ -7,7 +7,7 @@
             <traction-section
               title="Create Library Batch"
               number="1"
-              description="To get started, please select a tag set and csv file, then press Create Libraries button"
+              description="To get started, please select a tag set and csv file, then press the 'Create Libraries' button"
             ></traction-section>
             <div class="text-left px-4">
               Select tag set
@@ -18,7 +18,7 @@
               ></traction-select>
             </div>
             <div class="px-4">
-              <label class="flex text-left" for="csvFieInput">Select file</label>
+              <label class="flex text-left" for="csvFieInput">Select csv file</label>
               <div class="flex flex-row space-x-2">
                 <div id="borderDiv" class="w-full">
                   <input
@@ -69,7 +69,7 @@
             <traction-section
               title="View Created Libraries"
               number="2"
-              description="All libraries created will be displayed here"
+              description="Once the 'Create Libraries' button is clicked, all the created libraries will be displayed here."
             ></traction-section>
             <div class="flex flex-row space-x-4">
               <div class="w-full overflow-y-auto">
@@ -94,7 +94,7 @@
             <traction-section
               title="Print Labels"
               number="3"
-              description="Once the libraries are created, please select a printer and press the Print button"
+              description="Once the libraries are created, please select a printer and press the 'Print Labels' button"
             ></traction-section>
 
             <div class="text-left px-4 pb-4">
@@ -157,6 +157,14 @@
 </template>
 
 <script setup>
+/**
+ * PacbioLibraryBatchCreate.vue
+ *
+ * This component is used to create a library batch from a csv file and tag set
+ * and print labels for the created libraries
+ *
+ * @module PacbioLibraryBatchCreate
+ */
 import { usePacbioRootStore } from '@/stores/pacbioRoot.js'
 import { usePrintingStore } from '@/stores/printing.js'
 import { usePacbioLibraryBatchCreateStore } from '@/stores/pacbioLibraryBatchCreate.js'
@@ -177,9 +185,7 @@ const defaultTagSetName = 'Pacbio_96_barcode_plate_v3'
 const selectedPrinterName = ref('') // selected printer id
 const showCSVPreview = ref(false) // Show preview of the csv file
 const selectedTagSet = ref('') // Chosen tag set
-const csvFileInput = ref('') //Reference to the csv file input
-const selectedCSVFile = ref('') //Reference to the selected csv file
-
+const csvFileInput = ref('') //Reference to the csv file input component
 /**
  * Set the default tag set
  *
@@ -220,6 +226,7 @@ const printerOptions = computed(() => {
   }))
 })
 
+const selectedCSVFile = ref('') //Reference to the selected csv file
 const csvTableFields = [
   { key: 'source', label: 'Source' },
   { key: 'tag', label: 'Tag' },
@@ -288,6 +295,9 @@ const createLibraryBatch = async () => {
   }
 }
 
+/**
+ * Prints the labels for the created libraries
+ */
 const onPrintAction = async () => {
   const { success, message = {} } = await printLabels(
     selectedPrinterName.value,

--- a/src/views/pacbio/PacbioLibraryIndex.vue
+++ b/src/views/pacbio/PacbioLibraryIndex.vue
@@ -185,7 +185,6 @@ const { printLabels } = usePacbioLibraryPrint()
 //Create Pinia store
 const librariesStore = usePacbioLibrariesStore()
 
-
 //computed
 const libraries = computed(() => librariesStore.librariesArray)
 
@@ -230,13 +229,8 @@ const handleLibraryDelete = async () => {
   }
 }
 
-
-
 const onPrintAction = async (printerName) => {
-  const { success, message = {} } = await printLabels(
-    printerName,
-    state.selected
-  )
+  const { success, message = {} } = await printLabels(printerName, state.selected)
   showAlert(message, success ? 'success' : 'danger')
 }
 

--- a/src/views/pacbio/PacbioLibraryIndex.vue
+++ b/src/views/pacbio/PacbioLibraryIndex.vue
@@ -7,7 +7,7 @@
           ref="printerModal"
           class="float-left"
           :disabled="state.selected.length === 0"
-          @select-printer="printLabels($event)"
+          @select-printer="onPrintAction($event)"
         />
         <traction-button
           id="deleteLibraries"
@@ -92,14 +92,13 @@ import PrinterModal from '@/components/labelPrinting/PrinterModal.vue'
 import FilterCard from '@/components/FilterCard.vue'
 import DataFetcher from '@/components/DataFetcher.vue'
 import useLocationFetcher from '@/composables/useLocationFetcher.js'
-import { getCurrentDate } from '@/lib/DateHelpers.js'
 import useQueryParams from '@/composables/useQueryParams.js'
 import useAlert from '@/composables/useAlert.js'
 import { ref, reactive, computed, watchEffect } from 'vue'
 import { usePacbioLibrariesStore } from '@/stores/pacbioLibraries'
 import PacbioLibraryEdit from '@/components/pacbio/PacbioLibraryEdit.vue'
-import { usePrintingStore } from '@/stores/printing.js'
 import { locationBuilder } from '@/services/labwhere/helpers.js'
+import usePacbioLibraryPrint from '@/composables/usePacbioLibraryPrint.js'
 
 /**
  * Following are new Vue 3 features used in this component:
@@ -181,12 +180,11 @@ const sortBy = ref('id')
 //Composables
 const { showAlert } = useAlert()
 const { fetchWithQueryParams } = useQueryParams()
+const { printLabels } = usePacbioLibraryPrint()
 
 //Create Pinia store
 const librariesStore = usePacbioLibrariesStore()
 
-// Create printing store
-const printingStore = usePrintingStore()
 
 //computed
 const libraries = computed(() => librariesStore.librariesArray)
@@ -232,26 +230,13 @@ const handleLibraryDelete = async () => {
   }
 }
 
-const createLabels = () => {
-  const date = getCurrentDate()
-  return state.selected.map(({ barcode, source_identifier }) => {
-    return {
-      barcode,
-      first_line: 'Pacbio - Library',
-      second_line: date,
-      third_line: barcode,
-      fourth_line: source_identifier,
-      label_name: 'main_label',
-    }
-  })
-}
 
-const printLabels = async (printerName) => {
-  const { success, message = {} } = await printingStore.createPrintJob({
+
+const onPrintAction = async (printerName) => {
+  const { success, message = {} } = await printLabels(
     printerName,
-    labels: createLabels(),
-    copies: 1,
-  })
+    state.selected
+  )
   showAlert(message, success ? 'success' : 'danger')
 }
 

--- a/tests/e2e/specs/pacbio/pacbio_library_batch_create.cy.js
+++ b/tests/e2e/specs/pacbio/pacbio_library_batch_create.cy.js
@@ -1,17 +1,26 @@
 import PacbioTagSetFactory from '../../../factories/PacbioTagSetFactory.js'
 import PrinterFactory from '../../../factories/PrinterFactory.js'
 import PacbioLibraryBatchFactory from '../../../factories/PacbioLibraryBatchFactory.js'
+import PacbioRequestFactory from '../../../factories/PacbioRequestFactory.js'
+const pacbioLibraryBatchFactory = PacbioLibraryBatchFactory()
 
 describe('Pacbio Pool Create', () => {
   beforeEach(() => {
     cy.wrap(PacbioTagSetFactory()).as('pacbioTagSetFactory')
     cy.wrap(PrinterFactory()).as('printerFactory')
+    cy.wrap(PacbioRequestFactory()).as('pacbioRequestFactory')
     cy.wrap(PacbioLibraryBatchFactory()).as('pacbioLibraryBatchFactory')
 
     cy.get('@pacbioTagSetFactory').then((pacbioTagSetFactory) => {
-      cy.intercept('GET', '/v1/pacbio/tag_sets?include=tags', {
+      cy.intercept('GET', '/v1/pacbio/tag_sets?include=tags*', {
         statusCode: 200,
         body: pacbioTagSetFactory.content,
+      })
+    })
+    cy.get('@pacbioRequestFactory').then((pacbioRequestFactory) => {
+      cy.intercept('GET', '/v1/pacbio/requests?filter*', {
+        statusCode: 200,
+        body: pacbioRequestFactory.content,
       })
     })
 
@@ -29,7 +38,7 @@ describe('Pacbio Pool Create', () => {
 
     // Upload CSV file
     //Create a file from PacbioLibraryBatchFactory and attach it to the input
-    const csvContent = PacbioLibraryBatchFactory().createCsvFromLibraryBatchData(
+    const csvContent = pacbioLibraryBatchFactory.createCsvFromLibraryBatchData(
       PacbioTagSetFactory().storeData.tags,
     )
     const blob = new Blob([csvContent], { type: 'text/csv' })
@@ -47,33 +56,74 @@ describe('Pacbio Pool Create', () => {
     cy.get('[data-type=csv-preview]').should('exist')
 
     // Create Libraries
-    cy.intercept('POST', '/v1/pacbio/library_batches', {
-      statusCode: 201,
-      body: {
-        data: {
-          library_batch: {
-            id: '1',
-            libraries: [{ barcode: 'barcode1' }, { barcode: 'barcode2' }],
-          },
-        },
-      },
+    cy.intercept('POST', '/v1/pacbio/library_batches?include=libraries.tube', {
+      statusCode: 200,
+      body: pacbioLibraryBatchFactory.content,
+     
     })
     cy.get('[data-action=create-libraries]').click()
-    cy.get('#library-batch-table').should('exist')
+    cy.get('#library-batch-table tbody tr').should('have.length',pacbioLibraryBatchFactory.storeData.librariesInBatch.length)  
+
+    cy.get('#list-barcodes-to-print li').should('have.length', pacbioLibraryBatchFactory.storeData.librariesInBatch.length)
+    pacbioLibraryBatchFactory.storeData.librariesInBatch.forEach((library, index) => {
+      cy.get('#list-barcodes-to-print li').eq(index).should('contain', library.barcode)
+    })
 
     // Select Printer
     cy.get('@printerFactory').then((printerFactory) => {
       cy.get('[data-type=printer-options]').select(printerFactory.storeData.selected.printer.name)
     })
 
-     // Print Labels
-     cy.intercept('/v2/print_jobs', {
-        statusCode: 200,
-        body: {
-          message: 'Successful',
+    // Print Labels
+    cy.intercept('/v2/print_jobs', {
+      statusCode: 200,
+      body: {
+        message: 'Successful',
+      },
+    })
+    cy.get('#print-button').click()
+    cy.contains('Barcode(s) successfully printed')
+  })
+
+  it('will not create libraries when there is an error', () => {
+
+    cy.visit('#/pacbio/library-batch')
+    cy.contains('Create Library Batch')
+
+    // Upload CSV file
+    //Create a file from PacbioLibraryBatchFactory and attach it to the input
+    const csvContent = pacbioLibraryBatchFactory.createCsvFromLibraryBatchData(
+      PacbioTagSetFactory().storeData.tags,
+    )
+    const blob = new Blob([csvContent], { type: 'text/csv' })
+    const file = new File([blob], 'pacbio_library_batch.csv', { type: 'text/csv' })
+
+    // Attach the generated CSV file
+    cy.get('#csvFileInput').attachFile({
+      fileContent: file,
+      fileName: 'pacbio_library_batch.csv',
+      mimeType: 'text/csv',
+    })
+
+    // Show CSV Preview
+    cy.get('[data-type=csv-preview-btn]').click()
+    cy.get('[data-type=csv-preview]').should('exist')
+
+    // Create Libraries
+    cy.intercept('POST', '/v1/pacbio/library_batches?include=libraries.tube', {
+      statusCode: 422,
+      body: {
+        errors: {
+          error1: ['There was a problem'],
         },
-      })
-      cy.get('#print-button').click()
-      cy.contains('Barcode(s) successfully printed')
+      },
+    })
+
+    cy.get('#library-batch-table tbody tr').should('have.length',0)
+    cy.contains('No Libraries Created Yet').should('exist')
+    cy.contains('No Barcodes to Print Yet').should('exist')
+    cy.get('[data-action=create-libraries]').click()
+    cy.contains('error1 There was a problem')
+
   })
 })

--- a/tests/e2e/specs/pacbio/pacbio_library_batch_create.cy.js
+++ b/tests/e2e/specs/pacbio/pacbio_library_batch_create.cy.js
@@ -59,12 +59,17 @@ describe('Pacbio Pool Create', () => {
     cy.intercept('POST', '/v1/pacbio/library_batches?include=libraries.tube', {
       statusCode: 200,
       body: pacbioLibraryBatchFactory.content,
-     
     })
     cy.get('[data-action=create-libraries]').click()
-    cy.get('#library-batch-table tbody tr').should('have.length',pacbioLibraryBatchFactory.storeData.librariesInBatch.length)  
+    cy.get('#library-batch-table tbody tr').should(
+      'have.length',
+      pacbioLibraryBatchFactory.storeData.librariesInBatch.length,
+    )
 
-    cy.get('#list-barcodes-to-print li').should('have.length', pacbioLibraryBatchFactory.storeData.librariesInBatch.length)
+    cy.get('#list-barcodes-to-print li').should(
+      'have.length',
+      pacbioLibraryBatchFactory.storeData.librariesInBatch.length,
+    )
     pacbioLibraryBatchFactory.storeData.librariesInBatch.forEach((library, index) => {
       cy.get('#list-barcodes-to-print li').eq(index).should('contain', library.barcode)
     })
@@ -86,7 +91,6 @@ describe('Pacbio Pool Create', () => {
   })
 
   it('will not create libraries when there is an error', () => {
-
     cy.visit('#/pacbio/library-batch')
     cy.contains('Create Library Batch')
 
@@ -119,11 +123,10 @@ describe('Pacbio Pool Create', () => {
       },
     })
 
-    cy.get('#library-batch-table tbody tr').should('have.length',0)
+    cy.get('#library-batch-table tbody tr').should('have.length', 0)
     cy.contains('No Libraries Created Yet').should('exist')
     cy.contains('No Barcodes to Print Yet').should('exist')
     cy.get('[data-action=create-libraries]').click()
     cy.contains('error1 There was a problem')
-
   })
 })

--- a/tests/e2e/specs/pacbio/pacbio_library_batch_create.cy.js
+++ b/tests/e2e/specs/pacbio/pacbio_library_batch_create.cy.js
@@ -1,0 +1,79 @@
+import PacbioTagSetFactory from '../../../factories/PacbioTagSetFactory.js'
+import PrinterFactory from '../../../factories/PrinterFactory.js'
+import PacbioLibraryBatchFactory from '../../../factories/PacbioLibraryBatchFactory.js'
+
+describe('Pacbio Pool Create', () => {
+  beforeEach(() => {
+    cy.wrap(PacbioTagSetFactory()).as('pacbioTagSetFactory')
+    cy.wrap(PrinterFactory()).as('printerFactory')
+    cy.wrap(PacbioLibraryBatchFactory()).as('pacbioLibraryBatchFactory')
+
+    cy.get('@pacbioTagSetFactory').then((pacbioTagSetFactory) => {
+      cy.intercept('GET', '/v1/pacbio/tag_sets?include=tags', {
+        statusCode: 200,
+        body: pacbioTagSetFactory.content,
+      })
+    })
+
+    cy.get('@printerFactory').then((printerFactory) => {
+      cy.intercept('GET', '/v1/printers', {
+        statusCode: 200,
+        body: printerFactory.content,
+      })
+    })
+  })
+
+  it('Creates a pool successfully', () => {
+    cy.visit('#/pacbio/library-batch')
+    cy.contains('Create Library Batch')
+
+    // Upload CSV file
+    //Create a file from PacbioLibraryBatchFactory and attach it to the input
+    const csvContent = PacbioLibraryBatchFactory().createCsvFromLibraryBatchData(
+      PacbioTagSetFactory().storeData.tags,
+    )
+    const blob = new Blob([csvContent], { type: 'text/csv' })
+    const file = new File([blob], 'pacbio_library_batch.csv', { type: 'text/csv' })
+
+    // Attach the generated CSV file
+    cy.get('#csvFileInput').attachFile({
+      fileContent: file,
+      fileName: 'pacbio_library_batch.csv',
+      mimeType: 'text/csv',
+    })
+
+    // Show CSV Preview
+    cy.get('[data-type=csv-preview-btn]').click()
+    cy.get('[data-type=csv-preview]').should('exist')
+
+    // Create Libraries
+    cy.intercept('POST', '/v1/pacbio/library_batches', {
+      statusCode: 201,
+      body: {
+        data: {
+          library_batch: {
+            id: '1',
+            libraries: [{ barcode: 'barcode1' }, { barcode: 'barcode2' }],
+          },
+        },
+      },
+    })
+    cy.get('[data-action=create-libraries]').click()
+    cy.get('#library-batch-table').should('exist')
+
+    // Select Printer
+    cy.get('@printerFactory').then((printerFactory) => {
+      cy.get('[data-type=printer-options]').select(printerFactory.storeData.selected.printer.name)
+    })
+
+     // Print Labels
+     cy.intercept('/v2/print_jobs', {
+        statusCode: 200,
+        body: {
+          message: 'Successful',
+        },
+      })
+      cy.get('#print-button').click()
+      cy.contains('Barcode(s) successfully printed')
+  })
+})

--- a/tests/factories/PacbioLibraryBatchFactory.js
+++ b/tests/factories/PacbioLibraryBatchFactory.js
@@ -1,5 +1,5 @@
 import BaseFactory from './BaseFactory'
-import { dataToObjectById, groupIncludedByResource } from '@/api/JsonApi'
+import { dataToObjectById, groupIncludedByResource } from './../../src/api/JsonApi'
 
 const PacbioLibraryBatchFactory = (tags = []) => {
   const data = {

--- a/tests/factories/PacbioRequestFactory.js
+++ b/tests/factories/PacbioRequestFactory.js
@@ -1,5 +1,5 @@
 import BaseFactory from './BaseFactory.js'
-import { dataToObjectById } from '@/api/JsonApi.js'
+import { dataToObjectById } from './../../src/api/JsonApi'
 
 const createStoreData = (data) => {
   const requests = dataToObjectById({ data: data.data, includeRelationships: true })

--- a/tests/factories/PacbioTagSetFactory.js
+++ b/tests/factories/PacbioTagSetFactory.js
@@ -23,7 +23,7 @@ const createStoreData = (data) => {
         first: (n = 1) => tagSet.tags.slice(0, n).map((id) => tags[id]),
       },
     },
-    findTagSetByName: (name) => Object.values(tagSets).find((ts) => ts.name === name)
+    findTagSetByName: (name) => Object.values(tagSets).find((ts) => ts.name === name),
   }
 }
 

--- a/tests/factories/PacbioTagSetFactory.js
+++ b/tests/factories/PacbioTagSetFactory.js
@@ -23,6 +23,7 @@ const createStoreData = (data) => {
         first: (n = 1) => tagSet.tags.slice(0, n).map((id) => tags[id]),
       },
     },
+    findTagSetByName: (name) => Object.values(tagSets).find((ts) => ts.name === name)
   }
 }
 

--- a/tests/factories/PrinterFactory.js
+++ b/tests/factories/PrinterFactory.js
@@ -15,7 +15,8 @@ const createStoreData = (data) => {
     selected: {
       printer: printers['1'],
     },
-    getPrintersOfType: (type) => Object.values(printers).filter((printer) => printer.labware_type === type),
+    getPrintersOfType: (type) =>
+      Object.values(printers).filter((printer) => printer.labware_type === type),
   }
 }
 

--- a/tests/factories/PrinterFactory.js
+++ b/tests/factories/PrinterFactory.js
@@ -15,6 +15,7 @@ const createStoreData = (data) => {
     selected: {
       printer: printers['1'],
     },
+    getPrintersOfType: (type) => Object.values(printers).filter((printer) => printer.labware_type === type),
   }
 }
 

--- a/tests/unit/composables/usePacbioLibraryPrint.spec.js
+++ b/tests/unit/composables/usePacbioLibraryPrint.spec.js
@@ -13,37 +13,27 @@ vi.mock('@/lib/DateHelpers.js', () => ({
 }))
 
 describe('#usePacbioLibraryPrint', () => {
+  const expectedCreatedLabels = [
+    {
+      barcode: 'TRAC-1',
+      first_line: 'Pacbio - Library',
+      second_line: '01-Jan-2023',
+      third_line: 'TRAC-1',
+      fourth_line: 'SQSC-1',
+      label_name: 'main_label',
+    },
+    {
+      barcode: 'TRAC-2',
+      first_line: 'Pacbio - Library',
+      second_line: '01-Jan-2023',
+      third_line: 'TRAC-2',
+      fourth_line: 'SQSC-2',
+      label_name: 'main_label',
+    },
+  ]
   beforeEach(() => {
     const pinia = createPinia()
     setActivePinia(pinia)
-  })
-
-  it('creates labels correctly', () => {
-    const { createLabels } = usePacbioLibraryPrint()
-    const printBarcodes = [
-      { barcode: 'barcode1', source_identifier: 'source1' },
-      { barcode: 'barcode2', source_identifier: 'source2' },
-    ]
-    getCurrentDate.mockReturnValue('01-Jan-2023')
-    const labels = createLabels(printBarcodes)
-    expect(labels).toEqual([
-      {
-        barcode: 'barcode1',
-        first_line: 'Pacbio - Library',
-        second_line: '01-Jan-2023',
-        third_line: 'barcode1',
-        fourth_line: 'source1',
-        label_name: 'main_label',
-      },
-      {
-        barcode: 'barcode2',
-        first_line: 'Pacbio - Library',
-        second_line: '01-Jan-2023',
-        third_line: 'barcode2',
-        fourth_line: 'source2',
-        label_name: 'main_label',
-      },
-    ])
   })
 
   it('prints labels correctly', async () => {
@@ -51,31 +41,14 @@ describe('#usePacbioLibraryPrint', () => {
     const createPrintJob = vi.fn().mockResolvedValue({ success: true, message: 'success' })
     usePrintingStore.mockReturnValue({ createPrintJob })
     const printBarcodes = [
-      { barcode: 'barcode1', source_identifier: 'source1' },
-      { barcode: 'barcode2', source_identifier: 'source2' },
+      { id: 1, barcode: 'TRAC-1', source_identifier: 'SQSC-1' },
+      { id: 2, barcode: 'TRAC-2', source_identifier: 'SQSC-2' },
     ]
     getCurrentDate.mockReturnValue('01-Jan-2023')
     const result = await printLabels('printer1', printBarcodes)
     expect(createPrintJob).toHaveBeenCalledWith({
       printerName: 'printer1',
-      labels: [
-        {
-          barcode: 'barcode1',
-          first_line: 'Pacbio - Library',
-          second_line: '01-Jan-2023',
-          third_line: 'barcode1',
-          fourth_line: 'source1',
-          label_name: 'main_label',
-        },
-        {
-          barcode: 'barcode2',
-          first_line: 'Pacbio - Library',
-          second_line: '01-Jan-2023',
-          third_line: 'barcode2',
-          fourth_line: 'source2',
-          label_name: 'main_label',
-        },
-      ],
+      labels: expectedCreatedLabels,
       copies: 1,
     })
     expect(result).toEqual({ success: true, message: 'success' })

--- a/tests/unit/composables/usePacbioLibraryPrint.spec.js
+++ b/tests/unit/composables/usePacbioLibraryPrint.spec.js
@@ -1,0 +1,83 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { vi, describe, beforeEach, it, expect } from 'vitest'
+import usePacbioLibraryPrint from '@/composables/usePacbioLibraryPrint.js'
+import { usePrintingStore } from '@/stores/printing.js'
+import { getCurrentDate } from '@/lib/DateHelpers.js'
+
+vi.mock('@/stores/printing.js', () => ({
+  usePrintingStore: vi.fn(),
+}))
+
+vi.mock('@/lib/DateHelpers.js', () => ({
+  getCurrentDate: vi.fn(),
+}))
+
+describe('#usePacbioLibraryPrint', () => {
+  beforeEach(() => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+  })
+
+  it('creates labels correctly', () => {
+    const { createLabels } = usePacbioLibraryPrint()
+    const printBarcodes = [
+      { barcode: 'barcode1', source_identifier: 'source1' },
+      { barcode: 'barcode2', source_identifier: 'source2' },
+    ]
+    getCurrentDate.mockReturnValue('01-Jan-2023')
+    const labels = createLabels(printBarcodes)
+    expect(labels).toEqual([
+      {
+        barcode: 'barcode1',
+        first_line: 'Pacbio - Library',
+        second_line: '01-Jan-2023',
+        third_line: 'barcode1',
+        fourth_line: 'source1',
+        label_name: 'main_label',
+      },
+      {
+        barcode: 'barcode2',
+        first_line: 'Pacbio - Library',
+        second_line: '01-Jan-2023',
+        third_line: 'barcode2',
+        fourth_line: 'source2',
+        label_name: 'main_label',
+      },
+    ])
+  })
+
+  it('prints labels correctly', async () => {
+    const { printLabels } = usePacbioLibraryPrint()
+    const createPrintJob = vi.fn().mockResolvedValue({ success: true, message: 'success' })
+    usePrintingStore.mockReturnValue({ createPrintJob })
+    const printBarcodes = [
+      { barcode: 'barcode1', source_identifier: 'source1' },
+      { barcode: 'barcode2', source_identifier: 'source2' },
+    ]
+    getCurrentDate.mockReturnValue('01-Jan-2023')
+    const result = await printLabels('printer1', printBarcodes)
+    expect(createPrintJob).toHaveBeenCalledWith({
+      printerName: 'printer1',
+      labels: [
+        {
+          barcode: 'barcode1',
+          first_line: 'Pacbio - Library',
+          second_line: '01-Jan-2023',
+          third_line: 'barcode1',
+          fourth_line: 'source1',
+          label_name: 'main_label',
+        },
+        {
+          barcode: 'barcode2',
+          first_line: 'Pacbio - Library',
+          second_line: '01-Jan-2023',
+          third_line: 'barcode2',
+          fourth_line: 'source2',
+          label_name: 'main_label',
+        },
+      ],
+      copies: 1,
+    })
+    expect(result).toEqual({ success: true, message: 'success' })
+  })
+})

--- a/tests/unit/stores/pacbioLibraryBatchCreate.spec.js
+++ b/tests/unit/stores/pacbioLibraryBatchCreate.spec.js
@@ -97,7 +97,9 @@ describe('usePacbioLibraryBatchCreateStore', () => {
         expect(pacbioLibraryBatchCreateStore.libraries).toEqual(
           pacbioLibraryBatchFactory.storeData.libraries,
         )
-        expect(pacbioLibraryBatchCreateStore.tubes).toEqual(pacbioLibraryBatchFactory.storeData.tubes)
+        expect(pacbioLibraryBatchCreateStore.tubes).toEqual(
+          pacbioLibraryBatchFactory.storeData.tubes,
+        )
         expect(result).toEqual(pacbioLibraryBatchCreateStore.librariesInBatch)
       })
 

--- a/tests/unit/stores/pacbioLibraryBatchCreate.spec.js
+++ b/tests/unit/stores/pacbioLibraryBatchCreate.spec.js
@@ -5,7 +5,7 @@ import {
   successfulResponse,
   failedResponse,
 } from '@support/testHelper.js'
-import { usePacbioLibraryBatchesStore } from '@/stores/pacbioLibraryBatches.js'
+import { usePacbioLibraryBatchCreateStore } from '@/stores/pacbioLibraryBatchCreate.js'
 import { beforeEach, describe, expect, vi } from 'vitest'
 import PacbioLibraryBatchFactory from '@tests/factories/PacbioLibraryBatchFactory.js'
 import PacbioRequestFactory from '@tests/factories/PacbioRequestFactory.js'
@@ -15,24 +15,24 @@ const pacbioRequestFactory = PacbioRequestFactory()
 const pacbioTagSetFactory = PacbioTagSetFactory()
 const pacbioLibraryBatchFactory = PacbioLibraryBatchFactory(pacbioTagSetFactory.storeData.tags)
 
-describe('usePacbioLibraryBatchesStore', () => {
-  let rootStore, pacbioLibraryBatchStore, pacbioRootStore
+describe('usePacbioLibraryBatchCreateStore', () => {
+  let rootStore, pacbioLibraryBatchCreateStore, pacbioRootStore
   beforeEach(() => {
     /*Creates a fresh pinia instance and make it active so it's automatically picked
       up by any useStore() call without having to pass it to it for e.g `useStore(pinia)`*/
     const pinia = createPinia()
     setActivePinia(pinia)
     rootStore = useRootStore()
-    pacbioLibraryBatchStore = usePacbioLibraryBatchesStore()
+    pacbioLibraryBatchCreateStore = usePacbioLibraryBatchCreateStore()
     pacbioRootStore = usePacbioRootStore()
   })
 
   describe('librariesInBatch', () => {
     it('returns libraries in batch', () => {
-      pacbioLibraryBatchStore.libraries = pacbioLibraryBatchFactory.storeData.libraries
-      pacbioLibraryBatchStore.tubes = pacbioLibraryBatchFactory.storeData.tubes
+      pacbioLibraryBatchCreateStore.libraries = pacbioLibraryBatchFactory.storeData.libraries
+      pacbioLibraryBatchCreateStore.tubes = pacbioLibraryBatchFactory.storeData.tubes
       pacbioRootStore.tags = pacbioTagSetFactory.storeData.tags
-      expect(pacbioLibraryBatchStore.librariesInBatch).toEqual(
+      expect(pacbioLibraryBatchCreateStore.librariesInBatch).toEqual(
         pacbioLibraryBatchFactory.storeData.librariesInBatch,
       )
     })
@@ -68,12 +68,12 @@ describe('usePacbioLibraryBatchesStore', () => {
         }
 
         // Test with csvFile as null
-        let result = await pacbioLibraryBatchStore.createLibraryBatch(null, tagSet)
+        let result = await pacbioLibraryBatchCreateStore.createLibraryBatch(null, tagSet)
         expect(result.success).toBeFalsy()
         expect(result.errors).toEqual(['csvFile is required'])
 
         // Test with tagSet as null
-        result = await pacbioLibraryBatchStore.createLibraryBatch(csvFile, null)
+        result = await pacbioLibraryBatchCreateStore.createLibraryBatch(csvFile, null)
         expect(result.success).toBeFalsy()
         expect(result.errors).toEqual(['tagSet is required'])
       })
@@ -83,7 +83,7 @@ describe('usePacbioLibraryBatchesStore', () => {
           pacbioTagSetFactory.storeData.tags,
         )
         create.mockResolvedValue(mockSuccessResponse)
-        const { success, result } = await pacbioLibraryBatchStore.createLibraryBatch(
+        const { success, result } = await pacbioLibraryBatchCreateStore.createLibraryBatch(
           csvFile,
           tagSet,
         )
@@ -94,11 +94,11 @@ describe('usePacbioLibraryBatchesStore', () => {
 
         expect(create).toBeCalled(payload)
         expect(success).toBeTruthy()
-        expect(pacbioLibraryBatchStore.libraries).toEqual(
+        expect(pacbioLibraryBatchCreateStore.libraries).toEqual(
           pacbioLibraryBatchFactory.storeData.libraries,
         )
-        expect(pacbioLibraryBatchStore.tubes).toEqual(pacbioLibraryBatchFactory.storeData.tubes)
-        expect(result).toEqual(pacbioLibraryBatchStore.librariesInBatch)
+        expect(pacbioLibraryBatchCreateStore.tubes).toEqual(pacbioLibraryBatchFactory.storeData.tubes)
+        expect(result).toEqual(pacbioLibraryBatchCreateStore.librariesInBatch)
       })
 
       it('returns error when csv file contains errors', async () => {
@@ -107,7 +107,7 @@ describe('usePacbioLibraryBatchesStore', () => {
           true,
         )
 
-        const { success, errors } = await pacbioLibraryBatchStore.createLibraryBatch(
+        const { success, errors } = await pacbioLibraryBatchCreateStore.createLibraryBatch(
           csvFile,
           tagSet,
         )
@@ -122,7 +122,7 @@ describe('usePacbioLibraryBatchesStore', () => {
         )
         const failureResponse = failedResponse()
         create.mockResolvedValue(failureResponse)
-        const { success, errors } = await pacbioLibraryBatchStore.createLibraryBatch(
+        const { success, errors } = await pacbioLibraryBatchCreateStore.createLibraryBatch(
           csvFile,
           tagSet,
         )

--- a/tests/unit/stores/utilities/pabioLibraryBatches.spec.js
+++ b/tests/unit/stores/utilities/pabioLibraryBatches.spec.js
@@ -140,7 +140,7 @@ describe('pacbioLibraryBatches', () => {
     })
 
     it('fetches requests and tags successfully', async () => {
-      const { requests, tags } = await fetchTagsAndRequests(sources, tagSet)
+      const { requests, tags } = await fetchTagsAndRequests(sources, tagSet.name)
 
       expect(rootStore.api.v2.traction.pacbio.requests.get).toHaveBeenCalledWith({
         filter: { source_identifier: sources.join(',') },
@@ -156,7 +156,7 @@ describe('pacbioLibraryBatches', () => {
     it('returns null tags if tag set fetch fails', async () => {
       rootStore.api.v2.traction.pacbio.tag_sets.get.mockResolvedValue({ success: false })
 
-      const { requests, tags } = await fetchTagsAndRequests(sources, tagSet)
+      const { requests, tags } = await fetchTagsAndRequests(sources, tagSet.name)
 
       expect(rootStore.api.v2.traction.pacbio.requests.get).toHaveBeenCalledWith({
         filter: { source_identifier: sources.join(',') },
@@ -172,7 +172,7 @@ describe('pacbioLibraryBatches', () => {
     it('returns empty requests if request fetch fails', async () => {
       rootStore.api.v2.traction.pacbio.requests.get.mockResolvedValue({ success: false })
 
-      const { requests } = await fetchTagsAndRequests(sources, tagSet)
+      const { requests } = await fetchTagsAndRequests(sources, tagSet.name)
 
       expect(rootStore.api.v2.traction.pacbio.requests.get).toHaveBeenCalledWith({
         filter: { source_identifier: sources.join(',') },

--- a/tests/unit/views/pacbio/PacbioLibraryBatchCreate.spec.js
+++ b/tests/unit/views/pacbio/PacbioLibraryBatchCreate.spec.js
@@ -1,0 +1,356 @@
+import {
+  mount,
+  flushPromises,
+  createTestingPinia,
+  successfulResponse,
+} from '@support/testHelper.js'
+import { expect, it, vi } from 'vitest'
+import PacbioLibraryBatchCreate from '@/views/pacbio/PacbioLibraryBatchCreate.vue'
+import { usePacbioLibraryBatchCreateStore } from '@/stores/pacbioLibraryBatchCreate.js'
+
+import PrinterFactory from '@tests/factories/PrinterFactory.js'
+import PacbioTagSetFactory from '@tests/factories/PacbioTagSetFactory.js'
+import PacbioLibraryBatchFactory from '@tests/factories/PacbioLibraryBatchFactory.js'
+import useRootStore from '@/stores'
+
+const pacbioTagSetFactory = PacbioTagSetFactory()
+const printerFactory = PrinterFactory()
+const pacbioLibraryBatchFactory = PacbioLibraryBatchFactory()
+
+const mockShowAlert = vi.fn()
+vi.mock('@/composables/useAlert', () => ({
+  default: () => ({
+    showAlert: mockShowAlert,
+  }),
+}))
+
+function mountWithStore({ state = {}, stubActions = false, plugins = [], props } = {}) {
+  const wrapperObj = mount(PacbioLibraryBatchCreate, {
+    global: {
+      plugins: [
+        createTestingPinia({
+          state,
+          stubActions,
+          plugins,
+        }),
+      ],
+    },
+    props,
+  })
+  const createStoreObj = usePacbioLibraryBatchCreateStore()
+  return { wrapperObj, createStoreObj }
+}
+
+describe('PacbioLibraryBatchCreate.vue', () => {
+  let wrapper, pacbioLibraryBatchCreateStore
+
+  beforeEach(async () => {
+    const plugins = [
+      ({ store }) => {
+        if (store.$id === 'root') {
+          store.api.v2.traction.pacbio.tag_sets.get = vi.fn(
+            () => pacbioTagSetFactory.responses.fetch,
+          )
+          store.api.v2.traction.printers.get = vi.fn(() => printerFactory.responses.fetch)
+        }
+      },
+    ]
+    const { wrapperObj, createStoreObj } = mountWithStore({
+      plugins,
+    })
+    wrapper = wrapperObj
+    pacbioLibraryBatchCreateStore = createStoreObj
+    await flushPromises()
+  })
+
+  describe('building the component', () => {
+    it('displays initial state correctly', async () => {
+      const select = wrapper.find('select[data-type="tag-set-list"]')
+      expect(select.exists()).toBe(true)
+      const options = select.findAll('option')
+      expect(options.length).toEqual(Object.values(pacbioTagSetFactory.storeData.tagSets).length)
+
+      const printerSelect = wrapper.find('select[data-type="printer-options"]')
+      expect(printerSelect.exists()).toBe(true)
+      const printerOptions = printerSelect.findAll('option')
+      expect(printerOptions.length).toEqual(
+        printerFactory.storeData.getPrintersOfType('tube').length,
+      )
+
+      const csvInput = wrapper.find('input[id="csvFileInput"]')
+      expect(csvInput.exists()).toBe(true)
+      const csvPreviewBtn = wrapper.find('button[data-type="csv-preview-btn"]')
+      expect(csvPreviewBtn.exists()).toBe(true)
+      expect(csvPreviewBtn.element.disabled).toBe(true)
+      expect(wrapper.find('div[data-type="csv-preview"]').exists()).toBe(false)
+
+      const resetBtn = wrapper.find('#reset')
+      expect(resetBtn.exists()).toBe(true)
+      expect(resetBtn.element.disabled).toBe(false)
+
+      const createBtn = wrapper.find('#create')
+      expect(createBtn.exists()).toBe(true)
+      expect(createBtn.element.disabled).toBe(true)
+
+      const createdLibaries = wrapper.find('div[data-type="created-libraries"]')
+      expect(createdLibaries.text()).toBe('No Libraries Created Yet')
+
+      expect(wrapper.find('#print-button').element.disabled).toBe(true)
+
+      const emptyBarcodes = wrapper.find('div[data-type="empty-barcodes"]')
+      expect(emptyBarcodes.text()).toBe('No Barcodes to Print Yet')
+    })
+
+    it('contains the correct data on mount', async () => {
+      expect(wrapper.vm.selectedPrinterName).toEqual('')
+      expect(wrapper.vm.printerOptions.length).toEqual(
+        printerFactory.storeData.getPrintersOfType('tube').length,
+      )
+      expect(wrapper.vm.selectedTagSet).toEqual(
+        pacbioTagSetFactory.storeData.findTagSetByName('Pacbio_96_barcode_plate_v3').id,
+      )
+      expect(wrapper.vm.state.csvData).toEqual([])
+      expect(wrapper.vm.state.resultData).toEqual([])
+      expect(wrapper.vm.printBarcodes).toEqual([])
+    })
+  })
+
+  describe('#onSelectFile', () => {
+    it('parses the CSV file and updates state on success', async () => {
+      const csvContent = pacbioLibraryBatchFactory.createCsvFromLibraryBatchData(
+        pacbioTagSetFactory.storeData.tags,
+      )
+      const csvFile = {
+        text: () => Promise.resolve(csvContent),
+      }
+      const event = { target: { files: [csvFile] } }
+      await wrapper.vm.onSelectFile(event)
+      await flushPromises()
+      expect(wrapper.vm.state.csvData.length).toEqual(2)
+      // Check the preview button is enabled
+      const csvPreviewBtn = wrapper.find('button[data-type="csv-preview-btn"]')
+      expect(csvPreviewBtn.exists()).toBe(true)
+      expect(csvPreviewBtn.element.disabled).toBe(false)
+    })
+
+    it('shows an alert on error', async () => {
+      const csvFile = {
+        text: () => Promise.reject('error'),
+      }
+      const event = { target: { files: [csvFile] } }
+      await wrapper.vm.onSelectFile(event)
+      await flushPromises()
+      expect(mockShowAlert).toBeCalledWith('error', 'danger')
+
+      // Check the preview button is disabled
+      const csvPreviewBtn = wrapper.find('button[data-type="csv-preview-btn"]')
+      expect(csvPreviewBtn.exists()).toBe(true)
+      expect(csvPreviewBtn.element.disabled).toBe(true)
+    })
+  })
+
+  describe('#onPreviewCsv', () => {
+    let csvContent
+    beforeEach(async () => {
+      csvContent = pacbioLibraryBatchFactory.createCsvFromLibraryBatchData(
+        pacbioTagSetFactory.storeData.tags,
+      )
+      const csvFile = {
+        text: () => Promise.resolve(csvContent),
+      }
+      const event = { target: { files: [csvFile] } }
+      await wrapper.vm.onSelectFile(event)
+      await flushPromises()
+    })
+    it('toggles the csv preview table display', async () => {
+      const csvPreviewBtn = wrapper.find('button[data-type="csv-preview-btn"]')
+      expect(csvPreviewBtn.text()).toBe('Show CSV Data')
+      // Click the button to show the preview table
+      expect(wrapper.find('div[data-type="csv-preview"]').exists()).toBe(false)
+      await csvPreviewBtn.trigger('click')
+      await wrapper.vm.$nextTick()
+      expect(csvPreviewBtn.text()).toBe('Hide CSV Data')
+      expect(wrapper.find('div[data-type="csv-preview"]').exists()).toBe(true)
+    })
+  })
+
+  describe('#createLibraryBatchButton', () => {
+    it('enables the create button when csv data and tagset is present', async () => {
+      const csvContent = pacbioLibraryBatchFactory.createCsvFromLibraryBatchData(
+        pacbioTagSetFactory.storeData.tags,
+      )
+      const csvFile = {
+        text: () => Promise.resolve(csvContent),
+      }
+      const event = { target: { files: [csvFile] } }
+      await wrapper.vm.onSelectFile(event)
+      await flushPromises()
+      const createBtn = wrapper.find('#create')
+      expect(createBtn.element.disabled).toBe(false)
+    })
+    it('disables the create button when csv data is not present', async () => {
+      const createBtn = wrapper.find('#create')
+      expect(createBtn.element.disabled).toBe(true)
+    })
+    it('disables the create button when tagset is not present', async () => {
+      const csvContent = pacbioLibraryBatchFactory.createCsvFromLibraryBatchData(
+        pacbioTagSetFactory.storeData.tags,
+      )
+      const csvFile = {
+        text: () => Promise.resolve(csvContent),
+      }
+      const event = { target: { files: [csvFile] } }
+      await wrapper.vm.onSelectFile(event)
+      await flushPromises()
+      wrapper.vm.selectedTagSet = null
+      await flushPromises()
+      const createBtn = wrapper.find('#create')
+      expect(createBtn.element.disabled).toBe(true)
+    })
+  })
+
+  describe('#createLibraryBatch', () => {
+    beforeEach(async () => {
+      const csvContent = pacbioLibraryBatchFactory.createCsvFromLibraryBatchData(
+        pacbioTagSetFactory.storeData.tags,
+      )
+      const csvFile = {
+        text: () => Promise.resolve(csvContent),
+      }
+      const event = { target: { files: [csvFile] } }
+      await wrapper.vm.onSelectFile(event)
+    })
+    it('creates a library batch and updates state', async () => {
+      const expectedResult = pacbioLibraryBatchFactory.storeData.librariesInBatch
+
+      pacbioLibraryBatchCreateStore.createLibraryBatch = vi.fn().mockResolvedValue({
+        success: true,
+        result: expectedResult,
+      })
+
+      wrapper.find('#create').trigger('click')
+      await flushPromises()
+      expect(wrapper.vm.state.resultData).toEqual(expectedResult)
+
+      // Check the created libraries
+      const libraryBatchTable = wrapper.find('#library-batch-table')
+      expect(libraryBatchTable.exists()).toBe(true)
+
+      // Check the table rows
+      const rows = libraryBatchTable.findAll('tbody tr')
+      expect(rows.length).toBe(expectedResult.length)
+
+      //Check the Barcode list to print
+      const barcodeList = wrapper.find('#list-barcodes-to-print')
+      expect(barcodeList.exists()).toBe(true)
+
+      const listItems = barcodeList.findAll('li')
+      expect(listItems.length).toBe(expectedResult.length)
+      expectedResult.forEach((library, index) => {
+        expect(listItems.at(index).text()).toBe(library.barcode)
+      })
+    })
+
+    it('shows an alert on error', async () => {
+      pacbioLibraryBatchCreateStore.createLibraryBatch = vi
+        .fn()
+        .mockResolvedValue({ success: false, errors: 'error' })
+      wrapper.find('#create').trigger('click')
+      await wrapper.vm.$nextTick()
+      expect(mockShowAlert).toBeCalledWith('error', 'danger')
+
+      // Check the created libraries
+      const createdLibaries = wrapper.find('div[data-type="created-libraries"]')
+      expect(createdLibaries.text()).toBe('No Libraries Created Yet')
+
+      // Check the created barcode list
+      const barcodeList = wrapper.find('#list-barcodes-to-print')
+      expect(barcodeList.exists()).toBe(false)
+      const emptyBarcodes = wrapper.find('div[data-type="empty-barcodes"]')
+      expect(emptyBarcodes.text()).toBe('No Barcodes to Print Yet')
+    })
+  })
+
+  describe('#printButton', async () => {
+    it('enables the print button when barcodes are present and a printer is selected', async () => {
+      wrapper.vm.state.resultData = pacbioLibraryBatchFactory.storeData.librariesInBatch
+      wrapper.vm.selectedPrinterName = printerFactory.storeData.selected.printer.id
+      await flushPromises()
+
+      const printButton = wrapper.find('#print-button')
+      expect(printButton.element.disabled).toBe(false)
+    })
+    it('disables the print button when barcodes are not present', async () => {
+      wrapper.vm.selectedPrinterName = printerFactory.storeData.selected.printer.id
+      const printButton = wrapper.find('#print-button')
+      expect(printButton.element.disabled).toBe(true)
+    })
+    it('disables the print button when a printer is not selected', async () => {
+      wrapper.vm.resultData = pacbioLibraryBatchFactory.storeData.librariesInBatch
+      const printButton = wrapper.find('#print-button')
+      expect(printButton.element.disabled).toBe(true)
+    })
+  })
+
+  describe('#printLabels', async () => {
+    let create
+    beforeEach(async () => {
+      const rootStore = useRootStore()
+      create = vi.fn()
+      rootStore.api.v2 = { printMyBarcode: { print_jobs: { create } } }
+    })
+    it('creates a print job and shows a success alert', async () => {
+      create.mockResolvedValue(successfulResponse())
+      wrapper.vm.resultData = pacbioLibraryBatchFactory.storeData.librariesInBatch
+      wrapper.vm.selectedPrinterName = printerFactory.storeData.selected.printer.name
+      wrapper.vm.onPrintAction()
+      await flushPromises()
+
+      expect(mockShowAlert).toBeCalledWith('Barcode(s) successfully printed', 'success')
+    })
+
+    it('shows an alert on error', async () => {
+      const mockResponse = {
+        status: '422',
+        ok: false,
+        json: () =>
+          Promise.resolve({
+            errors: [{ source: { pointer: '/data/attributes/printer' }, detail: "can't be blank" }],
+          }),
+      }
+      create.mockResolvedValue(mockResponse)
+      wrapper.vm.resultData = pacbioLibraryBatchFactory.storeData.librariesInBatch
+      wrapper.vm.selectedPrinterName = printerFactory.storeData.selected.printer.name
+      wrapper.vm.onPrintAction()
+      await flushPromises()
+      expect(mockShowAlert).toBeCalledWith("printer can't be blank", 'danger')
+    })
+  })
+
+  describe('#resetButton', () => {
+    it('resets the state of the component', async () => {
+      const csvContent = pacbioLibraryBatchFactory.createCsvFromLibraryBatchData(
+        pacbioTagSetFactory.storeData.tags,
+      )
+      const csvFile = {
+        text: () => Promise.resolve(csvContent),
+      }
+      const event = { target: { files: [csvFile] } }
+      await wrapper.vm.onSelectFile(event)
+
+      wrapper.find('#create').trigger('click')
+      await flushPromises()
+
+      wrapper.find('#reset').trigger('click')
+      await flushPromises()
+
+      expect(wrapper.vm.state.csvData).toEqual([])
+      expect(wrapper.vm.state.resultData).toEqual([])
+      expect(wrapper.vm.printBarcodes).toEqual([])
+      expect(wrapper.vm.csvFileInput.value.value).toEqual(undefined)
+      expect(wrapper.vm.selectedTagSet).toEqual(
+        pacbioTagSetFactory.storeData.findTagSetByName('Pacbio_96_barcode_plate_v3').id,
+      )
+    })
+  })
+})


### PR DESCRIPTION
Closes https://github.com/sanger/traction-ui/issues/2008

#### Changes proposed in this pull request

Page Component for Creating Library Batches:
-     Option to select a CSV file and tag set.
-     CSV preview display, which can be toggled on and off.
-     'Create Library Batch' button to initiate library batch creation.
-     Table to display created libraries.
-     Option to select a printer.
-     Barcode preview pane to display barcodes for printing.
-     Print button to print all barcodes.


![Screenshot 2024-12-03 at 16 10 54](https://github.com/user-attachments/assets/2d8f3fe2-beb5-43f9-8688-b99f196f1d27)





#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
