### PR TITLE
Y25-010 use sample name for library batch creation

### DIFF
--- a/src/stores/utilities/pacbioLibraryBatches.js
+++ b/src/stores/utilities/pacbioLibraryBatches.js
@@ -38,7 +38,7 @@ const validateAndFormatAsPayloadData = ({ record, info }, requests, tags) => {
     return createError(`tag ${tag} not found`)
   }
 
-  const request = requests.find((r) => r.source_identifier === source)
+  const request = requests.find((r) => r.sample_name === source)
   if (!request) {
     return createError(`source ${source} not found`)
   }
@@ -73,7 +73,7 @@ async function fetchTagsAndRequests(sources, tagSet) {
 
   const rootStore = useRootStore()
   let promise = rootStore.api.traction.pacbio.requests.get({
-    filter: { source_identifier: sources.join(',') },
+    filter: { sample_name: sources.join(',') },
   })
   let response = await handleResponse(promise)
 

--- a/tests/factories/PacbioLibraryBatchFactory.js
+++ b/tests/factories/PacbioLibraryBatchFactory.js
@@ -155,6 +155,7 @@ const PacbioLibraryBatchFactory = (tags = []) => {
       }),
       tubes: tubesObj,
       libraries: librariesObj,
+      librariesArray: Object.values(librariesObj),
     }
   }
 

