### PR TITLE
Bump release-action 

### DIFF
--- a/.github/workflows/asset_dispatch.yml
+++ b/.github/workflows/asset_dispatch.yml
@@ -31,7 +31,7 @@ jobs:
           ./compile-build.sh release.tar.gz dist
 
       - name: Create release and upload release.tar.gz
-        uses: ncipollo/release-action@v1.8.8
+        uses: ncipollo/release-action@v1.15.0
         with:
           name: ${{ github.event.inputs.image_tag }}
           tag: v${{ github.event.inputs.image_tag }}

--- a/.github/workflows/automated_release.yml
+++ b/.github/workflows/automated_release.yml
@@ -35,7 +35,7 @@ jobs:
           ./compile-build.sh release.tar.gz dist
 
       - name: Create release and upload release.tar.gz
-        uses: ncipollo/release-action@v1.8.8
+        uses: ncipollo/release-action@v1.15.0
         with:
           name: ${{ env.RELEASE_VERSION }}
           tag: v${{ env.RELEASE_VERSION }}


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

The GitHub workflow job `build_and_release` was giving a warning because the `release-action` was using the deprecated `set-output` command, which will be disabled soon. The PR updates the `release-action` to a more recent version, resolving this issue.

![Screenshot 2025-02-26 at 12 50 57](https://github.com/user-attachments/assets/f2eeeb2d-ff25-4e6e-80ef-5ed940415861)



#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
