### PR TITLE
feat(ci): removes chrome version pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,9 +64,6 @@ jobs:
   cypress:
     name: Run Cypress tests
     runs-on: ubuntu-latest
-    container:
-      image: cypress/browsers:node16.17.0-chrome106
-      options: --user 1001
     steps:
     - uses: actions/checkout@v4
     - name: Setup node


### PR DESCRIPTION
Testing removing the chrome version pin for CI

#### Changes proposed in this pull request

- Removes CI Chrome version pinned (probably to fix an old cypress bug)
