### PR TITLE
Y24-491 change swipecard fields to password fields

### DIFF
--- a/src/components/shared/TractionInput.vue
+++ b/src/components/shared/TractionInput.vue
@@ -65,12 +65,6 @@ export default {
       type: Function,
       default: undefined,
     },
-    // Although the type attribute is passed through the $attrs object to support fallthrough attributes,
-    // it is explicitly defined here for clarity and to ensure proper type handling.
-    type: {
-      type: String,
-      default: 'text',
-    },
   },
   emits: ['enterKeyPress', 'update:modelValue'],
   data() {

--- a/src/components/shared/TractionInput.vue
+++ b/src/components/shared/TractionInput.vue
@@ -65,6 +65,12 @@ export default {
       type: Function,
       default: undefined,
     },
+    // Although the type attribute is passed through the $attrs object to support fallthrough attributes,
+    // it is explicitly defined here for clarity and to ensure proper type handling.
+    type: {
+      type: String,
+      default: 'text',
+    },
   },
   emits: ['enterKeyPress', 'update:modelValue'],
   data() {

--- a/src/views/GeneralReception.vue
+++ b/src/views/GeneralReception.vue
@@ -77,6 +77,7 @@
                 v-model="user_code"
                 data-attribute="user-code-input"
                 class="mt-1"
+                type="password"
               />
             </traction-field-error>
           </div>

--- a/src/views/LabwhereReception.vue
+++ b/src/views/LabwhereReception.vue
@@ -12,6 +12,7 @@
             v-model="user_code"
             data-attribute="user-code-input"
             class="flex w-full"
+            type="password"
             @update:model-value="validateUserCode"
           />
         </traction-field-error>

--- a/tests/unit/components/shared/TractionInput.spec.js
+++ b/tests/unit/components/shared/TractionInput.spec.js
@@ -30,6 +30,17 @@ describe('TractionInput.vue', () => {
     expect(wrapper.find('input[type=number]').element.value).toEqual('10')
   })
 
+  it('sets default value for type password', () => {
+    const wrapper = buildWrapper({ type: 'password', modelValue: 'secret' })
+    expect(wrapper.find('input[type=password]').element.value).toEqual('secret')
+  })
+
+  it('emits the value for type password', async () => {
+    const wrapper = buildWrapper({ type: 'password' })
+    await wrapper.find('input').setValue('newsecret')
+    expect(wrapper.emitted('update:modelValue')).toEqual([['newsecret']])
+  })
+
   it('emits the value', async () => {
     const wrapper = buildWrapper({ type: 'number' })
     await wrapper.find('input').setValue('10000')

--- a/tests/unit/views/GeneralReception.spec.js
+++ b/tests/unit/views/GeneralReception.spec.js
@@ -61,7 +61,10 @@ describe('GeneralReception', () => {
       const { wrapperObj: wrapper } = buildWrapper()
       const workflowSelect = wrapper.find('#workflowSelect')
       await workflowSelect.setValue('lw-shelf-1-30451')
-      expect(wrapper.find('[data-attribute=user-code-input]').isVisible()).toBe(true)
+      const userCodeInput = wrapper.find('[data-attribute=user-code-input]')
+      expect(userCodeInput.exists()).toBe(true)
+      expect(userCodeInput.isVisible()).toBe(true)
+      expect(userCodeInput.attributes('type')).toBe('password')
     })
 
     it('hides user swipecard when a workflow is not selected', async () => {

--- a/tests/unit/views/LabWhereReception.spec.js
+++ b/tests/unit/views/LabWhereReception.spec.js
@@ -26,7 +26,9 @@ describe('LabWhereReception', () => {
 
   it('has a user code input field', () => {
     const wrapper = buildWrapper()
-    expect(wrapper.find('#userCode').exists()).toBe(true)
+    const userCodeInput = wrapper.find('#userCode')
+    expect(userCodeInput.exists()).toBe(true)
+    expect(userCodeInput.attributes('type')).toBe('password')
   })
 
   it('has a location barcode input field', () => {


### PR DESCRIPTION
Closes https://github.com/sanger/traction-ui/issues/2083

#### Changes proposed in this pull request

- Update the LabWhereReception and GeneralReception components to set the type of relevant input fields to password.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
