### PR TITLE
Y24-169 - Remove tube references from PacBio Pool Create

### DIFF
--- a/src/components/pacbio/PacbioPoolEdit.vue
+++ b/src/components/pacbio/PacbioPoolEdit.vue
@@ -28,14 +28,10 @@
                 <traction-label>Auto tagging</traction-label>
                 <traction-toggle v-model="autoTag" data-attribute="check-box" />
               </fieldset>
-              <fieldset v-if="!!tubeItem.barcode" class="flex flex-col">
+              <fieldset v-if="!!pool.barcode" class="flex flex-col">
                 <traction-label class="h-full">Pool Barcode</traction-label>
-                <traction-label
-                  v-if="!!tubeItem.barcode"
-                  data-attribute="barcode"
-                  class="font-bold text-nowrap"
-                >
-                  {{ tubeItem.barcode }}
+                <traction-label data-attribute="barcode" class="font-bold text-nowrap">
+                  {{ pool.barcode }}
                 </traction-label>
               </fieldset>
               <fieldset class="flex flex-col">
@@ -146,7 +142,6 @@ const validated = ref(true) // Flag to indicate if the form data is valid
 
 const {
   pool,
-  tubeItem,
   selectedUsedAliquots,
   createPool,
   updatePool,

--- a/src/components/shared/LoadingFullScreenModal.vue
+++ b/src/components/shared/LoadingFullScreenModal.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     v-if="visible"
-    class="bg-black fixed inset-0 py-24 bg-opacity-75 select-none"
+    class="bg-black/75 fixed inset-0 py-24 select-none"
     data-type="loading-full-screen-modal"
   >
     <div class="flex flex-col h-full items-center justify-center">

--- a/src/services/labwhere/client.js
+++ b/src/services/labwhere/client.js
@@ -113,12 +113,11 @@ const exhaustLibraryVolumeIfDestroyed = async (locationBarcode, labwareBarcodes)
   const fetchAndMergeLibraries = async (barcodes, filterKey) => {
     const filterOptions = { filter: { [filterKey]: barcodes.join(',') } }
 
-    const { success, libraries, tubes, tags, requests } =
-      await getPacbioLibraryResources(filterOptions)
+    const { success, libraries, tags, requests } = await getPacbioLibraryResources(filterOptions)
     if (success) {
       librariesToDestroy = [
         ...librariesToDestroy,
-        ...formatAndTransformLibraries(libraries, tubes, tags, requests),
+        ...formatAndTransformLibraries(libraries, tags, requests),
       ]
     }
   }

--- a/src/services/traction/PacbioLibrary.js
+++ b/src/services/traction/PacbioLibrary.js
@@ -7,11 +7,11 @@ import useRootStore from '@/stores/index.js'
  *
  * @param {Object} getPacbioLibraryResources - The options to fetch libraries with.
  * The options include page, filter, and include.
- * e.g { page: { "size": "24", "number": "1"}, filter: { source_identifier: 'sample1' }, include: 'request,tag,tube' }
+ * e.g { page: { "size": "24", "number": "1"}, filter: { source_identifier: 'sample1' }, include: 'request,tag' }
  */
 async function getPacbioLibraryResources(fetchOptions = {}) {
   const includes = new Set(fetchOptions.include ? fetchOptions.include.split(',') : [])
-  const requiredIncludes = ['request', 'tag', 'tube']
+  const requiredIncludes = ['request', 'tag']
   requiredIncludes.forEach((item) => includes.add(item))
 
   const fetchOptionsDefaultInclude = {
@@ -23,21 +23,15 @@ async function getPacbioLibraryResources(fetchOptions = {}) {
 
   const { success, body: { data, included = [], meta = {} } = {}, errors = [] } = response
   let libraries = {},
-    tubes = {},
     tags = {},
     requests = {}
   if (success && data && data.length > 0) {
-    const {
-      tubes: included_tubes,
-      tags: included_tags,
-      requests: included_requests,
-    } = groupIncludedByResource(included)
+    const { tags: included_tags, requests: included_requests } = groupIncludedByResource(included)
     libraries = dataToObjectById({ data, includeRelationships: true })
-    tubes = dataToObjectById({ data: included_tubes })
     tags = dataToObjectById({ data: included_tags })
     requests = dataToObjectById({ data: included_requests })
   }
-  return { success, data, errors, meta, libraries, tubes, tags, requests }
+  return { success, data, errors, meta, libraries, tags, requests }
 }
 
 /**

--- a/src/stores/pacbioPoolCreate.js
+++ b/src/stores/pacbioPoolCreate.js
@@ -524,7 +524,6 @@ export const usePacbioPoolCreateStore = defineStore('pacbioPoolCreate', {
      * Validates the used_aliquots before proceeding.
      * If the used_aliquots are not valid, returns an error response.
      * Otherwise, sends a request to create the pool and handles the response.
-     * Groups the included resources by type and extracts the barcode from the first tube.
      *
      * @async
      * @returns {Promise<Object>} A promise that resolves to an object containing the success status, barcode, and any errors.

--- a/src/stores/pacbioPoolCreate.js
+++ b/src/stores/pacbioPoolCreate.js
@@ -285,8 +285,6 @@ export const usePacbioPoolCreateStore = defineStore('pacbioPoolCreate', {
           return { ...request, selected: !!selectedUsedAliquots[`_${source}`] }
         })
       }
-      console.log(source_obj)
-      console.log(val)
       return val
     },
     /**

--- a/src/stores/utilities/pacbioLibraries.js
+++ b/src/stores/utilities/pacbioLibraries.js
@@ -37,6 +37,7 @@ const validateLibraryFields = (library) => {
 const formatAndTransformLibraries = (libraries, tags, requests) =>
   Object.values(libraries).map((library) => {
     const { id, request, tag_id, tag, ...attributes } = library
+    // TODO: Look into the below tag lines and see if they can be simplified
     const tagId = tag_id ?? tag
     const tagGroupId = tags[tagId] ? (tags[tagId].group_id ?? '') : ''
     return {

--- a/src/stores/utilities/pacbioLibraries.js
+++ b/src/stores/utilities/pacbioLibraries.js
@@ -30,28 +30,23 @@ const validateLibraryFields = (library) => {
  * Formats and transforms libraries.
  *
  * @param {Object} libraries - The libraries to format and transform.
- * @param {Object} tubes - The tubes associated with the libraries.
  * @param {Object} tags - The tags associated with the libraries.
  * @param {Object} requests - The requests associated with the libraries.
  * @returns {Array<Object>} - The formatted and transformed libraries.
  */
-const formatAndTransformLibraries = (libraries, tubes, tags, requests) =>
-  Object.values(libraries)
-    .filter((library) => library.tube)
-    .map((library) => {
-      const { id, request, tag_id, tag, tube, ...attributes } = library
-      const tagId = tag_id ?? tag
-      const tagGroupId = tags[tagId] ? (tags[tagId].group_id ?? '') : ''
-      return {
-        id,
-        tag_id: String(tagId),
-        tube,
-        ...attributes,
-        tag_group_id: tagGroupId,
-        sample_name: requests[request]?.sample_name,
-        barcode: tubes[tube]?.barcode,
-      }
-    })
+const formatAndTransformLibraries = (libraries, tags, requests) =>
+  Object.values(libraries).map((library) => {
+    const { id, request, tag_id, tag, ...attributes } = library
+    const tagId = tag_id ?? tag
+    const tagGroupId = tags[tagId] ? (tags[tagId].group_id ?? '') : ''
+    return {
+      id,
+      tag_id: String(tagId),
+      ...attributes,
+      tag_group_id: tagGroupId,
+      sample_name: requests[request]?.sample_name,
+    }
+  })
 
 /**
  * Exhausts the volume of a library.

--- a/src/stores/utilities/pool.js
+++ b/src/stores/utilities/pool.js
@@ -199,14 +199,13 @@ const createUsedAliquotsFromState = ({ pool, state }) => {
 }
 
 /**
- * @param {Object} state - The state object - pools, tubes, used_aliquots, requests, tags
+ * @param {Object} state - The state object - pools, used_aliquots, requests, tags
  * @returns {Object[]} The array of pools with the retrieved data.
  * This function takes the state object as an argument and returns an array of pools with the retrieved data.
  * It maps over the values of the pools object, and for each pool, it creates an array of used aliquots using the `createUsedAliquotsFromState` function.
- * It retrieves the barcode for each pool from the tubes object based on the pool's tube.
  * It returns the pools with the retrieved data, including the used aliquots, barcode, and run suitability
  */
-const addUsedAliquotsBarcodeAndErrorsToPools = (state) => {
+const addUsedAliquotsAndErrorsToPools = (state) => {
   return Object.values(state.pools).map((pool) => {
     const used_aliquots = createUsedAliquotsFromState({ pool, state })
     return {
@@ -228,5 +227,5 @@ export {
   assignRequestIdsToTubes,
   buildRunSuitabilityErrors,
   createUsedAliquotsFromState,
-  addUsedAliquotsBarcodeAndErrorsToPools,
+  addUsedAliquotsAndErrorsToPools,
 }

--- a/src/stores/utilities/pool.js
+++ b/src/stores/utilities/pool.js
@@ -209,11 +209,9 @@ const createUsedAliquotsFromState = ({ pool, state }) => {
 const addUsedAliquotsBarcodeAndErrorsToPools = (state) => {
   return Object.values(state.pools).map((pool) => {
     const used_aliquots = createUsedAliquotsFromState({ pool, state })
-    const { barcode } = state.tubes[pool.tube]
     return {
       ...pool,
       used_aliquots,
-      barcode,
       run_suitability: {
         ...pool.run_suitability,
         formattedErrors: buildRunSuitabilityErrors({ used_aliquots, pool }),

--- a/src/views/pacbio/PacbioLibraryIndex.vue
+++ b/src/views/pacbio/PacbioLibraryIndex.vue
@@ -21,7 +21,7 @@
         <!-- Confirmation Modal -->
         <div
           v-if="showConfirmationModal"
-          class="fixed top-0 left-0 w-full h-full flex items-center justify-center bg-black bg-opacity-50"
+          class="fixed top-0 left-0 w-full h-full flex items-center justify-center bg-black/50 z-1"
         >
           <div class="bg-white p-6 rounded shadow-lg">
             <p class="mb-4">Are you sure you want to delete the selected libraries?</p>

--- a/tests/e2e/specs/pacbio/create_pacbio_library_from_samples_page.cy.js
+++ b/tests/e2e/specs/pacbio/create_pacbio_library_from_samples_page.cy.js
@@ -8,7 +8,7 @@ describe('Pacbio library creation from sample', () => {
     cy.wrap(PacbioTagSetFactory()).as('pacbioTagSetFactory')
     cy.wrap(PrinterFactory()).as('printerFactory')
     cy.wrap(PacbioRequestFactory({ includeRelationships: false })).as('pacbioRequestFactory')
-    cy.wrap(PacbioLibraryFactory()).as('pacbioLibraryFactory')
+    cy.wrap(PacbioLibraryFactory({ count: 1 })).as('pacbioLibraryFactory')
   })
 
   it('Visits the pacbio samples url', () => {
@@ -33,14 +33,17 @@ describe('Pacbio library creation from sample', () => {
       })
     })
 
-    // something not quite right here.
-    // we are not returning the primary aliquot plus we are hard coding the data.
-    cy.get('@pacbioLibraryFactory').then((pacbioLibraryFactory) => {
-      cy.intercept('/v1/pacbio/libraries?include=tube,primary_aliquot', {
-        statusCode: 200,
-        body: pacbioLibraryFactory.content,
-      })
+    cy.intercept('/v1/pacbio/libraries?include=primary_aliquot', {
+      statusCode: 200,
+      body: {
+        data: {
+          attributes: {
+            barcode: 'TRAC-2-721',
+          },
+        },
+      },
     })
+
     cy.visit('#/pacbio/samples')
     cy.get('#samples-table').contains('td', '5')
     cy.get('#samples-table').first().click()

--- a/tests/e2e/specs/pacbio/pacbio_libraries_view.cy.js
+++ b/tests/e2e/specs/pacbio/pacbio_libraries_view.cy.js
@@ -9,7 +9,7 @@ describe('Pacbio Libraries view', () => {
     cy.wrap(PacbioLibraryFactory()).as('pacbioLibraryFactory')
 
     cy.get('@pacbioLibraryFactory').then((pacbioLibraryFactory) => {
-      cy.intercept('/v1/pacbio/libraries?page[size]=25&page[number]=1&include=request,tag,tube', {
+      cy.intercept('/v1/pacbio/libraries?page[size]=25&page[number]=1&include=request,tag', {
         statusCode: 200,
         body: pacbioLibraryFactory.content,
       })

--- a/tests/e2e/specs/pacbio/pacbio_libraries_view.cy.js
+++ b/tests/e2e/specs/pacbio/pacbio_libraries_view.cy.js
@@ -53,11 +53,11 @@ describe('Pacbio Libraries view', () => {
   // it would be better to use the factory to get the values.
   it('allows editing a library and updates the library values', () => {
     cy.get('@pacbioTagSetFactory').then((pacbioTagSetFactory) => {
-      cy.intercept('PATCH', '/v1/pacbio/libraries/722', {
+      cy.intercept('PATCH', '/v1/pacbio/libraries/725', {
         statusCode: 200,
         body: {
           data: {
-            id: '722',
+            id: '725',
             attributes: {
               concentration: 2.0,
               template_prep_kit_box_barcode: 'LK54321',
@@ -65,6 +65,7 @@ describe('Pacbio Libraries view', () => {
               available_volume: 3.0,
               insert_size: 200,
               tag_id: pacbioTagSetFactory.storeData.selected.tag.id,
+              barcode: 'TRAC-2-725',
             },
           },
         },
@@ -72,10 +73,8 @@ describe('Pacbio Libraries view', () => {
     })
 
     cy.visit('#/pacbio/libraries')
-    //When clicking on edit again on a librray with no  tag
-    cy.get('#show_details').within(() => {
-      cy.get('#edit-btn-722').click()
-    })
+    //When clicking on edit again on a library with no  tag
+    cy.get('#edit-btn-725').click()
     //It should show the form to edit the library with the values with an empty tag
     cy.get('#libraryForm').should('be.visible')
     cy.get('#library-volume').should('have.value', '1')
@@ -96,7 +95,7 @@ describe('Pacbio Libraries view', () => {
       cy.get('#tag-input').select(pacbioTagSetFactory.storeData.selected.tag.group_id)
     })
     cy.get('#update-btn').click()
-    cy.contains('Updated library with barcode TRAC-2-722')
+    cy.contains('Updated library with barcode TRAC-2-725')
     cy.get('#libraryForm').should('not.exist')
 
     //It should display updated values in table

--- a/tests/e2e/specs/pacbio/pacbio_pool_create.cy.js
+++ b/tests/e2e/specs/pacbio/pacbio_pool_create.cy.js
@@ -106,15 +106,13 @@ describe('Pacbio Pool Create', () => {
         })
     })
 
-    cy.intercept('POST', '/v1/pacbio/pools?include=tube', {
+    cy.intercept('POST', '/v1/pacbio/pools', {
       statusCode: 201,
       body: {
         data: {
-          pool: {
+          attributes: {
             id: '1',
-            tube: {
-              barcode: 'TRAC-1',
-            },
+            barcode: 'TRAC-1',
           },
         },
       },
@@ -156,7 +154,7 @@ describe('Pacbio Pool Create', () => {
       cy.get('[data-attribute=concentration]').type('10.0')
       cy.get('[data-attribute=insert-size]').type('100')
     })
-    cy.intercept('POST', '/v1/pacbio/pools?include=tube', {
+    cy.intercept('POST', '/v1/pacbio/pools', {
       statusCode: 422,
       body: {
         errors: {
@@ -243,15 +241,13 @@ describe('Pacbio Pool Create', () => {
         .should('have.value', tagList[1].id)
     })
 
-    cy.intercept('POST', '/v1/pacbio/pools?include=tube', {
+    cy.intercept('POST', '/v1/pacbio/pools', {
       statusCode: 201,
       body: {
         data: {
-          pool: {
+          attributes: {
             id: '1',
-            tube: {
-              barcode: 'TRAC-1',
-            },
+            barcode: 'TRAC-1',
           },
         },
       },
@@ -317,15 +313,13 @@ describe('Pacbio Pool Create', () => {
         .should('have.value', tagList[1].id)
     })
 
-    cy.intercept('POST', '/v1/pacbio/pools?include=tube', {
+    cy.intercept('POST', '/v1/pacbio/pools', {
       statusCode: 201,
       body: {
         data: {
-          pool: {
+          attributes: {
             id: '1',
-            tube: {
-              barcode: 'TRAC-1',
-            },
+            barcode: 'TRAC-1',
           },
         },
       },

--- a/tests/e2e/specs/pacbio/pacbio_pool_edit.cy.js
+++ b/tests/e2e/specs/pacbio/pacbio_pool_edit.cy.js
@@ -37,7 +37,7 @@ describe('Pacbio Pool Edit', () => {
     cy.wrap(PacbioPoolFactory({ count: 1 })).as('pacbioPoolFactoryForSinglePool')
     cy.get('@pacbioPoolFactoryForSinglePool').then((pacbioPoolFactoryForSinglePool) => {
       cy.intercept(
-        'v1/pacbio/pools/6011?include=used_aliquots.tag.tag_set,requests.tube,tube,libraries.tube,libraries.request,requests.plate.wells.requests',
+        'v1/pacbio/pools/6011?include=used_aliquots.tag.tag_set,requests.tube,libraries.tube,libraries.request,requests.plate.wells.requests',
         {
           statusCode: 200,
           body: pacbioPoolFactoryForSinglePool.content,
@@ -49,7 +49,7 @@ describe('Pacbio Pool Edit', () => {
     cy.get('@pacbioPoolFactoryForSinglePoolWithPlate').then(
       (pacbioPoolFactoryForSinglePoolWithPlate) => {
         cy.intercept(
-          'v1/pacbio/pools/15?include=used_aliquots.tag.tag_set,requests.tube,tube,libraries.tube,libraries.request,requests.plate.wells.requests',
+          'v1/pacbio/pools/15?include=used_aliquots.tag.tag_set,requests.tube,libraries.tube,libraries.request,requests.plate.wells.requests',
           {
             statusCode: 200,
             body: pacbioPoolFactoryForSinglePoolWithPlate.content,

--- a/tests/e2e/specs/pacbio/pacbio_pool_edit.cy.js
+++ b/tests/e2e/specs/pacbio/pacbio_pool_edit.cy.js
@@ -19,7 +19,7 @@ describe('Pacbio Pool Edit', () => {
     cy.get('@pacbioPoolFactory').then((pacbioPoolFactory) => {
       cy.intercept(
         'GET',
-        'v1/pacbio/pools?page[size]=25&page[number]=1&include=tube,used_aliquots.tag,used_aliquots.source,libraries.request&fields[requests]=sample_name&fields[tubes]=barcode&fields[tags]=group_id',
+        'v1/pacbio/pools?page[size]=25&page[number]=1&include=used_aliquots.tag,used_aliquots.source,libraries.request&fields[requests]=sample_name&fields[tags]=group_id',
         {
           statusCode: 200,
           body: pacbioPoolFactory.content,

--- a/tests/e2e/specs/pacbio/pacbio_pools_view.cy.js
+++ b/tests/e2e/specs/pacbio/pacbio_pools_view.cy.js
@@ -7,7 +7,7 @@ describe('Pacbio Pools view', () => {
     cy.get('@pacbioPoolFactory').then((pacbioPoolFactory) => {
       cy.intercept(
         'GET',
-        'v1/pacbio/pools?page[size]=25&page[number]=1&include=tube,used_aliquots.tag,used_aliquots.source,libraries.request&fields[requests]=sample_name&fields[tubes]=barcode&fields[tags]=group_id',
+        'v1/pacbio/pools?page[size]=25&page[number]=1&include=used_aliquots.tag,used_aliquots.source,libraries.request&fields[requests]=sample_name&fields[tags]=group_id',
         {
           statusCode: 200,
           body: pacbioPoolFactory.content,

--- a/tests/e2e/specs/visit_labwhere_reception_page.cy.js
+++ b/tests/e2e/specs/visit_labwhere_reception_page.cy.js
@@ -44,13 +44,10 @@ describe('Labware Reception page', () => {
 
     cy.wrap(pacbioLibraryFactory).as('pacbioLibraryFactory')
     cy.get('@pacbioLibraryFactory').then((pacbioLibraryFactory) => {
-      cy.intercept(
-        '/v1/pacbio/libraries?filter[barcode]=barcode1,barcode2&include=request,tag,tube',
-        {
-          statusCode: 200,
-          body: pacbioLibraryFactory.content,
-        },
-      )
+      cy.intercept('/v1/pacbio/libraries?filter[barcode]=barcode1,barcode2&include=request,tag', {
+        statusCode: 200,
+        body: pacbioLibraryFactory.content,
+      })
       cy.intercept('PATCH', '/v1/pacbio/libraries/722', {
         statusCode: 200,
         body: {

--- a/tests/factories/PacbioLibraryFactory.js
+++ b/tests/factories/PacbioLibraryFactory.js
@@ -8,12 +8,11 @@ import { groupIncludedByResource, dataToObjectById } from '../../src/api/JsonApi
  * @description A function that creates an object with the libraries, tubes, tags, and requests data.
  */
 const createStoreData = ({ data, included }) => {
-  const { tubes, tags, requests } = groupIncludedByResource(included)
+  const { tags, requests } = groupIncludedByResource(included)
   const libraries = dataToObjectById({ data, includeRelationships: true })
 
   return {
     libraries,
-    tubes: dataToObjectById({ data: tubes }),
     tags: dataToObjectById({ data: tags }),
     requests: dataToObjectById({ data: requests }),
   }
@@ -47,6 +46,7 @@ const PacbioLibraryFactory = ({ relationships = true, exhausted = false } = {}) 
             ready_for_run: true,
             errors: [],
           },
+          barcode: 'TRAC-2-721',
         },
         relationships: {
           request: {
@@ -79,12 +79,6 @@ const PacbioLibraryFactory = ({ relationships = true, exhausted = false } = {}) 
               id: '1',
             },
           },
-          tube: {
-            data: {
-              type: 'tubes',
-              id: '721',
-            },
-          },
         },
       },
       {
@@ -106,6 +100,7 @@ const PacbioLibraryFactory = ({ relationships = true, exhausted = false } = {}) 
             ready_for_run: true,
             errors: [],
           },
+          barcode: 'TRAC-2-722',
         },
         relationships: {
           request: {
@@ -138,12 +133,6 @@ const PacbioLibraryFactory = ({ relationships = true, exhausted = false } = {}) 
               id: '2',
             },
           },
-          tube: {
-            data: {
-              type: 'tubes',
-              id: '722',
-            },
-          },
         },
       },
       {
@@ -165,6 +154,7 @@ const PacbioLibraryFactory = ({ relationships = true, exhausted = false } = {}) 
             ready_for_run: true,
             errors: [],
           },
+          barcode: 'TRAC-2-723',
         },
         relationships: {
           request: {
@@ -218,6 +208,7 @@ const PacbioLibraryFactory = ({ relationships = true, exhausted = false } = {}) 
             ready_for_run: true,
             errors: [],
           },
+          barcode: 'TRAC-2-724',
         },
         relationships: {
           request: {
@@ -271,6 +262,7 @@ const PacbioLibraryFactory = ({ relationships = true, exhausted = false } = {}) 
             ready_for_run: true,
             errors: [],
           },
+          barcode: 'TRAC-2-725',
         },
         relationships: {
           request: {

--- a/tests/factories/PacbioPoolFactory.js
+++ b/tests/factories/PacbioPoolFactory.js
@@ -37,8 +37,6 @@ const createStoreDataForSinglePool = (data) => {
     tubes,
   })
 
-  delete storeTubes[data.data.relationships.tube.data.id]
-
   const used_aliquots = createUsedAliquotsAndMapToSourceId({
     aliquots,
     libraries: storeLibraries,
@@ -136,18 +134,9 @@ const PacbioPoolFactory = ({ count = undefined, includeAll = false, start = 0 } 
           used_volume: 15.0,
           available_volume: 0.0,
           source_identifier: 'TRAC-2-11876,TRAC-2-11877',
+          barcode: 'TRAC-2-1',
         },
         relationships: {
-          tube: {
-            links: {
-              self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/pools/6011/relationships/tube',
-              related: 'https://traction.psd.sanger.ac.uk/v1/pacbio/pools/6011/tube',
-            },
-            data: {
-              type: 'tubes',
-              id: '12066',
-            },
-          },
           used_aliquots: {
             links: {
               self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/pools/6011/relationships/used_aliquots',
@@ -215,18 +204,9 @@ const PacbioPoolFactory = ({ count = undefined, includeAll = false, start = 0 } 
           used_volume: 0,
           available_volume: 20.0,
           source_identifier: 'GEN-1730730210-1:A1-B1',
+          barcode: 'TRAC-2-15',
         },
         relationships: {
-          tube: {
-            links: {
-              self: 'http://localhost:3100/v1/pacbio/pools/15/relationships/tube',
-              related: 'http://localhost:3100/v1/pacbio/pools/15/tube',
-            },
-            data: {
-              type: 'tubes',
-              id: '25',
-            },
-          },
           used_aliquots: {
             links: {
               self: 'http://localhost:3100/v1/pacbio/pools/15/relationships/used_aliquots',
@@ -288,22 +268,13 @@ const PacbioPoolFactory = ({ count = undefined, includeAll = false, start = 0 } 
           source_identifier: 'DN1:A1',
           created_at: '2021-07-15T15:26:29.000Z',
           updated_at: '2021-07-15T15:26:29.000Z',
+          barcode: 'TRAC-2-5',
           run_suitability: {
             ready_for_run: true,
             errors: [],
           },
         },
         relationships: {
-          tube: {
-            links: {
-              self: '/v1/pacbio/pools/1/relationships/tube',
-              related: '/v1/pacbio/pools/1/tube',
-            },
-            data: {
-              type: 'tubes',
-              id: '1',
-            },
-          },
           used_aliquots: {
             links: {
               self: '/v1/pacbio/pools/1/relationships/aliquots',
@@ -332,22 +303,13 @@ const PacbioPoolFactory = ({ count = undefined, includeAll = false, start = 0 } 
           source_identifier: 'DN1:B1',
           created_at: '2021-07-15T15:26:29.000Z',
           updated_at: '2021-07-15T15:26:29.000Z',
+          barcode: 'TRAC-2-6',
           run_suitability: {
             ready_for_run: true,
             errors: [],
           },
         },
         relationships: {
-          tube: {
-            links: {
-              self: '/v1/pacbio/pools/2/relationships/tube',
-              related: '/v1/pacbio/pools/2/tube',
-            },
-            data: {
-              type: 'tubes',
-              id: '2',
-            },
-          },
           used_aliquots: {
             links: {
               self: '/v1/pacbio/pools/2/relationships/aliquots',
@@ -563,48 +525,6 @@ const PacbioPoolFactory = ({ count = undefined, includeAll = false, start = 0 } 
                 id: '369',
               },
             ],
-          },
-        },
-      },
-      {
-        id: '12066',
-        type: 'tubes',
-        links: {
-          self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/12066',
-        },
-        attributes: {
-          barcode: 'TRAC-2-12066',
-        },
-        relationships: {
-          materials: {
-            links: {
-              self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/12066/relationships/materials',
-              related: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/12066/materials',
-            },
-          },
-          pools: {
-            links: {
-              self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/12066/relationships/pools',
-              related: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/12066/pools',
-            },
-            data: [
-              {
-                type: 'pools',
-                id: '6011',
-              },
-            ],
-          },
-          libraries: {
-            links: {
-              self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/12066/relationships/libraries',
-              related: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/12066/libraries',
-            },
-          },
-          requests: {
-            links: {
-              self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/12066/relationships/requests',
-              related: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/12066/requests',
-            },
           },
         },
       },

--- a/tests/unit/components/pacbio/PacbioPoolEdit.spec.js
+++ b/tests/unit/components/pacbio/PacbioPoolEdit.spec.js
@@ -220,10 +220,6 @@ describe('pacbioPoolEdit#edit', () => {
     concentration: 2.4,
     insert_size: 100,
     used_volume: 2,
-  }
-
-  const tube = {
-    id: '1',
     barcode: 'TRAC-1',
   }
 
@@ -231,7 +227,7 @@ describe('pacbioPoolEdit#edit', () => {
 
   beforeEach(() => {
     ;({ wrapper, store } = mountPacbioPoolEdit({
-      state: { pool, tube, used_aliquots: {} },
+      state: { pool, used_aliquots: {} },
     }))
   })
 
@@ -303,8 +299,8 @@ describe('pacbioPoolEdit#edit', () => {
     })
   })
 
-  describe('tube', () => {
-    it('barcode', async () => {
+  describe('pool barcode', () => {
+    it('is present', async () => {
       const barcode = wrapper.find('[data-attribute=barcode]')
       expect(barcode.text()).toContain('TRAC-1')
     })

--- a/tests/unit/services/traction/PacbioLibrary.spec.js
+++ b/tests/unit/services/traction/PacbioLibrary.spec.js
@@ -36,27 +36,26 @@ describe('PacbioLibrary', () => {
     it('calls the api to fetch libraries with default includea', async () => {
       const fetchOptions = { filter: { source_identifier: 'sample1' } }
       await getPacbioLibraryResources(fetchOptions)
-      expect(get).toHaveBeenCalledWith({ ...fetchOptions, include: 'request,tag,tube' })
+      expect(get).toHaveBeenCalledWith({ ...fetchOptions, include: 'request,tag' })
     })
 
     it('calls the api to fetch libraries with custom includes along with default includes', async () => {
       const fetchOptions = { include: 'test' }
       await getPacbioLibraryResources(fetchOptions)
-      expect(get).toHaveBeenCalledWith({ ...fetchOptions, include: 'test,request,tag,tube' })
+      expect(get).toHaveBeenCalledWith({ ...fetchOptions, include: 'test,request,tag' })
     })
     it('calls api to fetch libraries with joined includes if custom includes includes default values', async () => {
-      const fetchOptions = { include: 'request,tag,tube,test' }
+      const fetchOptions = { include: 'request,tag,test' }
       await getPacbioLibraryResources(fetchOptions)
-      expect(get).toHaveBeenCalledWith({ ...fetchOptions, include: 'request,tag,tube,test' })
+      expect(get).toHaveBeenCalledWith({ ...fetchOptions, include: 'request,tag,test' })
     })
 
     it('calls api successfully', async () => {
       get.mockResolvedValue(pacbioLibraryFactory.responses.fetch)
-      const { success, errors, libraries, tubes, requests } = await getPacbioLibraryResources()
+      const { success, errors, libraries, requests } = await getPacbioLibraryResources()
       expect(success).toEqual(true)
       expect(errors).toEqual([])
       expect(libraries).toEqual(pacbioLibraryFactory.storeData.libraries)
-      expect(tubes).toEqual(pacbioLibraryFactory.storeData.tubes)
       expect(requests).toEqual(pacbioLibraryFactory.storeData.requests)
     })
 
@@ -80,7 +79,6 @@ describe('PacbioLibrary', () => {
       const libraryFields = {
         id: 1,
         tag_id: 1,
-        tube: 1,
         concentration: 1,
         volume: 1,
         insert_size: 1,
@@ -95,7 +93,6 @@ describe('PacbioLibrary', () => {
       const libraryFields = {
         id: 1,
         tag_id: 1,
-        tube: 1,
         concentration: 1,
         volume: 1,
         insert_size: 1,

--- a/tests/unit/stores/pacbioLibraries.spec.js
+++ b/tests/unit/stores/pacbioLibraries.spec.js
@@ -76,11 +76,9 @@ describe('usePacbioLibrariesStore', () => {
       const store = usePacbioLibrariesStore()
 
       store.$state = { ...pacbioLibraryFactory.storeData }
-      const { libraries, tubes, tags, requests } = pacbioLibraryFactory.storeData
+      const { libraries, tags, requests } = pacbioLibraryFactory.storeData
 
-      expect(store.librariesArray).toEqual(
-        formatAndTransformLibraries(libraries, tubes, tags, requests),
-      )
+      expect(store.librariesArray).toEqual(formatAndTransformLibraries(libraries, tags, requests))
     })
   })
   describe('actions', () => {
@@ -108,14 +106,13 @@ describe('usePacbioLibrariesStore', () => {
       })
       it('successfully', async () => {
         const mockResponse = successfulResponse({
-          data: {},
-          included: [{ type: 'tubes', attributes: { barcode: 'TRAC-1' } }],
+          data: { attributes: { barcode: 'TRAC-1' } },
         })
         create.mockResolvedValue(mockResponse)
         const { success, barcode } = await store.createLibrary(formLibrary)
         expect(create).toBeCalledWith({
           data: buildLibraryResourcePayload({ ...requiredAttributes, pacbio_request_id: 1 }),
-          include: 'tube,primary_aliquot',
+          include: 'primary_aliquot',
         })
         expect(success).toBeTruthy()
         expect(barcode).toEqual('TRAC-1')
@@ -171,9 +168,6 @@ describe('usePacbioLibrariesStore', () => {
         const expectedLibrary = Object.values(pacbioLibraryFactory.storeData.libraries)[0]
 
         expect(store.libraries[expectedLibrary.id]).toEqual(expectedLibrary)
-        expect(store.tubes[expectedLibrary.tube]).toEqual(
-          pacbioLibraryFactory.storeData.tubes[expectedLibrary.tube],
-        )
         expect(store.tags[expectedLibrary.tag]).toEqual(
           pacbioLibraryFactory.storeData.tags[expectedLibrary.tag],
         )
@@ -184,7 +178,7 @@ describe('usePacbioLibrariesStore', () => {
         expect(errors).toEqual([])
       })
 
-      it('when the library has no request, tube or tag', async () => {
+      it('when the library has no request, or tag', async () => {
         get.mockResolvedValue(pacbioLibraryWithoutRelationships.responses.fetch)
 
         const { success, errors } = await store.fetchLibraries()
@@ -192,7 +186,6 @@ describe('usePacbioLibrariesStore', () => {
           pacbioLibraryWithoutRelationships.storeData.libraries,
         )[0]
         expect(store.libraries[expectedLibrary.id]).toEqual(expectedLibrary)
-        expect(store.tubes).toEqual({})
         expect(success).toEqual(true)
         expect(errors).toEqual([])
       })

--- a/tests/unit/stores/pacbioPoolCreate.spec.js
+++ b/tests/unit/stores/pacbioPoolCreate.spec.js
@@ -177,23 +177,6 @@ describe('usePacbioPoolCreateStore', () => {
       store.used_aliquots = used_aliquots
       expect(store.usedAliquotItem('3')).toEqual(used_aliquots['_3'])
     })
-
-    describe('tubeItem', () => {
-      const tube = {
-        id: 1,
-        barcode: 'TRAC-1',
-      }
-
-      it('returns the correct data', () => {
-        store.tube = tube
-        expect(store.tubeItem).toEqual(tube)
-      })
-
-      it('when the tube does not exist', () => {
-        store.tube = undefined
-        expect(store.tubeItem).toEqual({})
-      })
-    })
   })
 
   describe('actions', () => {
@@ -523,8 +506,7 @@ describe('usePacbioPoolCreateStore', () => {
       // for now: create a pool state with a simple success message
       it('when the pool is valid', async () => {
         const mockResponse = successfulResponse({
-          data: {},
-          included: [{ type: 'tubes', attributes: { barcode: 'TRAC-1' } }],
+          data: { attributes: { barcode: 'TRAC-1' } },
         })
         const used_aliquots = {
           _1: used_aliquot1,
@@ -536,7 +518,6 @@ describe('usePacbioPoolCreateStore', () => {
         const { success, barcode } = await store.createPool()
         expect(create).toHaveBeenCalledWith({
           data: payload({ used_aliquots, pool }),
-          include: expect.anything(),
         })
         expect(success).toBeTruthy()
         expect(barcode).toEqual('TRAC-1')
@@ -587,7 +568,6 @@ describe('usePacbioPoolCreateStore', () => {
 
         expect(create).toHaveBeenCalledWith({
           data: playload,
-          include: expect.anything(),
         })
 
         expect(playload.data.attributes.used_aliquots_attributes[0].source_type).toEqual(

--- a/tests/unit/stores/pacbioPools.spec.js
+++ b/tests/unit/stores/pacbioPools.spec.js
@@ -3,7 +3,7 @@ import { usePacbioPoolsStore } from '@/stores/pacbioPools.js'
 import useRootStore from '@/stores'
 import { expect } from 'vitest'
 import PacbioPoolFactory from '@tests/factories/PacbioPoolFactory.js'
-import { addUsedAliquotsBarcodeAndErrorsToPools } from '@/stores/utilities/pool.js'
+import { addUsedAliquotsAndErrorsToPools } from '@/stores/utilities/pool.js'
 import { failedResponse } from '@support/testHelper.js'
 
 const pacbioPoolFactory = PacbioPoolFactory()
@@ -23,9 +23,7 @@ describe('usePacbioPools', () => {
       store.$state = pacbioPoolFactory.storeData
     })
     it('"poolsArrays" returns denormalized pools from "state.pools"', () => {
-      expect(store.poolsArray).toEqual(
-        addUsedAliquotsBarcodeAndErrorsToPools(pacbioPoolFactory.storeData),
-      )
+      expect(store.poolsArray).toEqual(addUsedAliquotsAndErrorsToPools(pacbioPoolFactory.storeData))
     })
   })
   describe('actions', () => {
@@ -43,7 +41,6 @@ describe('usePacbioPools', () => {
         get.mockResolvedValue(pacbioPoolFactory.responses.fetch)
         await store.fetchPools()
         expect(store.pools).toEqual(pacbioPoolFactory.storeData.pools)
-        expect(store.tubes).toEqual(pacbioPoolFactory.storeData.tubes)
         expect(store.used_aliquots).toEqual(pacbioPoolFactory.storeData.used_aliquots)
         expect(store.tags).toEqual(pacbioPoolFactory.storeData.tags)
         expect(store.requests).toEqual(pacbioPoolFactory.storeData.requests)

--- a/tests/unit/stores/utilities/pacbioLibraries.spec.js
+++ b/tests/unit/stores/utilities/pacbioLibraries.spec.js
@@ -23,15 +23,9 @@ describe('pacbioLibraries', () => {
           id: 1,
           request: 1,
           tag_id: 1,
-          tube: 1,
           concentration: 1,
           volume: 1,
           insert_size: 1,
-        },
-      }
-      const tubes = {
-        1: {
-          id: 1,
           barcode: 'tube1',
         },
       }
@@ -48,12 +42,11 @@ describe('pacbioLibraries', () => {
           sample_name: 'request1',
         },
       }
-      const formattedLibraries = formatAndTransformLibraries(libraries, tubes, tags, requests)
+      const formattedLibraries = formatAndTransformLibraries(libraries, tags, requests)
       expect(formattedLibraries).toEqual([
         {
           id: 1,
           tag_id: '1',
-          tube: 1,
           concentration: 1,
           volume: 1,
           insert_size: 1,
@@ -75,7 +68,6 @@ describe('pacbioLibraries', () => {
       const libraryFields = {
         id: 1,
         tag_id: 1,
-        tube: 1,
         concentration: 1,
         volume: 1,
         insert_size: '',
@@ -89,7 +81,6 @@ describe('pacbioLibraries', () => {
       const libraryFields = {
         id: 1,
         tag_id: 1,
-        tube: 1,
         concentration: 1,
         volume: 0,
         insert_size: 1,
@@ -102,7 +93,6 @@ describe('pacbioLibraries', () => {
       const libraryFields = {
         id: 1,
         tag_id: 1,
-        tube: 1,
         concentration: 1,
         volume: 1,
         insert_size: 1,
@@ -116,7 +106,6 @@ describe('pacbioLibraries', () => {
       const libraryFields = {
         id: 1,
         tag_id: null,
-        tube: 1,
         concentration: 1,
         volume: 1,
         insert_size: 1,

--- a/tests/unit/stores/utilities/pool.spec.js
+++ b/tests/unit/stores/utilities/pool.spec.js
@@ -364,23 +364,6 @@ describe('pool', () => {
 
     const tubes = [
       {
-        id: '12066',
-        type: 'tubes',
-        attributes: {
-          barcode: 'TRAC-2-12066',
-        },
-        relationships: {
-          pools: {
-            data: [
-              {
-                type: 'pools',
-                id: '6011',
-              },
-            ],
-          },
-        },
-      },
-      {
         id: '11877',
         type: 'tubes',
         attributes: {
@@ -731,6 +714,7 @@ describe('pool', () => {
           used_aliquots: ['1', '3'],
           tube: '1',
           type: 'pools',
+          barcode: 'TRAC-2-1',
           source_identifier: 'DN1:A1',
           run_suitability: {
             ready_for_run: true,

--- a/tests/unit/stores/utilities/pool.spec.js
+++ b/tests/unit/stores/utilities/pool.spec.js
@@ -6,7 +6,7 @@ import {
   assignRequestIdsToTubes,
   buildRunSuitabilityErrors,
   createUsedAliquotsFromState,
-  addUsedAliquotsBarcodeAndErrorsToPools,
+  addUsedAliquotsAndErrorsToPools,
 } from '@/stores/utilities/pool'
 import { expect, it } from 'vitest'
 import { createUsedAliquot } from '@/stores/utilities/usedAliquot.js'
@@ -810,7 +810,7 @@ describe('pool', () => {
       expect(createUsedAliquotsFromState({ pool: state.pools[1], state })).toEqual(expected)
     })
 
-    it('#addUsedAliquotsBarcodeAndErrorsToPools - will produce the correct pools', () => {
+    it('#addUsedAliquotsAndErrorsToPools - will produce the correct pools', () => {
       const expected = [
         {
           2: {
@@ -845,7 +845,7 @@ describe('pool', () => {
           barcode: 'TRAC-2-1',
         },
       ]
-      expect(addUsedAliquotsBarcodeAndErrorsToPools(state)).toEqual(expected)
+      expect(addUsedAliquotsAndErrorsToPools(state)).toEqual(expected)
     })
   })
 })

--- a/tests/unit/views/pacbio/PacbioLibraryIndex.spec.js
+++ b/tests/unit/views/pacbio/PacbioLibraryIndex.spec.js
@@ -43,7 +43,7 @@ describe('Libraries.vue', () => {
     })
 
     it('contains the correct data', async () => {
-      expect(wrapper.find('tbody').findAll('tr').length).toEqual(2)
+      expect(wrapper.find('tbody').findAll('tr').length).toEqual(5)
     })
   })
   describe('exhausted badge display', () => {


### PR DESCRIPTION
Closes #2228 

#### Changes proposed in this pull request
- Removes pool tube references from Pacbio Pool Create page and store in favour of using pool barcode attribute.
- Removes pool tube references from Pacbio pools index page.
- Removes library tube references from Pacbio library index page.
- Removes library tube references from pacbio library creation.
- Removes library tube references from labwhere reception.
- Fixes tailwind v4 bug with background opacity.


#### Additional notes
- Started to separate tubes and libraries to be handled separately in PacbioPoolCreate but decided against continuing as it is strongly tied to the general refactor and cannot be done without major changes: https://github.com/sanger/traction-ui/issues/2229