### PR TITLE
updates: Y24-413 fixes for duplicate sources and library_batch page layout issues

### DIFF
--- a/src/lib/DataHelpers.js
+++ b/src/lib/DataHelpers.js
@@ -77,3 +77,24 @@ export const flattenObject = (obj, parentKey) => {
 
   return result
 }
+
+/**
+ * Finds duplicate values in an array.
+ *
+ * @param {Array} arr - The array to check for duplicates.
+ * @returns {Array} - An array of duplicate values.
+ */
+export const findDuplicates = (arr) => {
+  const seen = new Set()
+  const duplicates = new Set()
+
+  arr.forEach((item) => {
+    if (seen.has(item)) {
+      duplicates.add(item)
+    } else {
+      seen.add(item)
+    }
+  })
+
+  return Array.from(duplicates)
+}

--- a/src/stores/pacbioLibraryBatchCreate.js
+++ b/src/stores/pacbioLibraryBatchCreate.js
@@ -117,11 +117,6 @@ export const usePacbioLibraryBatchCreateStore = defineStore('pacbioLibraryBatchC
           return { success: false, errors: 'None of the given tags found' }
         }
 
-        const uniqueSources = [...new Set(sources)]
-        if (uniqueSources.length !== sources.length) {
-          return { success: false, errors: 'Duplicate sources found in the csv' }
-        }
-
         // Validate csv and return results
         const eachReordRetObj = eachRecord(csv, validateAndFormatAsPayloadData, requests, tags)
         if (eachReordRetObj.error) {

--- a/src/stores/pacbioLibraryBatchCreate.js
+++ b/src/stores/pacbioLibraryBatchCreate.js
@@ -10,6 +10,7 @@ import {
 import { dataToObjectById } from '@/api/JsonApi.js'
 import { usePacbioRootStore } from '@/stores/pacbioRoot.js'
 import { getColumnValues } from '@/lib/csv/pacbio.js'
+import { findDuplicates } from '@/lib/DataHelpers.js'
 
 /**
  * usePacbioLibraryBatchesStore is a store to manage pacbio library batches.
@@ -86,6 +87,25 @@ export const usePacbioLibraryBatchCreateStore = defineStore('pacbioLibraryBatchC
       try {
         const csv = await csvFile.text()
         const sources = getColumnValues(csv, 0)
+        const tagNames = getColumnValues(csv, 1)
+
+        // Check for duplicate sources
+        let duplicates = findDuplicates(sources)
+        if (duplicates.length) {
+          return {
+            success: false,
+            errors: `Duplicate sources found in the csv: ${duplicates.join(', ')}`,
+          }
+        }
+
+        // Check for duplicate tags
+        duplicates = findDuplicates(tagNames)
+        if (duplicates.length) {
+          return {
+            success: false,
+            errors: `Duplicate tags found in the csv: ${duplicates.join(', ')}`,
+          }
+        }
 
         // Fetch the tags and requests
         const { requests, tags } = await fetchTagsAndRequests(sources, tagSet)
@@ -96,6 +116,12 @@ export const usePacbioLibraryBatchCreateStore = defineStore('pacbioLibraryBatchC
         if (tags.length === 0) {
           return { success: false, errors: 'None of the given tags found' }
         }
+
+        const uniqueSources = [...new Set(sources)]
+        if (uniqueSources.length !== sources.length) {
+          return { success: false, errors: 'Duplicate sources found in the csv' }
+        }
+
         // Validate csv and return results
         const eachReordRetObj = eachRecord(csv, validateAndFormatAsPayloadData, requests, tags)
         if (eachReordRetObj.error) {

--- a/src/stores/utilities/pacbioLibraryBatches.js
+++ b/src/stores/utilities/pacbioLibraryBatches.js
@@ -33,10 +33,6 @@ const validateAndFormatAsPayloadData = ({ record, info }, requests, tags) => {
     }
   }
 
-  if (tags.filter((t) => t.group_id === tag).length > 1) {
-    return createError(`Duplicate tag: ${tag}`)
-  }
-
   const tagObj = tags.find((t) => t.group_id === tag)
   if (!tagObj) {
     return createError(`tag ${tag} not found`)

--- a/src/views/pacbio/PacbioLibraryBatchCreate.vue
+++ b/src/views/pacbio/PacbioLibraryBatchCreate.vue
@@ -1,6 +1,6 @@
 <template>
   <DataFetcher :fetcher="fetchData">
-    <div class="w-full h-screen px-4">
+    <div class="w-full px-4">
       <div class="flex flex-row w-full h-full">
         <div class="w-1/2 px-4">
           <div class="flex flex-col space-y-4">

--- a/tests/factories/PacbioLibraryBatchFactory.js
+++ b/tests/factories/PacbioLibraryBatchFactory.js
@@ -89,7 +89,7 @@ const PacbioLibraryBatchFactory = (tags = []) => {
           insert_size: 10191,
           created_at: '2024/11/15 17:38',
           deactivated_at: null,
-          source_identifier: 'GEN-1725896371-4:B3',
+          source_identifier: 'DN814327C:A1',
           pacbio_request_id: 407,
           tag_id: 304,
           used_volume: 0,

--- a/tests/unit/lib/DataHelpers.spec.js
+++ b/tests/unit/lib/DataHelpers.spec.js
@@ -1,4 +1,9 @@
-import { flattenObject, alphaNumericSortDefault, regexSort } from '@/lib/DataHelpers'
+import {
+  flattenObject,
+  alphaNumericSortDefault,
+  regexSort,
+  findDuplicates,
+} from '@/lib/DataHelpers'
 
 describe('DataHelpers', () => {
   describe('flattenObject', () => {
@@ -83,6 +88,42 @@ describe('DataHelpers', () => {
       expect(
         regexSort('A-TEST2', 'A-TEST2', { alpha: /[^a-zA-Z]*/g, numeric: /[^0-9]*/g }, false),
       ).toEqual(0)