--- a/tests/factories/PacbioLibraryBatchFactory.js
+++ b/tests/factories/PacbioLibraryBatchFactory.js
@@ -52,6 +52,7 @@ const PacbioLibraryBatchFactory = (tags = []) => {
           insert_size: 10191,
           created_at: '2024/11/15 17:38',
           deactivated_at: null,
+          sample_name: '2STDY97',
           source_identifier: 'GEN-1725896371-4:B3',
           pacbio_request_id: 407,
           tag_id: 303,
@@ -89,6 +90,7 @@ const PacbioLibraryBatchFactory = (tags = []) => {
           insert_size: 10191,
           created_at: '2024/11/15 17:38',
           deactivated_at: null,
+          sample_name: '5049STDY8152830',
           source_identifier: 'DN814327C:A1',
           pacbio_request_id: 407,
           tag_id: 304,
@@ -174,7 +176,7 @@ const PacbioLibraryBatchFactory = (tags = []) => {
         duplicate_tags && indx > 0
           ? lines[0].split(',')[1]
           : tagArrr.find((t) => t.id === String(library.tag_id))?.group_id
-      const source = indx === 0 && invalid_source ? 'test' : library.source_identifier
+      const source = indx === 0 && invalid_source ? 'test' : library.sample_name
       lines[indx] = [
         source,
         tag,
@@ -192,7 +194,7 @@ const PacbioLibraryBatchFactory = (tags = []) => {
     const tagArrr = Object.values(tags)
     const libraries_attributes = Object.values(storeData.libraries).map((library) => {
       const tag = tagArrr.find((t) => t.id === String(library.tag_id))?.group_id
-      const request = requests.find((r) => r.source_identifier === library.source_identifier)
+      const request = requests.find((r) => r.sample_name === library.sample_name)
       return {
         ...library,
         pacbio_request_id: request?.id,

--- a/tests/unit/stores/pacbioLibraryBatchCreate.spec.js
+++ b/tests/unit/stores/pacbioLibraryBatchCreate.spec.js
@@ -120,8 +120,8 @@ describe('usePacbioLibraryBatchCreateStore', () => {
         )
         expect(success).toBeFalsy()
         expect(errors).toEqual(
-          `Duplicate sources found in the csv: ${
-            pacbioLibraryBatchFactory.storeData.librariesArray.map((batch) => batch.sample_name)
+          `Duplicate sources found in the csv: ${pacbioLibraryBatchFactory.storeData.librariesArray
+            .map((batch) => batch.sample_name)
             .join(', ')}`,
         )
       })

--- a/tests/unit/stores/pacbioLibraryBatchCreate.spec.js
+++ b/tests/unit/stores/pacbioLibraryBatchCreate.spec.js
@@ -120,7 +120,9 @@ describe('usePacbioLibraryBatchCreateStore', () => {
         )
         expect(success).toBeFalsy()
         expect(errors).toEqual(
-          `Duplicate sources found in the csv: ${Object.values(pacbioLibraryBatchFactory.storeData.libraries).map((batch) => batch.sample_name).join(', ')}`,
+          `Duplicate sources found in the csv: ${
+            pacbioLibraryBatchFactory.storeData.librariesArray.map((batch) => batch.sample_name)
+            .join(', ')}`,
         )
       })
 

--- a/tests/unit/stores/pacbioLibraryBatchCreate.spec.js
+++ b/tests/unit/stores/pacbioLibraryBatchCreate.spec.js
@@ -120,7 +120,7 @@ describe('usePacbioLibraryBatchCreateStore', () => {
         )
         expect(success).toBeFalsy()
         expect(errors).toEqual(
-          `Duplicate sources found in the csv: ${pacbioLibraryBatchFactory.storeData.librariesInBatch.map((batch) => batch.source).join(', ')}`,
+          `Duplicate sources found in the csv: ${Object.values(pacbioLibraryBatchFactory.storeData.libraries).map((batch) => batch.sample_name).join(', ')}`,
         )
       })
 

--- a/tests/unit/stores/utilities/pabioLibraryBatches.spec.js
+++ b/tests/unit/stores/utilities/pabioLibraryBatches.spec.js
@@ -58,7 +58,7 @@ describe('pacbioLibraryBatches', () => {
 
     it('returns an error if tag is not found in tags', () => {
       const record = {
-        source: requests[0].source_identifier,
+        source: requests[0].sample_name,
         tag: 'abc',
         concentration: 10,
         insert_size: 100,
@@ -75,7 +75,7 @@ describe('pacbioLibraryBatches', () => {
       const tag = pacbioTagSetFactory.storeData.selected.tag
       const request = pacbioRequestFactory.content.data[0]
       const record = {
-        source: request.attributes.source_identifier,
+        source: request.attributes.sample_name,
         tag_set: tagSet.name,
         tag: tag.group_id,
         concentration: 10,
@@ -119,14 +119,14 @@ describe('pacbioLibraryBatches', () => {
       }
       tagSet = pacbioTagSetFactory.storeData.selected.tagSet
       requestsData = pacbioRequestFactory.storeData.requestsArray
-      sources = requestsData.map((r) => r.source_identifier)
+      sources = requestsData.map((r) => r.sample_name)
     })
 
     it('fetches requests and tags successfully', async () => {
       const { requests, tags } = await fetchTagsAndRequests(sources, tagSet.name)
 
       expect(rootStore.api.traction.pacbio.requests.get).toHaveBeenCalledWith({
-        filter: { source_identifier: sources.join(',') },
+        filter: { sample_name: sources.join(',') },
       })
       expect(rootStore.api.traction.pacbio.tag_sets.get).toHaveBeenCalledWith({
         include: 'tags',
@@ -142,7 +142,7 @@ describe('pacbioLibraryBatches', () => {
       const { requests, tags } = await fetchTagsAndRequests(sources, tagSet.name)
 
       expect(rootStore.api.traction.pacbio.requests.get).toHaveBeenCalledWith({
-        filter: { source_identifier: sources.join(',') },
+        filter: { sample_name: sources.join(',') },
       })
       expect(rootStore.api.traction.pacbio.tag_sets.get).toHaveBeenCalledWith({
         include: 'tags',
@@ -158,7 +158,7 @@ describe('pacbioLibraryBatches', () => {
       const { requests } = await fetchTagsAndRequests(sources, tagSet.name)
 
       expect(rootStore.api.traction.pacbio.requests.get).toHaveBeenCalledWith({
-        filter: { source_identifier: sources.join(',') },
+        filter: { sample_name: sources.join(',') },
       })
       expect(rootStore.api.traction.pacbio.tag_sets.get).toHaveBeenCalledWith({
         include: 'tags',


### PR DESCRIPTION
Closes https://github.com/sanger/traction-ui/issues/2136

#### Changes proposed in this pull request

- Replace the "Source" column to use the sample name instead of the source barcode for library batch creation

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
