### PR TITLE
Y24-453  select the rebasecalling process when creating an ONT run

### DIFF
--- a/src/components/ont/runs/ONTRunInformation.vue
+++ b/src/components/ont/runs/ONTRunInformation.vue
@@ -37,7 +37,6 @@
 
 <script setup>
 import { computed } from 'vue'
-import { storeToRefs } from 'pinia'
 import { useOntRunsStore } from '@/stores/ontRuns'
 import useOntRootStore from '@/stores/ontRoot'
 
@@ -45,12 +44,8 @@ import useOntRootStore from '@/stores/ontRoot'
 const ontRunsStore = useOntRunsStore()
 const ontRootStore = useOntRootStore()
 
-// Extract reactive properties using storeToRefs()
-const { currentRun } = storeToRefs(ontRunsStore)
-const { instruments } = storeToRefs(ontRootStore)
-
-// Actions
-const { setInstrumentName, setState, setRebasecallingProcess } = ontRunsStore
+const { instruments } = ontRootStore
+const { setInstrumentName, setState, setRebasecallingProcess, currentRun } = ontRunsStore
 
 // Static lists
 const statesList = ['Pending', 'Completed', 'User Terminated', 'Instrument Crashed', 'Restart']
@@ -58,7 +53,7 @@ const rebasecallingList = ['5mC + 5hmC CpG-context', '5mC + 5hmC all-context', '
 
 const instrumentOptions = computed(() => [
   { value: null, text: 'Please select an instrument', disabled: true },
-  ...instruments.value.map((instrument) => ({
+  ...instruments.map((instrument) => ({
     value: instrument.name,
     text: instrument.name,
   })),
@@ -80,7 +75,7 @@ const rebasecallingOptions = computed(() => [
   })),
 ])
 
-const newRecord = computed(() => isNaN(currentRun.value.id))
+const newRecord = computed(() => isNaN(ontRunsStore.currentRun.id))
 
 // Helper function to format state values
 const formatState = (str) => str.replace(/\s+/g, '_').toLowerCase()

--- a/src/components/ont/runs/ONTRunInformation.vue
+++ b/src/components/ont/runs/ONTRunInformation.vue
@@ -37,7 +37,6 @@
 
 <script setup>
 import { computed } from 'vue'
-import { storeToRefs } from 'pinia'
 import { useOntRunsStore } from '@/stores/ontRuns'
 import useOntRootStore from '@/stores/ontRoot'
 
@@ -45,25 +44,21 @@ import useOntRootStore from '@/stores/ontRoot'
 const ontRunsStore = useOntRunsStore()
 const ontRootStore = useOntRootStore()
 
-// Extract reactive properties using storeToRefs()
-const { currentRun } = storeToRefs(ontRunsStore)
-const { instruments } = storeToRefs(ontRootStore)
-
-// Actions
 const { setInstrumentName, setState, setRebasecallingProcess } = ontRunsStore
+const { instruments } = ontRootStore
 
 // Static lists
 const statesList = ['Pending', 'Completed', 'User Terminated', 'Instrument Crashed', 'Restart']
 const rebasecallingList = ['5mC + 5hmC CpG-context', '5mC + 5hmC all-context', '6mA all-context']
 
 // Computed properties
-const instrumentName = computed(() => currentRun.value.instrument_name)
-const state = computed(() => currentRun.value.state)
-const rebasecallingProcess = computed(() => currentRun.value.rebasecalling_process)
+const instrumentName = computed(() => ontRunsStore.currentRun.instrument_name)
+const state = computed(() => ontRunsStore.currentRun.state)
+const rebasecallingProcess = computed(() => ontRunsStore.currentRun.rebasecalling_process)
 
 const instrumentOptions = computed(() => [
   { value: null, text: 'Please select an instrument', disabled: true },
-  ...instruments.value.map((instrument) => ({
+  ...instruments.map((instrument) => ({
     value: instrument.name,
     text: instrument.name,
   })),
@@ -85,7 +80,7 @@ const rebasecallingOptions = computed(() => [
   })),
 ])
 
-const newRecord = computed(() => isNaN(currentRun.value.id))
+const newRecord = computed(() => isNaN(ontRunsStore.currentRun.id))
 
 // Helper function to format state values
 const formatState = (str) => str.replace(/\s+/g, '_').toLowerCase()

--- a/src/components/ont/runs/ONTRunInformation.vue
+++ b/src/components/ont/runs/ONTRunInformation.vue
@@ -6,7 +6,7 @@
         <traction-select
           id="instrument-selection"
           :options="instrumentOptions"
-          :model-value="instrumentName"
+          :model-value="currentRun.instrument_name"
           :disabled="!newRecord"
           @update:model-value="setInstrumentName"
         ></traction-select>
@@ -17,7 +17,7 @@
         <traction-select
           id="state-selection"
           :options="stateOptions"
-          :model-value="state"
+          :model-value="currentRun.state"
           @update:model-value="setState"
         ></traction-select>
       </div>
@@ -27,7 +27,7 @@
         <traction-select
           id="rebasecalling-selection"
           :options="rebasecallingOptions"
-          :model-value="rebasecallingProcess"
+          :model-value="currentRun.rebasecalling_process"
           @update:model-value="setRebasecallingProcess"
         ></traction-select>
       </div>
@@ -44,17 +44,12 @@ import useOntRootStore from '@/stores/ontRoot'
 const ontRunsStore = useOntRunsStore()
 const ontRootStore = useOntRootStore()
 
-const { setInstrumentName, setState, setRebasecallingProcess } = ontRunsStore
+const { setInstrumentName, setState, setRebasecallingProcess, currentRun } = ontRunsStore
 const { instruments } = ontRootStore
 
 // Static lists
 const statesList = ['Pending', 'Completed', 'User Terminated', 'Instrument Crashed', 'Restart']
 const rebasecallingList = ['5mC + 5hmC CpG-context', '5mC + 5hmC all-context', '6mA all-context']
-
-// Computed properties
-const instrumentName = computed(() => ontRunsStore.currentRun.instrument_name)
-const state = computed(() => ontRunsStore.currentRun.state)
-const rebasecallingProcess = computed(() => ontRunsStore.currentRun.rebasecalling_process)
 
 const instrumentOptions = computed(() => [
   { value: null, text: 'Please select an instrument', disabled: true },
@@ -80,7 +75,7 @@ const rebasecallingOptions = computed(() => [
   })),
 ])
 
-const newRecord = computed(() => isNaN(ontRunsStore.currentRun.id))
+const newRecord = computed(() => isNaN(currentRun.id))
 
 // Helper function to format state values
 const formatState = (str) => str.replace(/\s+/g, '_').toLowerCase()

--- a/src/components/ont/runs/ONTRunInformation.vue
+++ b/src/components/ont/runs/ONTRunInformation.vue
@@ -12,12 +12,21 @@
         ></traction-select>
       </div>
       <div class="flex flex-col gap-y-2 items-start">
-        <label label-for="instrument-selection"> State </label>
+        <label label-for="state-selection"> State </label>
         <traction-select
           id="state-selection"
           :options="stateOptions"
           :model-value="state"
           @update:model-value="setState"
+        ></traction-select>
+      </div>
+      <div class="flex flex-col gap-y-2 items-start">
+        <label label-for="rebasecalling-selection"> Rebasecalling process </label>
+        <traction-select
+          id="rebasecalling-selection"
+          :options="rebasecallingOptions"
+          :model-value="rebasecallingProcess"
+          @update:model-value="setRebasecallingProcess"
         ></traction-select>
       </div>
     </div>
@@ -39,6 +48,7 @@ export default {
   data() {
     return {
       statesList: ['Pending', 'Completed', 'User Terminated', 'Instrument Crashed', 'Restart'],
+      rebasecallingList: ['5mC + 5hmC CpG-context', '5mC + 5hmC all-context', '6mA all-context'],
     }
   },
   computed: {
@@ -54,7 +64,11 @@ export default {
       const ontRunsStore = useOntRunsStore()
       return ontRunsStore.currentRun.state
     },
-
+    rebasecallingProcess() {
+      //This is to keep currentRun.rebasecalling in sync with the Pinia store state  (option api way)
+      const ontRunsStore = useOntRunsStore()
+      return ontRunsStore.currentRun.rebasecalling_process
+    },
     instrumentOptions() {
       const options = this.instruments.map((instrument) => ({
         value: instrument.name,
@@ -71,6 +85,17 @@ export default {
 
       return [{ value: null, text: 'Please select a state', disabled: true }, ...options]
     },
+    rebasecallingOptions() {
+      const options = this.rebasecallingList.map((rebasecalling) => ({
+        value: rebasecalling,
+        text: rebasecalling,
+      }))
+
+      return [
+        { value: null, text: 'Please select a rebasecalling process', disabled: true },
+        ...options,
+      ]
+    },
     newRecord() {
       return isNaN(this.currentRun.id)
     },
@@ -79,7 +104,7 @@ export default {
     formatState(str) {
       return str.replace(/\s+/g, '_').toLowerCase()
     },
-    ...mapActions(useOntRunsStore, ['setInstrumentName', 'setState']),
+    ...mapActions(useOntRunsStore, ['setInstrumentName', 'setState', 'setRebasecallingProcess']),
   },
 }
 </script>

--- a/src/components/ont/runs/ONTRunInformation.vue
+++ b/src/components/ont/runs/ONTRunInformation.vue
@@ -11,6 +11,7 @@
           @update:model-value="setInstrumentName"
         ></traction-select>
       </div>
+
       <div class="flex flex-col gap-y-2 items-start">
         <label label-for="state-selection"> State </label>
         <traction-select
@@ -20,8 +21,9 @@
           @update:model-value="setState"
         ></traction-select>
       </div>
+
       <div class="flex flex-col gap-y-2 items-start">
-        <label label-for="rebasecalling-selection"> Rebasecalling process </label>
+        <label label-for="rebasecalling-selection"> Rebasecalling Process </label>
         <traction-select
           id="rebasecalling-selection"
           :options="rebasecallingOptions"
@@ -33,78 +35,58 @@
   </traction-section>
 </template>
 
-<script>
-import { mapState, mapActions } from 'pinia'
+<script setup>
+import { computed } from 'vue'
+import { storeToRefs } from 'pinia'
 import { useOntRunsStore } from '@/stores/ontRuns'
 import useOntRootStore from '@/stores/ontRoot'
 
-/**
- * # ONTRunInformation
- *
- * Displays an information panel allowing the user to select an instrument and state for the run.
- */
-export default {
-  name: 'ONTRunInformation',
-  data() {
-    return {
-      statesList: ['Pending', 'Completed', 'User Terminated', 'Instrument Crashed', 'Restart'],
-      rebasecallingList: ['5mC + 5hmC CpG-context', '5mC + 5hmC all-context', '6mA all-context'],
-    }
-  },
-  computed: {
-    ...mapState(useOntRootStore, ['instruments']),
-    ...mapState(useOntRunsStore, ['currentRun']),
-    instrumentName() {
-      //This is to keep instrumentName in sync with the Pinia store state  (option api way)
-      const ontRunsStore = useOntRunsStore()
-      return ontRunsStore.currentRun.instrument_name
-    },
-    state() {
-      //This is to keep currentRun.state in sync with the Pinia store state  (option api way)
-      const ontRunsStore = useOntRunsStore()
-      return ontRunsStore.currentRun.state
-    },
-    rebasecallingProcess() {
-      //This is to keep currentRun.rebasecalling in sync with the Pinia store state  (option api way)
-      const ontRunsStore = useOntRunsStore()
-      return ontRunsStore.currentRun.rebasecalling_process
-    },
-    instrumentOptions() {
-      const options = this.instruments.map((instrument) => ({
-        value: instrument.name,
-        text: instrument.name,
-      }))
+// Initialize stores
+const ontRunsStore = useOntRunsStore()
+const ontRootStore = useOntRootStore()
 
-      return [{ value: null, text: 'Please select an instrument', disabled: true }, ...options]
-    },
-    stateOptions() {
-      const options = this.statesList.map((state) => ({
-        value: this.formatState(state),
-        text: state,
-      }))
+// Extract reactive properties using storeToRefs()
+const { currentRun } = storeToRefs(ontRunsStore)
+const { instruments } = storeToRefs(ontRootStore)
 
-      return [{ value: null, text: 'Please select a state', disabled: true }, ...options]
-    },
-    rebasecallingOptions() {
-      const options = this.rebasecallingList.map((rebasecalling) => ({
-        value: rebasecalling,
-        text: rebasecalling,
-      }))
+// Actions
+const { setInstrumentName, setState, setRebasecallingProcess } = ontRunsStore
 
-      return [
-        { value: null, text: 'Please select a rebasecalling process', disabled: true },
-        ...options,
-      ]
-    },
-    newRecord() {
-      return isNaN(this.currentRun.id)
-    },
-  },
-  methods: {
-    formatState(str) {
-      return str.replace(/\s+/g, '_').toLowerCase()
-    },
-    ...mapActions(useOntRunsStore, ['setInstrumentName', 'setState', 'setRebasecallingProcess']),
-  },
-}
+// Static lists
+const statesList = ['Pending', 'Completed', 'User Terminated', 'Instrument Crashed', 'Restart']
+const rebasecallingList = ['5mC + 5hmC CpG-context', '5mC + 5hmC all-context', '6mA all-context']
+
+// Computed properties
+const instrumentName = computed(() => currentRun.value.instrument_name)
+const state = computed(() => currentRun.value.state)
+const rebasecallingProcess = computed(() => currentRun.value.rebasecalling_process)
+
+const instrumentOptions = computed(() => [
+  { value: null, text: 'Please select an instrument', disabled: true },
+  ...instruments.value.map((instrument) => ({
+    value: instrument.name,
+    text: instrument.name,
+  })),
+])
+
+const stateOptions = computed(() => [
+  { value: null, text: 'Please select a state', disabled: true },
+  ...statesList.map((state) => ({
+    value: formatState(state),
+    text: state,
+  })),
+])
+
+const rebasecallingOptions = computed(() => [
+  { value: null, text: 'Please select a rebasecalling process', disabled: true },
+  ...rebasecallingList.map((rebasecalling) => ({
+    value: rebasecalling,
+    text: rebasecalling,
+  })),
+])
+
+const newRecord = computed(() => isNaN(currentRun.value.id))
+
+// Helper function to format state values
+const formatState = (str) => str.replace(/\s+/g, '_').toLowerCase()
 </script>

--- a/src/components/ont/runs/ONTRunInformation.vue
+++ b/src/components/ont/runs/ONTRunInformation.vue
@@ -37,6 +37,7 @@
 
 <script setup>
 import { computed } from 'vue'
+import { storeToRefs } from 'pinia'
 import { useOntRunsStore } from '@/stores/ontRuns'
 import useOntRootStore from '@/stores/ontRoot'
 
@@ -44,8 +45,12 @@ import useOntRootStore from '@/stores/ontRoot'
 const ontRunsStore = useOntRunsStore()
 const ontRootStore = useOntRootStore()
 
-const { setInstrumentName, setState, setRebasecallingProcess, currentRun } = ontRunsStore
-const { instruments } = ontRootStore
+// Extract reactive properties using storeToRefs()
+const { currentRun } = storeToRefs(ontRunsStore)
+const { instruments } = storeToRefs(ontRootStore)
+
+// Actions
+const { setInstrumentName, setState, setRebasecallingProcess } = ontRunsStore
 
 // Static lists
 const statesList = ['Pending', 'Completed', 'User Terminated', 'Instrument Crashed', 'Restart']
@@ -53,7 +58,7 @@ const rebasecallingList = ['5mC + 5hmC CpG-context', '5mC + 5hmC all-context', '
 
 const instrumentOptions = computed(() => [
   { value: null, text: 'Please select an instrument', disabled: true },
-  ...instruments.map((instrument) => ({
+  ...instruments.value.map((instrument) => ({
     value: instrument.name,
     text: instrument.name,
   })),
@@ -75,7 +80,7 @@ const rebasecallingOptions = computed(() => [
   })),
 ])
 
-const newRecord = computed(() => isNaN(currentRun.id))
+const newRecord = computed(() => isNaN(currentRun.value.id))
 
 // Helper function to format state values
 const formatState = (str) => str.replace(/\s+/g, '_').toLowerCase()

--- a/src/stores/ontRuns.js
+++ b/src/stores/ontRuns.js
@@ -43,6 +43,7 @@ function createPayload(run, pools) {
       attributes: {
         ont_instrument_id: instrument_id,
         state: run.state,
+        rebasecalling_process: run.rebasecalling_process,
         flowcell_attributes: flowcell_attributes,
       },
     },
@@ -55,6 +56,7 @@ export const useOntRunsStore = defineStore('ontRuns', {
       flowcell_attributes: [],
       id: 'new',
       state: null,
+      rebasecalling_process: null,
       instrument_name: null,
     },
     pools: {},
@@ -82,6 +84,7 @@ export const useOntRunsStore = defineStore('ontRuns', {
         id: 'new',
         instrument_name: null,
         state: null,
+        rebasecalling_process: null,
         flowcell_attributes: [],
       }
     },
@@ -158,6 +161,9 @@ export const useOntRunsStore = defineStore('ontRuns', {
     },
     setState(state) {
       this.currentRun.state = state
+    },
+    setRebasecallingProcess(process) {
+      this.currentRun.rebasecalling_process = process
     },
     setNewFlowCell(position) {
       this.currentRun.flowcell_attributes.push({

--- a/src/stores/utilities/ontRuns.js
+++ b/src/stores/utilities/ontRuns.js
@@ -7,6 +7,7 @@ const buildFormatedOntRun = (instruments, pools, data, included) => {
     id: data.id,
     instrument_name: instrument_name,
     state: data.attributes.state,
+    rebasecalling_process: data.attributes.rebasecalling_process,
     flowcell_attributes: included
       .filter((item) => item.type === 'flowcells')
       .map((fc) => {

--- a/src/views/ont/ONTRunIndex.vue
+++ b/src/views/ont/ONTRunIndex.vue
@@ -73,6 +73,12 @@ export default {
           sortable: true,
           tdClass: 'instrument-name',
         },
+        {
+          key: 'rebasecalling_process',
+          label: 'Rebasecalling Process',
+          sortable: true,
+          tdClass: 'instrument-name',
+        },
         { key: 'created_at', label: 'Created at (UTC)', sortable: true },
         { key: 'actions', label: 'Actions', tdClass: 'actions' },
       ],

--- a/tests/unit/components/ont/runs/ONTRunInformation.spec.js
+++ b/tests/unit/components/ont/runs/ONTRunInformation.spec.js
@@ -16,6 +16,7 @@ describe('ONTRunInformation.vue', () => {
       id: 'new',
       instrument_name: '',
       state: '',
+      rebasecalling_process: '',
       flowcell_attributes: [],
     }
     ;({ wrapper, store } = mountWithStore(ONTRunInformation, {
@@ -37,6 +38,12 @@ describe('ONTRunInformation.vue', () => {
   describe('State selection', () => {
     it('will always show', () => {
       expect(wrapper.find('#state-selection').exists()).toBeTruthy()
+    })
+  })
+
+  describe('Rebasecalling process', () => {
+    it('will always show', () => {
+      expect(wrapper.find('#rebasecalling-selection').exists()).toBeTruthy()
     })
   })
 
@@ -95,6 +102,20 @@ describe('ONTRunInformation.vue', () => {
       }))
       const expected = [{ value: null, text: 'Please select a state', disabled: true }, ...options]
       expect(ontRunInfomation.stateOptions).toEqual(expected)
+    })
+  })
+
+  describe('#rebasecallingProcessOptions', () => {
+    it('must have rebasecallingProcessOptions', () => {
+      const options = ontRunInfomation.rebasecallingList.map((rebasecalling) => ({
+        value: rebasecalling,
+        text: rebasecalling,
+      }))
+      const expected = [
+        { value: null, text: 'Please select a rebasecalling process', disabled: true },
+        ...options,
+      ]
+      expect(ontRunInfomation.rebasecallingOptions).toEqual(expected)
     })
   })
 

--- a/tests/unit/components/ont/runs/ONTRunInformation.spec.js
+++ b/tests/unit/components/ont/runs/ONTRunInformation.spec.js
@@ -61,7 +61,7 @@ describe('ONTRunInformation.vue', () => {
 
   describe('#mapGetters', () => {
     it('must have currentRun', () => {
-      expect(ontRunInfomation.currentRun).toEqual(mockRun)
+      expect(ontRunInfomation.ontRunsStore.currentRun).toEqual(mockRun)
     })
     it('must have instruments', () => {
       const expected = ontInstrumentFactory.storeData.instrumentsArray.map((i) => {

--- a/tests/unit/components/ont/runs/ONTRunInformation.spec.js
+++ b/tests/unit/components/ont/runs/ONTRunInformation.spec.js
@@ -19,7 +19,7 @@ describe('ONTRunInformation.vue', () => {
       rebasecalling_process: '',
       flowcell_attributes: [],
     }
-    ;({ wrapper, store } = mountWithStore(ONTRunInformation, {
+    ;({ wrapper } = mountWithStore(ONTRunInformation, {
       initialState: {
         ontRuns: { currentRun: mockRun },
         ontRoot: { resources: { instruments: mockInstruments } },

--- a/tests/unit/components/ont/runs/ONTRunInformation.spec.js
+++ b/tests/unit/components/ont/runs/ONTRunInformation.spec.js
@@ -8,7 +8,7 @@ import OntInstrumentFactory from '@tests/factories/OntInstrumentFactory.js'
 const ontInstrumentFactory = OntInstrumentFactory()
 
 describe('ONTRunInformation.vue', () => {
-  let wrapper, ontRunInfomation, mockInstruments, mockRun, store
+  let wrapper, ontRunInfomation, mockInstruments, mockRun
 
   beforeEach(() => {
     mockInstruments = ontInstrumentFactory.storeData.instruments

--- a/tests/unit/components/ont/runs/ONTRunInformation.spec.js
+++ b/tests/unit/components/ont/runs/ONTRunInformation.spec.js
@@ -123,13 +123,14 @@ describe('ONTRunInformation.vue', () => {
     it('returns true when currentRun is a new record', () => {
       expect(ontRunInfomation.newRecord).toEqual(true)
     })
-    it('returns false when currentRun is not a new record', () => {
+    it('returns false when currentRun is not a new record', async () => {
       store.setCurrentRun({
         id: '1',
-        instrument_name: '',
+        instrument_name: 'ABC',
         state: '',
         flowcell_attributes: [],
       })
+
       expect(ontRunInfomation.newRecord).toEqual(false)
     })
   })

--- a/tests/unit/components/ont/runs/ONTRunInformation.spec.js
+++ b/tests/unit/components/ont/runs/ONTRunInformation.spec.js
@@ -41,7 +41,7 @@ describe('ONTRunInformation.vue', () => {
     })
   })
 
-  describe('Rebasecalling process', () => {
+  describe('Rebasecalling selection', () => {
     it('will always show', () => {
       expect(wrapper.find('#rebasecalling-selection').exists()).toBeTruthy()
     })

--- a/tests/unit/components/ont/runs/ONTRunInformation.spec.js
+++ b/tests/unit/components/ont/runs/ONTRunInformation.spec.js
@@ -123,15 +123,22 @@ describe('ONTRunInformation.vue', () => {
     it('returns true when currentRun is a new record', () => {
       expect(ontRunInfomation.newRecord).toEqual(true)
     })
-    it('returns false when currentRun is not a new record', async () => {
-      store.setCurrentRun({
-        id: '1',
-        instrument_name: 'ABC',
-        state: '',
-        flowcell_attributes: [],
-      })
 
-      expect(ontRunInfomation.newRecord).toEqual(false)
+    it('returns false when currentRun is not a new record', () => {
+      const { wrapper } = mountWithStore(ONTRunInformation, {
+        initialState: {
+          ontRuns: {
+            currentRun: {
+              id: 1,
+              instrument_name: '',
+              state: '',
+              flowcell_attributes: [],
+            },
+          },
+          ontRoot: { resources: { instruments: mockInstruments } },
+        },
+      })
+      expect(wrapper.vm.newRecord).toEqual(false)
     })
   })
 

--- a/tests/unit/components/ont/runs/ONTRunInformation.spec.js
+++ b/tests/unit/components/ont/runs/ONTRunInformation.spec.js
@@ -61,7 +61,7 @@ describe('ONTRunInformation.vue', () => {
 
   describe('#mapGetters', () => {
     it('must have currentRun', () => {
-      expect(ontRunInfomation.ontRunsStore.currentRun).toEqual(mockRun)
+      expect(ontRunInfomation.currentRun).toEqual(mockRun)
     })
     it('must have instruments', () => {
       const expected = ontInstrumentFactory.storeData.instrumentsArray.map((i) => {
@@ -76,8 +76,8 @@ describe('ONTRunInformation.vue', () => {
   })
   describe('#mapState', () => {
     it('#mapState', () => {
-      expect(ontRunInfomation.instrumentName).toEqual('')
-      expect(ontRunInfomation.state).toEqual('')
+      expect(ontRunInfomation.currentRun.instrument_name).toEqual('')
+      expect(ontRunInfomation.currentRun.state).toEqual('')
     })
   })
   describe('#instrumentOptions', () => {
@@ -120,7 +120,7 @@ describe('ONTRunInformation.vue', () => {
   })
 
   describe('#newRecord', () => {
-    it('returns false when currentRun is a new record', () => {
+    it('returns true when currentRun is a new record', () => {
       expect(ontRunInfomation.newRecord).toEqual(true)
     })
     it('returns false when currentRun is not a new record', () => {
@@ -143,11 +143,11 @@ describe('ONTRunInformation.vue', () => {
   describe('#mapMutations', () => {
     it('#setInstrumentName', () => {
       ontRunInfomation.setInstrumentName('gridion')
-      expect(ontRunInfomation.instrumentName).toEqual('gridion')
+      expect(ontRunInfomation.currentRun.instrument_name).toEqual('gridion')
     })
     it('#setState', () => {
       ontRunInfomation.setState('started')
-      expect(ontRunInfomation.state).toEqual('started')
+      expect(ontRunInfomation.currentRun.state).toEqual('started')
     })
   })
 })

--- a/tests/unit/components/ont/runs/ONTRunInstrumentFlowcells.spec.js
+++ b/tests/unit/components/ont/runs/ONTRunInstrumentFlowcells.spec.js
@@ -16,6 +16,7 @@ describe('ONTRunInstrumentFlowcells', () => {
       id: 'new',
       instrument_name: 'PC24B148',
       state: 'pending',
+      rebasecalling_process: '6mA all-context',
       flowcell_attributes: [],
     }
     ;({ wrapper } = mountWithStore(ONTRunInstrumentFlowcells, {

--- a/tests/unit/stores/ontRuns.spec.js
+++ b/tests/unit/stores/ontRuns.spec.js
@@ -32,6 +32,7 @@ describe('useOntRunsStore', () => {
         id: 'new',
         instrument_name: null,
         state: null,
+        rebasecalling_process: null,
       })
       expect(store.pools).toEqual({})
     })
@@ -111,6 +112,7 @@ describe('useOntRunsStore', () => {
           id: 'new',
           instrument_name: null,
           state: null,
+          rebasecalling_process: null,
         })
       })
     })
@@ -126,6 +128,7 @@ describe('useOntRunsStore', () => {
           id: 1,
           instrument_name: 'GXB02004',
           state: 'pending',
+          rebasecalling_process: '6mA all-context',
           flowcell_attributes: [{ tube_barcode: 'TRAC-2-42', flowcell_id: 1 }],
         }
         store.pools = { 1: { id: '1', tube: 1, tube_barcode: 'TRAC-2-42' } }
@@ -145,6 +148,7 @@ describe('useOntRunsStore', () => {
               attributes: {
                 ont_instrument_id: 1,
                 state: 'pending',
+                rebasecalling_process: '6mA all-context',
                 flowcell_attributes: [
                   { tube_barcode: 'TRAC-2-42', flowcell_id: 1, ont_pool_id: '1' },
                 ],
@@ -173,6 +177,7 @@ describe('useOntRunsStore', () => {
         run = {
           id: '16',
           state: 'pending',
+          rebasecalling_process: '6mA all-context',
           instrument_name: 'GXB02004',
           flowcell_attributes: [],
         }
@@ -184,6 +189,7 @@ describe('useOntRunsStore', () => {
             attributes: {
               state: 'pending',
               ont_instrument_id: 1,
+              rebasecalling_process: '6mA all-context',
               flowcell_attributes: [],
             },
           },


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request
### add rebasecalling process option in create/update ONT run page;
### add rebasecalling process field in ONT run page.
### add rebasecalling process attribute to ONT run model
- 

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