+    })
+  })
+  describe('findDuplicates', () => {
+    it('should return an array of duplicate values', () => {
+      const input = ['a', 'b', 'a', 'c', 'b', 'd']
+      const expectedOutput = ['a', 'b']
+      const result = findDuplicates(input)
+      expect(result).toEqual(expectedOutput)
+    })
+
+    it('should return an empty array if there are no duplicates', () => {
+      const input = ['a', 'b', 'c', 'd']
+      const expectedOutput = []
+      const result = findDuplicates(input)
+      expect(result).toEqual(expectedOutput)
+    })
+
+    it('should return an empty array if the input array is empty', () => {
+      const input = []
+      const expectedOutput = []
+      const result = findDuplicates(input)
+      expect(result).toEqual(expectedOutput)
+    })
+
+    it('should handle arrays with all duplicate values', () => {
+      const input = ['a', 'a', 'a', 'a']
+      const expectedOutput = ['a']
+      const result = findDuplicates(input)
+      expect(result).toEqual(expectedOutput)
+    })
+
+    it('should handle arrays with no duplicate values', () => {
+      const input = ['a', 'b', 'c', 'd', 'e']
+      const expectedOutput = []
+      const result = findDuplicates(input)
+      expect(result).toEqual(expectedOutput)
     })
   })
 })

--- a/tests/unit/stores/pacbioLibraryBatchCreate.spec.js
+++ b/tests/unit/stores/pacbioLibraryBatchCreate.spec.js
@@ -124,7 +124,7 @@ describe('usePacbioLibraryBatchCreateStore', () => {
         )
       })
 
-      it('returns error if there are dupliacte tags', async () => {
+      it('returns error if there are duplicate tags', async () => {
         csvFileTextContent = pacbioLibraryBatchFactory.createCsvFromLibraryBatchData(
           pacbioTagSetFactory.storeData.tags,
         )

--- a/tests/unit/stores/pacbioLibraryBatchCreate.spec.js
+++ b/tests/unit/stores/pacbioLibraryBatchCreate.spec.js
@@ -109,6 +109,41 @@ describe('usePacbioLibraryBatchCreateStore', () => {
         expect(errors).toEqual('None of the given sources (/samples) were found')
       })
 
+      it('returns error if there are dupliacte sources', async () => {
+        csvFileTextContent = pacbioLibraryBatchFactory.createCsvFromLibraryBatchData(
+          pacbioTagSetFactory.storeData.tags,
+        )
+        csvFileTextContent += csvFileTextContent
+        const { success, errors } = await pacbioLibraryBatchCreateStore.createLibraryBatch(
+          csvFile,
+          tagSet,
+        )
+        expect(success).toBeFalsy()
+        expect(errors).toEqual(
+          `Duplicate sources found in the csv: ${pacbioLibraryBatchFactory.storeData.librariesInBatch.map((batch) => batch.source).join(', ')}`,
+        )
+      })
+
+      it('returns error if there are dupliacte tags', async () => {
+        csvFileTextContent = pacbioLibraryBatchFactory.createCsvFromLibraryBatchData(
+          pacbioTagSetFactory.storeData.tags,
+        )
+        //Create duplicate tags
+        let csvLines = csvFileTextContent.split('\n')
+        let firstLineColumns = csvLines[1].split(',')
+        let secondLineColumns = csvLines[2].split(',')
+        secondLineColumns[1] = firstLineColumns[1]
+        csvLines[1] = firstLineColumns.join(',')
+        csvLines[2] = secondLineColumns.join(',')
+        csvFileTextContent = csvLines.join('\n')
+        const { success, errors } = await pacbioLibraryBatchCreateStore.createLibraryBatch(
+          csvFile,
+          tagSet,
+        )
+        expect(success).toBeFalsy()
+        expect(errors).toEqual(`Duplicate tags found in the csv: ${firstLineColumns[1]}`)
+      })
+
       it('successfully creates a library batch', async () => {
         csvFileTextContent = pacbioLibraryBatchFactory.createCsvFromLibraryBatchData(
           pacbioTagSetFactory.storeData.tags,

--- a/tests/unit/stores/utilities/pabioLibraryBatches.spec.js
+++ b/tests/unit/stores/utilities/pabioLibraryBatches.spec.js
@@ -69,23 +69,6 @@ describe('pacbioLibraryBatches', () => {
       const result = validateAndFormatAsPayloadData({ record, info }, requests, tags)
       expect(result).toEqual(new Error('Invalid record at line 1: tag abc not found'))
     })
-    it('returns an error if tag is duplicated', () => {
-      const tagWithDuplicates = [...tags, tags[0]]
-
-      const record = {
-        source: requests[0].source_identifier,
-        tag: tags[0].group_id,
-        concentration: 10,
-        insert_size: 100,
-        volume: 5,
-        template_prep_kit_box_barcode: 'abc',
-      }
-      const info = { lines: 1 }
-      const result = validateAndFormatAsPayloadData({ record, info }, requests, tagWithDuplicates)
-      expect(result).toEqual(
-        new Error(`Invalid record at line 1: Duplicate tag: ${tags[0].group_id}`),
-      )
-    })
 
     it('returns formatted payload data if all validations pass', () => {
       const tagSet = pacbioTagSetFactory.storeData.selected.tagSet


### PR DESCRIPTION
Closes https://github.com/sanger/traction-ui/issues/2008

#### Changes proposed in this pull request
 Fixes for
- LibraryBatch layout issue where the footer banner is displaying in between table on scroll
- Duplicate sources

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
