### PR TITLE
Y25-168 - Refactor PacBio run tube usage

### DIFF
--- a/src/components/labware/PacbioRunWell.vue
+++ b/src/components/labware/PacbioRunWell.vue
@@ -118,9 +118,7 @@ const tooltip = computed(() => {
           // If the used aliquot has been destroyed, return null
           if (_destroy) return
           const type = source_type === 'Pacbio::Pool' ? 'pools' : 'libraries'
-          return store.tubeContents.find(
-            (tubeContent) => source_id == tubeContent.id && type == tubeContent.type,
-          ).barcode
+          return store.sourceItems.find((item) => source_id == item.id && type == item.type).barcode
         })
         .filter(Boolean)
         .join(',')
@@ -192,20 +190,20 @@ const drop = async (event) => {
  */
 const updateUsedAliquotSource = async (barcode) => {
   const well = await store.getOrCreateWell(props.position, props.plateNumber)
-  const tubeContent = store.tubeContentByBarcode(barcode)
+  const source = store.sourceByBarcode(barcode)
   // Determine the source type for the used aliquot
-  const source_type = tubeContent.type === 'pools' ? 'Pacbio::Pool' : 'Pacbio::Library'
+  const source_type = source.type === 'pools' ? 'Pacbio::Pool' : 'Pacbio::Library'
   // We get the full available volume from the given source by passing a volume of 0
   // This is used to calculate the initial volume of the used aliquot
   const available_volume = store.getAvailableVolumeForAliquot({
-    sourceId: tubeContent.id,
+    sourceId: source.id,
     sourceType: source_type,
     volume: 0,
   })
   /*id set to null because we are creating a new used aliquot */
   const used_aliquot = createUsedAliquot({
-    ...tubeContent,
-    source_id: tubeContent.id,
+    ...source,
+    source_id: source.id,
     id: null,
     volume: available_volume,
     available_volume,

--- a/src/components/pacbio/PacbioRunPoolLibraryList.vue
+++ b/src/components/pacbio/PacbioRunPoolLibraryList.vue
@@ -1,7 +1,7 @@
 <template>
   <traction-section title="Pools & Libraries">
     <LabwareFinder :fetcher="store.findPoolsOrLibrariesByTube" filter="barcode" />
-    <div v-for="item in store.tubeContents" :key="item.id" class="pt-2">
+    <div v-for="item in store.sourceItems" :key="item.id" class="pt-2">
       <Tube v-bind="item" />
     </div>
   </traction-section>

--- a/src/components/pacbio/PacbioRunWellEdit.vue
+++ b/src/components/pacbio/PacbioRunWellEdit.vue
@@ -256,24 +256,24 @@ const updateUsedAliquotVolume = (row, volume) => {
 const updateUsedAliquotSource = async (row, barcode) => {
   const index = row.index
   await store.findPoolsOrLibrariesByTube({ barcode })
-  const tubeContent = await store.tubeContentByBarcode(barcode)
-  if (tubeContent) {
-    const type = tubeContent.type === 'pools' ? 'Pacbio::Pool' : 'Pacbio::Library'
+  const source = await store.sourceByBarcode(barcode)
+  if (source) {
+    const type = source.type === 'pools' ? 'Pacbio::Pool' : 'Pacbio::Library'
     const available_volume = store.getAvailableVolumeForAliquot({
-      sourceId: tubeContent.id,
+      sourceId: source.id,
       sourceType: type,
       volume: 0,
     })
     const used_aliquot = createUsedAliquot({
       id: row.item.id || '',
-      source_id: tubeContent.id,
+      source_id: source.id,
       source_type: type,
       barcode,
       volume: available_volume,
       available_volume,
-      concentration: tubeContent.concentration,
-      insert_size: tubeContent.insert_size,
-      template_prep_kit_box_barcode: tubeContent.template_prep_kit_box_barcode,
+      concentration: source.concentration,
+      insert_size: source.insert_size,
+      template_prep_kit_box_barcode: source.template_prep_kit_box_barcode,
     })
     localUsedAliquots[index] = used_aliquot
   } else {
@@ -293,8 +293,8 @@ const setupWell = async () => {
   localUsedAliquots.splice(0)
   well.used_aliquots.forEach((aliquot) => {
     const type = aliquot.source_type === 'Pacbio::Pool' ? 'pools' : 'libraries'
-    const poolOrLibrary = store.tubeContents.find(
-      (tubeContent) => tubeContent.id == aliquot.source_id && tubeContent.type == type,
+    const poolOrLibrary = store.sourceItems.find(
+      (item) => item.id == aliquot.source_id && item.type == type,
     )
     if (poolOrLibrary) {
       const available_volume = store.getAvailableVolumeForAliquot({

--- a/src/stores/pacbioLibraryBatchCreate.js
+++ b/src/stores/pacbioLibraryBatchCreate.js
@@ -22,10 +22,6 @@ export const usePacbioLibraryBatchCreateStore = defineStore('pacbioLibraryBatchC
      * @property {Object} libraries - An object to store all libraries indexed by id.
      */
     libraries: {},
-    /**
-     * @property {Object} tubes - An object to store all tubes from all libraries indexed by id.
-     */
-    tubes: {},
   }),
 
   getters: {
@@ -46,12 +42,13 @@ export const usePacbioLibraryBatchCreateStore = defineStore('pacbioLibraryBatchC
           insert_size,
           template_prep_kit_box_barcode,
           source_identifier,
+          barcode,
         } = library
         const tag = pacbioRootStore.tags[tag_id]
         const tagGroupId = tag ? tag.group_id : ''
         return {
           id,
-          barcode: state.tubes[library.tube].barcode,
+          barcode,
           source: source_identifier,
           tag: tagGroupId,
           volume,
@@ -62,8 +59,8 @@ export const usePacbioLibraryBatchCreateStore = defineStore('pacbioLibraryBatchC
       })
     },
     librariesInfoInPrintFormat: (state) =>
-      Object.values(state.libraries).map(({ tube, source_identifier }) => ({
-        barcode: state.tubes[tube].barcode,
+      Object.values(state.libraries).map(({ barcode, source_identifier }) => ({
+        barcode,
         source_identifier,
       })),
   },
@@ -142,11 +139,10 @@ export const usePacbioLibraryBatchCreateStore = defineStore('pacbioLibraryBatchC
               },
             },
           },
-          include: 'libraries.tube',
+          include: 'libraries',
         })
         const { success, body: { included = [] } = {}, errors } = await handleResponse(promise)
-        const { tubes = [], libraries = [] } = groupIncludedByResource(included)
-        this.tubes = dataToObjectById({ data: tubes, includeRelationships: true })
+        const { libraries = [] } = groupIncludedByResource(included)
         this.libraries = dataToObjectById({ data: libraries, includeRelationships: true })
         return { success, result: this.librariesInBatch, errors }
       } catch (error) {

--- a/src/stores/pacbioRunCreate.js
+++ b/src/stores/pacbioRunCreate.js
@@ -143,11 +143,11 @@ export const usePacbioRunCreateStore = defineStore('pacbioRunCreate', {
     },
 
     /**
-     * Returns a list of all the tubes with their contents (pool or library)
+     * Returns a list of all the pools and libraries and their samples
      * @param {Object} state the pinia state object
      * @returns {Array} an array of pools and libraries
      */
-    tubeContents: (state) => {
+    sourceItems: (state) => {
       // for each tube
       return Object.values(state.libraries)
         .concat(Object.values(state.pools))
@@ -168,9 +168,9 @@ export const usePacbioRunCreateStore = defineStore('pacbioRunCreate', {
         })
     },
 
-    tubeContentByBarcode: (state) => {
+    sourceByBarcode: (state) => {
       return (barcode) => {
-        return state.tubeContents.find((tubeContent) => tubeContent.barcode === barcode)
+        return state.sourceItems.find((item) => item.barcode === barcode)
       }
     },
 

--- a/src/stores/pacbioRunCreate.js
+++ b/src/stores/pacbioRunCreate.js
@@ -100,9 +100,6 @@ export const usePacbioRunCreateStore = defineStore('pacbioRunCreate', {
     //Libraries: The libraries that belong to the wells or the library selected for a new run
     libraries: {},
 
-    //Tubes: The tubes for each pool or the tubes selected for a new run
-    tubes: {},
-
     //Requests: The requests for the libraries or pool libraries
     requests: {},
 
@@ -152,34 +149,23 @@ export const usePacbioRunCreateStore = defineStore('pacbioRunCreate', {
      */
     tubeContents: (state) => {
       // for each tube
-      return Object.values(state.tubes).reduce((result, tube) => {
-        // retrieve the barcode, id and type - pool or library
-        const { barcode } = tube
-        const { id, type } = tube.pools?.[0]
-          ? { id: tube.pools[0], type: 'pools' }
-          : { id: tube.libraries, type: 'libraries' }
+      return Object.values(state.libraries)
+        .concat(Object.values(state.pools))
+        .map((record) => {
+          let fn = null
 
-        // get the pool or library
-        const record = { barcode, ...state[type][id] }
+          // determine the function to generate samples based on the record type
+          if (record.type === 'pools') {
+            fn = generateSamplesForPools
+          } else if (record.type === 'libraries') {
+            fn = generateSamplesForLibraries
+          }
 
-        let fn = null
+          // if the type is known, generate the samples
+          const samples = fn ? fn(state, record) : []
 
-        // generate the samples function based on the type
-        if (type === 'pools') {
-          fn = generateSamplesForPools
-        }
-        if (type === 'libraries') {
-          fn = generateSamplesForLibraries
-        }
-
-        // if the type is known generate the samples
-        if (fn) {
-          const samples = fn(state, record)
-          result.push({ ...record, samples })
-        }
-
-        return result
-      }, [])
+          return { ...record, samples }
+        })
     },
 
     tubeContentByBarcode: (state) => {
@@ -274,9 +260,8 @@ export const usePacbioRunCreateStore = defineStore('pacbioRunCreate', {
       if (success && data.length > 0) {
         const { pools, libraries, aliquots, tags, requests } = groupIncludedByResource(included)
 
-        // populate pools, tubes, libraries, tags and requests in store
+        // populate pools, libraries, tags and requests in store
         this.pools = formatById(this.pools, pools, true)
-        this.tubes = formatById(this.tubes, data, true)
         this.libraries = formatById(this.libraries, libraries, true)
         this.aliquots = formatById(this.aliquots, aliquots, true)
         this.requests = formatById(this.requests, requests)
@@ -301,7 +286,7 @@ export const usePacbioRunCreateStore = defineStore('pacbioRunCreate', {
       const promise = request.find({
         id,
         include:
-          'plates.wells.used_aliquots,plates.wells.libraries.tube,plates.wells.pools.tube,plates.wells.libraries.request,plates.wells.pools.requests,plates.wells.pools.libraries.request,plates.wells.pools.used_aliquots.tag,plates.wells.libraries.used_aliquots.tag,smrt_link_version',
+          'plates.wells.used_aliquots,plates.wells.libraries.request,plates.wells.pools.requests,plates.wells.pools.libraries.request,plates.wells.pools.used_aliquots.tag,plates.wells.libraries.used_aliquots.tag,smrt_link_version',
       })
       const response = await handleResponse(promise)
       const { success, body: { data, included = [] } = {}, errors = [] } = response
@@ -312,7 +297,6 @@ export const usePacbioRunCreateStore = defineStore('pacbioRunCreate', {
           wells,
           pools,
           libraries,
-          tubes,
           aliquots,
           requests,
           tags,
@@ -329,7 +313,6 @@ export const usePacbioRunCreateStore = defineStore('pacbioRunCreate', {
         //Populate pools, libraries, tags, requests and tubes
         this.pools = formatById(this.pools, pools, true)
         this.libraries = formatById(this.libraries, libraries, true)
-        this.tubes = formatById(this.tubes, tubes, true)
         this.aliquots = formatById(this.aliquots, aliquots, true)
         this.requests = formatById(this.requests, requests, true)
         this.tags = formatById(this.tags, tags)
@@ -493,13 +476,9 @@ export const usePacbioRunCreateStore = defineStore('pacbioRunCreate', {
       }
     },
     removePool(id) {
-      // Delete the tube associated with the pool
-      delete this.tubes[this.pools[id].tube]
       delete this.pools[id]
     },
     removeLibrary(id) {
-      // Delete the tube associated with the library
-      delete this.tubes[this.libraries[id].tube]
       delete this.libraries[id]
     },
     clearRunData() {

--- a/tests/e2e/specs/pacbio/pacbio_library_batch_create.cy.js
+++ b/tests/e2e/specs/pacbio/pacbio_library_batch_create.cy.js
@@ -55,7 +55,7 @@ describe('Pacbio Library Batch Create', () => {
     cy.get('[data-type=csv-preview]').should('exist')
 
     // Create Libraries
-    cy.intercept('POST', '/v1/pacbio/library_batches?include=libraries.tube', {
+    cy.intercept('POST', '/v1/pacbio/library_batches?include=libraries', {
       statusCode: 200,
       body: pacbioLibraryBatchFactory.content,
     })
@@ -112,7 +112,7 @@ describe('Pacbio Library Batch Create', () => {
     cy.get('[data-type=csv-preview]').should('exist')
 
     // Create Libraries
-    cy.intercept('POST', '/v1/pacbio/library_batches?include=libraries.tube', {
+    cy.intercept('POST', '/v1/pacbio/library_batches?include=libraries', {
       statusCode: 422,
       body: {
         errors: {

--- a/tests/e2e/specs/pacbio/pacbio_run_edit.cy.js
+++ b/tests/e2e/specs/pacbio/pacbio_run_edit.cy.js
@@ -28,7 +28,7 @@ describe('Pacbio Run Edit view', () => {
     cy.wrap(PacbioRunFactory({ findBy: 'Revio' })).as('revioRunFactory')
     cy.get('@revioRunFactory').then((revioRunFactory) => {
       cy.intercept(
-        '/v1/pacbio/runs/1581?include=plates.wells.used_aliquots,plates.wells.libraries.tube,plates.wells.pools.tube,plates.wells.libraries.request,plates.wells.pools.requests,plates.wells.pools.libraries.request,plates.wells.pools.used_aliquots.tag,plates.wells.libraries.used_aliquots.tag,smrt_link_version',
+        '/v1/pacbio/runs/1581?include=plates.wells.used_aliquots,plates.wells.libraries.request,plates.wells.pools.requests,plates.wells.pools.libraries.request,plates.wells.pools.used_aliquots.tag,plates.wells.libraries.used_aliquots.tag,smrt_link_version',
         {
           statusCode: 200,
           body: revioRunFactory.content,
@@ -69,7 +69,7 @@ describe('Pacbio Run Edit view', () => {
     cy.wrap(PacbioRunFactory({ findBy: 'Sequel IIe' })).as('sequelRunFactory')
     cy.get('@sequelRunFactory').then((sequelRunFactory) => {
       cy.intercept(
-        'v1/pacbio/runs/1503?include=plates.wells.used_aliquots,plates.wells.libraries.tube,plates.wells.pools.tube,plates.wells.libraries.request,plates.wells.pools.requests,plates.wells.pools.libraries.request,plates.wells.pools.used_aliquots.tag,plates.wells.libraries.used_aliquots.tag,smrt_link_version',
+        'v1/pacbio/runs/1503?include=plates.wells.used_aliquots,plates.wells.libraries.request,plates.wells.pools.requests,plates.wells.pools.libraries.request,plates.wells.pools.used_aliquots.tag,plates.wells.libraries.used_aliquots.tag,smrt_link_version',
         {
           statusCode: 200,
           body: sequelRunFactory.content,
@@ -94,7 +94,7 @@ describe('Pacbio Run Edit view', () => {
     cy.wrap(PacbioRunFactory({ findBy: 'Revio' })).as('revioRunFactory')
     cy.get('@revioRunFactory').then((revioRunFactory) => {
       cy.intercept(
-        '/v1/pacbio/runs/1581?include=plates.wells.used_aliquots,plates.wells.libraries.tube,plates.wells.pools.tube,plates.wells.libraries.request,plates.wells.pools.requests,plates.wells.pools.libraries.request,plates.wells.pools.used_aliquots.tag,plates.wells.libraries.used_aliquots.tag,smrt_link_version',
+        '/v1/pacbio/runs/1581?include=plates.wells.used_aliquots,plates.wells.libraries.request,plates.wells.pools.requests,plates.wells.pools.libraries.request,plates.wells.pools.used_aliquots.tag,plates.wells.libraries.used_aliquots.tag,smrt_link_version',
         {
           statusCode: 200,
           body: revioRunFactory.content,

--- a/tests/factories/PacbioLibraryBatchFactory.js
+++ b/tests/factories/PacbioLibraryBatchFactory.js
@@ -58,6 +58,7 @@ const PacbioLibraryBatchFactory = (tags = []) => {
           tag_id: 303,
           used_volume: 0,
           available_volume: 10,
+          barcode: 'TRAC-2-121',
         },
         relationships: {
           tube: {
@@ -96,6 +97,7 @@ const PacbioLibraryBatchFactory = (tags = []) => {
           tag_id: 304,
           used_volume: 0,
           available_volume: 10,
+          barcode: 'TRAC-2-122',
         },
         relationships: {
           tube: {
@@ -110,26 +112,6 @@ const PacbioLibraryBatchFactory = (tags = []) => {
           },
         },
       },
-      {
-        id: '121',
-        type: 'tubes',
-        links: {
-          self: 'http://localhost:3100/v1/pacbio/tubes/111',
-        },
-        attributes: {
-          barcode: 'TRAC-2-121',
-        },
-      },
-      {
-        id: '122',
-        type: 'tubes',
-        links: {
-          self: 'http://localhost:3100/v1/pacbio/tubes/111',
-        },
-        attributes: {
-          barcode: 'TRAC-2-122',
-        },
-      },
     ],
     meta: {
       page_count: 1,
@@ -137,15 +119,14 @@ const PacbioLibraryBatchFactory = (tags = []) => {
   }
 
   const createStoreData = ({ included }) => {
-    const { tubes, libraries } = groupIncludedByResource(included)
+    const { libraries } = groupIncludedByResource(included)
     const librariesObj = dataToObjectById({ data: libraries, includeRelationships: true })
-    const tubesObj = dataToObjectById({ data: tubes })
     return {
       librariesInBatch: Object.values(librariesObj).map((library) => {
         return {
           source: library.source_identifier,
           id: library.id,
-          barcode: tubesObj[library.tube].barcode,
+          barcode: library.barcode,
           tag: tags[library.tag_id]?.group_id,
           volume: library.volume,
           concentration: library.concentration,
@@ -153,7 +134,6 @@ const PacbioLibraryBatchFactory = (tags = []) => {
           template_prep_kit_box_barcode: library.template_prep_kit_box_barcode,
         }
       }),
-      tubes: tubesObj,
       libraries: librariesObj,
       librariesArray: Object.values(librariesObj),
     }

--- a/tests/factories/PacbioRunFactory.js
+++ b/tests/factories/PacbioRunFactory.js
@@ -44,7 +44,6 @@ const createStoreDataForSingleRun = (data) => {
     wells,
     pools,
     libraries,
-    tubes,
     aliquots,
     requests,
     tags,
@@ -58,7 +57,6 @@ const createStoreDataForSingleRun = (data) => {
     smrtLinkVersion: extractAttributes(smrt_link_version),
     aliquots: dataToObjectById({ data: aliquots, includeRelationships: true }),
     libraries: dataToObjectById({ data: libraries, includeRelationships: true }),
-    tubes: dataToObjectById({ data: tubes, includeRelationships: true }),
     pools: dataToObjectById({ data: pools, includeRelationships: true }),
     tags: dataToObjectById({ data: tags, includeRelationships: true }),
     requests: dataToObjectById({ data: requests, includeRelationships: true }),
@@ -69,7 +67,6 @@ const createStoreDataForSingleRun = (data) => {
       wells,
       pools,
       libraries,
-      tubes,
       aliquots,
       requests,
       tags,
@@ -824,6 +821,7 @@ const PacbioRunFactory = ({ count = undefined, findBy = null } = {}) => {
           tag_id: 584,
           used_volume: 15.0,
           available_volume: 6.6,
+          barcode: 'TRAC-2-11563',
         },
         relationships: {
           request: {
@@ -844,16 +842,6 @@ const PacbioRunFactory = ({ count = undefined, findBy = null } = {}) => {
             data: {
               type: 'tags',
               id: '584',
-            },
-          },
-          tube: {
-            links: {
-              self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/libraries/13978/relationships/tube',
-              related: 'https://traction.psd.sanger.ac.uk/v1/pacbio/libraries/13978/tube',
-            },
-            data: {
-              type: 'tubes',
-              id: '11563',
             },
           },
           source_well: {
@@ -916,6 +904,7 @@ const PacbioRunFactory = ({ count = undefined, findBy = null } = {}) => {
           tag_id: 583,
           used_volume: 11.3,
           available_volume: 0.0,
+          barcode: 'TRAC-2-11562',
         },
         relationships: {
           request: {
@@ -936,16 +925,6 @@ const PacbioRunFactory = ({ count = undefined, findBy = null } = {}) => {
             data: {
               type: 'tags',
               id: '583',
-            },
-          },
-          tube: {
-            links: {
-              self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/libraries/13977/relationships/tube',
-              related: 'https://traction.psd.sanger.ac.uk/v1/pacbio/libraries/13977/tube',
-            },
-            data: {
-              type: 'tubes',
-              id: '11562',
             },
           },
           source_well: {
@@ -1008,6 +987,7 @@ const PacbioRunFactory = ({ count = undefined, findBy = null } = {}) => {
           tag_id: 582,
           used_volume: 15.0,
           available_volume: 22.6,
+          barcode: 'TRAC-2-11561',
         },
         relationships: {
           request: {
@@ -1028,16 +1008,6 @@ const PacbioRunFactory = ({ count = undefined, findBy = null } = {}) => {
             data: {
               type: 'tags',
               id: '582',
-            },
-          },
-          tube: {
-            links: {
-              self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/libraries/13976/relationships/tube',
-              related: 'https://traction.psd.sanger.ac.uk/v1/pacbio/libraries/13976/tube',
-            },
-            data: {
-              type: 'tubes',
-              id: '11561',
             },
           },
           source_well: {
@@ -1100,6 +1070,7 @@ const PacbioRunFactory = ({ count = undefined, findBy = null } = {}) => {
           tag_id: 608,
           used_volume: 42.5,
           available_volume: 0.0,
+          barcode: 'TRAC-2-10185',
         },
         relationships: {
           request: {
@@ -1120,16 +1091,6 @@ const PacbioRunFactory = ({ count = undefined, findBy = null } = {}) => {
             data: {
               type: 'tags',
               id: '608',
-            },
-          },
-          tube: {
-            links: {
-              self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/libraries/13239/relationships/tube',
-              related: 'https://traction.psd.sanger.ac.uk/v1/pacbio/libraries/13239/tube',
-            },
-            data: {
-              type: 'tubes',
-              id: '10185',
             },
           },
           source_well: {
@@ -1166,166 +1127,6 @@ const PacbioRunFactory = ({ count = undefined, findBy = null } = {}) => {
                 id: '30056',
               },
             ],
-          },
-        },
-      },
-      {
-        id: '10185',
-        type: 'tubes',
-        links: {
-          self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/10185',
-        },
-        attributes: {
-          barcode: 'TRAC-2-10185',
-        },
-        relationships: {
-          materials: {
-            links: {
-              self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/10185/relationships/materials',
-              related: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/10185/materials',
-            },
-          },
-          pools: {
-            links: {
-              self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/10185/relationships/pools',
-              related: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/10185/pools',
-            },
-          },
-          libraries: {
-            links: {
-              self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/10185/relationships/libraries',
-              related: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/10185/libraries',
-            },
-            data: {
-              type: 'libraries',
-              id: '13239',
-            },
-          },
-          requests: {
-            links: {
-              self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/10185/relationships/requests',
-              related: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/10185/requests',
-            },
-          },
-        },
-      },
-      {
-        id: '11561',
-        type: 'tubes',
-        links: {
-          self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/11561',
-        },
-        attributes: {
-          barcode: 'TRAC-2-11561',
-        },
-        relationships: {
-          materials: {
-            links: {
-              self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/11561/relationships/materials',
-              related: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/11561/materials',
-            },
-          },
-          pools: {
-            links: {
-              self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/11561/relationships/pools',
-              related: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/11561/pools',
-            },
-          },
-          libraries: {
-            links: {
-              self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/11561/relationships/libraries',
-              related: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/11561/libraries',
-            },
-            data: {
-              type: 'libraries',
-              id: '13976',
-            },
-          },
-          requests: {
-            links: {
-              self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/11561/relationships/requests',
-              related: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/11561/requests',
-            },
-          },
-        },
-      },
-      {
-        id: '11562',
-        type: 'tubes',
-        links: {
-          self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/11562',
-        },
-        attributes: {
-          barcode: 'TRAC-2-11562',
-        },
-        relationships: {
-          materials: {
-            links: {
-              self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/11562/relationships/materials',
-              related: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/11562/materials',
-            },
-          },
-          pools: {
-            links: {
-              self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/11562/relationships/pools',
-              related: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/11562/pools',
-            },
-          },
-          libraries: {
-            links: {
-              self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/11562/relationships/libraries',
-              related: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/11562/libraries',
-            },
-            data: {
-              type: 'libraries',
-              id: '13977',
-            },
-          },
-          requests: {
-            links: {
-              self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/11562/relationships/requests',
-              related: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/11562/requests',
-            },
-          },
-        },
-      },
-      {
-        id: '11563',
-        type: 'tubes',
-        links: {
-          self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/11563',
-        },
-        attributes: {
-          barcode: 'TRAC-2-11563',
-        },
-        relationships: {
-          materials: {
-            links: {
-              self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/11563/relationships/materials',
-              related: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/11563/materials',
-            },
-          },
-          pools: {
-            links: {
-              self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/11563/relationships/pools',
-              related: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/11563/pools',
-            },
-          },
-          libraries: {
-            links: {
-              self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/11563/relationships/libraries',
-              related: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/11563/libraries',
-            },
-            data: {
-              type: 'libraries',
-              id: '13978',
-            },
-          },
-          requests: {
-            links: {
-              self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/11563/relationships/requests',
-              related: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/11563/requests',
-            },
           },
         },
       },
@@ -2219,6 +2020,7 @@ const PacbioRunFactory = ({ count = undefined, findBy = null } = {}) => {
           tag_id: 585,
           used_volume: 6.0,
           available_volume: 27.5,
+          barcode: 'TRAC-2-10748',
         },
         relationships: {
           request: {
@@ -2239,16 +2041,6 @@ const PacbioRunFactory = ({ count = undefined, findBy = null } = {}) => {
             data: {
               type: 'tags',
               id: '585',
-            },
-          },
-          tube: {
-            links: {
-              self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/libraries/13462/relationships/tube',
-              related: 'https://traction.psd.sanger.ac.uk/v1/pacbio/libraries/13462/tube',
-            },
-            data: {
-              type: 'tubes',
-              id: '10748',
             },
           },
           source_well: {
@@ -2311,6 +2103,7 @@ const PacbioRunFactory = ({ count = undefined, findBy = null } = {}) => {
           tag_id: 0,
           used_volume: 78.0,
           available_volume: 83.5,
+          barcode: 'TRAC-2-10483',
         },
         relationships: {
           request: {
@@ -2329,16 +2122,6 @@ const PacbioRunFactory = ({ count = undefined, findBy = null } = {}) => {
               related: 'https://traction.psd.sanger.ac.uk/v1/pacbio/libraries/13357/tag',
             },
             data: null,
-          },
-          tube: {
-            links: {
-              self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/libraries/13357/relationships/tube',
-              related: 'https://traction.psd.sanger.ac.uk/v1/pacbio/libraries/13357/tube',
-            },
-            data: {
-              type: 'tubes',
-              id: '10483',
-            },
           },
           source_well: {
             links: {
@@ -2400,6 +2183,7 @@ const PacbioRunFactory = ({ count = undefined, findBy = null } = {}) => {
           tag_id: 607,
           used_volume: 7.0,
           available_volume: 4.0,
+          barcode: 'TRAC-2-9452',
         },
         relationships: {
           request: {
@@ -2420,16 +2204,6 @@ const PacbioRunFactory = ({ count = undefined, findBy = null } = {}) => {
             data: {
               type: 'tags',
               id: '607',
-            },
-          },
-          tube: {
-            links: {
-              self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/libraries/12739/relationships/tube',
-              related: 'https://traction.psd.sanger.ac.uk/v1/pacbio/libraries/12739/tube',
-            },
-            data: {
-              type: 'tubes',
-              id: '9452',
             },
           },
           source_well: {
@@ -2492,6 +2266,7 @@ const PacbioRunFactory = ({ count = undefined, findBy = null } = {}) => {
           tag_id: 603,
           used_volume: 3.0,
           available_volume: 27.8,
+          barcode: 'TRAC-2-10621',
         },
         relationships: {
           request: {
@@ -2512,16 +2287,6 @@ const PacbioRunFactory = ({ count = undefined, findBy = null } = {}) => {
             data: {
               type: 'tags',
               id: '603',
-            },
-          },
-          tube: {
-            links: {
-              self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/libraries/13413/relationships/tube',
-              related: 'https://traction.psd.sanger.ac.uk/v1/pacbio/libraries/13413/tube',
-            },
-            data: {
-              type: 'tubes',
-              id: '10621',
             },
           },
           source_well: {
@@ -2578,6 +2343,7 @@ const PacbioRunFactory = ({ count = undefined, findBy = null } = {}) => {
           tag_id: 602,
           used_volume: 3.0,
           available_volume: 18.3,
+          barcode: 'TRAC-2-10620',
         },
         relationships: {
           request: {
@@ -2598,16 +2364,6 @@ const PacbioRunFactory = ({ count = undefined, findBy = null } = {}) => {
             data: {
               type: 'tags',
               id: '602',
-            },
-          },
-          tube: {
-            links: {
-              self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/libraries/13412/relationships/tube',
-              related: 'https://traction.psd.sanger.ac.uk/v1/pacbio/libraries/13412/tube',
-            },
-            data: {
-              type: 'tubes',
-              id: '10620',
             },
           },
           source_well: {
@@ -2664,6 +2420,7 @@ const PacbioRunFactory = ({ count = undefined, findBy = null } = {}) => {
           tag_id: 601,
           used_volume: 3.0,
           available_volume: 18.5,
+          barcode: 'TRAC-2-10619',
         },
         relationships: {
           request: {
@@ -2684,16 +2441,6 @@ const PacbioRunFactory = ({ count = undefined, findBy = null } = {}) => {
             data: {
               type: 'tags',
               id: '601',
-            },
-          },
-          tube: {
-            links: {
-              self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/libraries/13411/relationships/tube',
-              related: 'https://traction.psd.sanger.ac.uk/v1/pacbio/libraries/13411/tube',
-            },
-            data: {
-              type: 'tubes',
-              id: '10619',
             },
           },
           source_well: {
@@ -2723,168 +2470,6 @@ const PacbioRunFactory = ({ count = undefined, findBy = null } = {}) => {
             links: {
               self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/libraries/13411/relationships/used_aliquots',
               related: 'https://traction.psd.sanger.ac.uk/v1/pacbio/libraries/13411/used_aliquots',
-            },
-          },
-        },
-      },
-      {
-        id: '9452',
-        type: 'tubes',
-        links: {
-          self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/9452',
-        },
-        attributes: {
-          barcode: 'TRAC-2-9452',
-        },
-        relationships: {
-          materials: {
-            links: {
-              self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/9452/relationships/materials',
-              related: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/9452/materials',
-            },
-          },
-          pools: {
-            links: {
-              self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/9452/relationships/pools',
-              related: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/9452/pools',
-            },
-          },
-          libraries: {
-            links: {
-              self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/9452/relationships/libraries',
-              related: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/9452/libraries',
-            },
-            data: {
-              type: 'libraries',
-              id: '12739',
-            },
-          },
-          requests: {
-            links: {
-              self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/9452/relationships/requests',
-              related: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/9452/requests',
-            },
-          },
-        },
-      },
-      {
-        id: '10483',
-        type: 'tubes',
-        links: {
-          self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/10483',
-        },
-        attributes: {
-          barcode: 'TRAC-2-10483',
-        },
-        relationships: {
-          materials: {
-            links: {
-              self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/10483/relationships/materials',
-              related: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/10483/materials',
-            },
-          },
-          pools: {
-            links: {
-              self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/10483/relationships/pools',
-              related: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/10483/pools',
-            },
-          },
-          libraries: {
-            links: {
-              self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/10483/relationships/libraries',
-              related: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/10483/libraries',
-            },
-            data: {
-              type: 'libraries',
-              id: '13357',
-            },
-          },
-          requests: {
-            links: {
-              self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/10483/relationships/requests',
-              related: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/10483/requests',
-            },
-          },
-        },
-      },
-      {
-        id: '10748',
-        type: 'tubes',
-        links: {
-          self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/10748',
-        },
-        attributes: {
-          barcode: 'TRAC-2-10748',
-        },
-        relationships: {
-          materials: {
-            links: {
-              self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/10748/relationships/materials',
-              related: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/10748/materials',
-            },
-          },
-          pools: {
-            links: {
-              self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/10748/relationships/pools',
-              related: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/10748/pools',
-            },
-          },
-          libraries: {
-            links: {
-              self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/10748/relationships/libraries',
-              related: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/10748/libraries',
-            },
-            data: {
-              type: 'libraries',
-              id: '13462',
-            },
-          },
-          requests: {
-            links: {
-              self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/10748/relationships/requests',
-              related: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/10748/requests',
-            },
-          },
-        },
-      },
-      {
-        id: '10797',
-        type: 'tubes',
-        links: {
-          self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/10797',
-        },
-        attributes: {
-          barcode: 'TRAC-2-10797',
-        },
-        relationships: {
-          materials: {
-            links: {
-              self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/10797/relationships/materials',
-              related: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/10797/materials',
-            },
-          },
-          pools: {
-            links: {
-              self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/10797/relationships/pools',
-              related: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/10797/pools',
-            },
-            data: [
-              {
-                type: 'pools',
-                id: '5817',
-              },
-            ],
-          },
-          libraries: {
-            links: {
-              self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/10797/relationships/libraries',
-              related: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/10797/libraries',
-            },
-          },
-          requests: {
-            links: {
-              self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/10797/relationships/requests',
-              related: 'https://traction.psd.sanger.ac.uk/v1/pacbio/tubes/10797/requests',
             },
           },
         },
@@ -3600,18 +3185,9 @@ const PacbioRunFactory = ({ count = undefined, findBy = null } = {}) => {
           used_volume: 9.0,
           available_volume: 0.0,
           source_identifier: 'TRAC-2-10619,TRAC-2-10620,TRAC-2-10621',
+          barcode: 'TRAC-2-10797',
         },
         relationships: {
-          tube: {
-            links: {
-              self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/pools/5817/relationships/tube',
-              related: 'https://traction.psd.sanger.ac.uk/v1/pacbio/pools/5817/tube',
-            },
-            data: {
-              type: 'tubes',
-              id: '10797',
-            },
-          },
           used_aliquots: {
             links: {
               self: 'https://traction.psd.sanger.ac.uk/v1/pacbio/pools/5817/relationships/used_aliquots',

--- a/tests/factories/PacbioTubeFactory.js
+++ b/tests/factories/PacbioTubeFactory.js
@@ -212,6 +212,7 @@ const PacbioTubeFactory = ({ findBy = null, transformTubes = false } = {}) => {
           created_at: '2024/03/18 15:03',
           updated_at: '2024/03/18 15:03',
           source_identifier: 'GEN-1710774222-1:E5-H5',
+          barcode: 'TRAC-2-24',
         },
         relationships: {
           tube: {
@@ -281,6 +282,7 @@ const PacbioTubeFactory = ({ findBy = null, transformTubes = false } = {}) => {
           updated_at: '2024/03/18 15:03',
           source_identifier: 'GEN-1710774222-1:H4-C5',
           available_volume: 20,
+          barcode: 'TRAC-2-22',
         },
         relationships: {
           tube: {
@@ -1015,6 +1017,7 @@ const PacbioTubeFactory = ({ findBy = null, transformTubes = false } = {}) => {
           source_identifier: 'GEN-1710774222-1:H4',
           pacbio_request_id: 32,
           tag_id: 1,
+          barcode: 'TRAC-2-32',
         },
         relationships: {
           request: {
@@ -1095,6 +1098,7 @@ const PacbioTubeFactory = ({ findBy = null, transformTubes = false } = {}) => {
           source_identifier: 'GEN-1710774222-1:A5',
           pacbio_request_id: 33,
           tag_id: 2,
+          barcode: 'TRAC-2-33',
         },
         relationships: {
           request: {
@@ -1175,6 +1179,7 @@ const PacbioTubeFactory = ({ findBy = null, transformTubes = false } = {}) => {
           source_identifier: 'GEN-1710774222-1:B5',
           pacbio_request_id: 34,
           tag_id: 3,
+          barcode: 'TRAC-2-34',
         },
         relationships: {
           request: {
@@ -1255,6 +1260,7 @@ const PacbioTubeFactory = ({ findBy = null, transformTubes = false } = {}) => {
           source_identifier: 'GEN-1710774222-1:C5',
           pacbio_request_id: 35,
           tag_id: 4,
+          barcode: 'TRAC-2-35',
         },
         relationships: {
           request: {
@@ -1335,6 +1341,7 @@ const PacbioTubeFactory = ({ findBy = null, transformTubes = false } = {}) => {
           source_identifier: 'GEN-1710774222-1:E5',
           pacbio_request_id: 37,
           tag_id: 1,
+          barcode: 'TRAC-2-37',
         },
         relationships: {
           request: {
@@ -1415,6 +1422,7 @@ const PacbioTubeFactory = ({ findBy = null, transformTubes = false } = {}) => {
           source_identifier: 'GEN-1710774222-1:F5',
           pacbio_request_id: 38,
           tag_id: 2,
+          barcode: 'TRAC-2-38',
         },
         relationships: {
           request: {
@@ -1495,6 +1503,7 @@ const PacbioTubeFactory = ({ findBy = null, transformTubes = false } = {}) => {
           source_identifier: 'GEN-1710774222-1:G5',
           pacbio_request_id: 39,
           tag_id: 3,
+          barcode: 'TRAC-2-39',
         },
         relationships: {
           request: {
@@ -1575,6 +1584,7 @@ const PacbioTubeFactory = ({ findBy = null, transformTubes = false } = {}) => {
           source_identifier: 'GEN-1710774222-1:H5',
           pacbio_request_id: 40,
           tag_id: 4,
+          barcode: 'TRAC-2-40',
         },
         relationships: {
           request: {
@@ -1655,6 +1665,7 @@ const PacbioTubeFactory = ({ findBy = null, transformTubes = false } = {}) => {
           source_identifier: 'GEN-1710774222-1:F4',
           pacbio_request_id: 30,
           available_volume: 20,
+          barcode: 'TRAC-2-30',
         },
         relationships: {
           request: {

--- a/tests/unit/components/labware/PacbioRunWell.spec.js
+++ b/tests/unit/components/labware/PacbioRunWell.spec.js
@@ -80,7 +80,7 @@ const smrtLinkVersions = {
  *
  */
 function mountPacbioRunWell({ state = {}, plugins = [] } = {}) {
-  const { pools, libraries, tubes, aliquots, requests, tags } = pacbioRunFactory.storeData
+  const { pools, libraries, aliquots, requests, tags } = pacbioRunFactory.storeData
 
   const defaultOptions = {
     run: {},
@@ -88,7 +88,6 @@ function mountPacbioRunWell({ state = {}, plugins = [] } = {}) {
     wells: { 1: { A1: storeWell } },
     pools,
     libraries,
-    tubes,
     requests,
     tags,
     aliquots: { ...usedAliquots, ...aliquots },

--- a/tests/unit/components/pacbio/PacbioRunWellEdit.spec.js
+++ b/tests/unit/components/pacbio/PacbioRunWellEdit.spec.js
@@ -605,7 +605,7 @@ describe('PacbioRunWellEdit', () => {
     describe('updateUsedAliquotSource', () => {
       it('updates the source, available_volume and volume of the used aliquot at the given index when the source is a pool', async () => {
         store.findPoolsOrLibrariesByTube = vi.fn()
-        store.tubeContentByBarcode = vi.fn().mockReturnValue({
+        store.sourceByBarcode = vi.fn().mockReturnValue({
           id: 1,
           type: 'pools',
           barcode: 'TRAC-2-1',
@@ -631,7 +631,7 @@ describe('PacbioRunWellEdit', () => {
 
       it('updates the source, available_volume and volume of the used aliquot at the given index when the source is a library', async () => {
         store.findPoolsOrLibrariesByTube = vi.fn()
-        store.tubeContentByBarcode = vi.fn().mockReturnValue({
+        store.sourceByBarcode = vi.fn().mockReturnValue({
           id: 1,
           type: 'libraries',
           barcode: 'TRAC-2-1',
@@ -658,7 +658,7 @@ describe('PacbioRunWellEdit', () => {
 
       it('adds an error if the volume changed to a value less than available volume of the aliquot', async () => {
         store.findPoolsOrLibrariesByTube = vi.fn()
-        store.tubeContentByBarcode = vi.fn().mockReturnValue({
+        store.sourceByBarcode = vi.fn().mockReturnValue({
           id: 1,
           type: 'libraries',
           barcode: 'TRAC-2-1',
@@ -693,7 +693,7 @@ describe('PacbioRunWellEdit', () => {
 
       it('shows an alert if the source does not exist', async () => {
         store.findPoolsOrLibrariesByTube = vi.fn()
-        store.tubeContentByBarcode = vi.fn().mockReturnValue(undefined)
+        store.sourceByBarcode = vi.fn().mockReturnValue(undefined)
 
         wrapper.vm.addRow()
         await wrapper.vm.updateUsedAliquotSource({ index: 1, item: { id: '' } }, 'TRAC-2-1')

--- a/tests/unit/components/pacbio/PacbioRunWellEdit.spec.js
+++ b/tests/unit/components/pacbio/PacbioRunWellEdit.spec.js
@@ -292,35 +292,35 @@ describe('PacbioRunWellEdit', () => {
             pools: {
               1: {
                 id: 1,
-                tube: 1,
                 used_aliquots: [],
                 type: 'pools',
                 volume: 5,
                 concentration: 10,
                 template_prep_kit_box_barcode: 'tpkbb1',
+                barcode: 'TRAC-1',
               },
               2: {
                 id: 2,
-                tube: 2,
                 used_aliquots: [],
                 type: 'pools',
                 volume: 6,
                 concentration: 11,
                 template_prep_kit_box_barcode: 'tpkbb1',
+                barcode: 'TRAC-2',
               },
             },
             libraries: {
               1: {
                 id: 1,
-                tube: 1,
                 request: 1,
                 type: 'libraries',
                 volume: 7,
                 concentration: 12,
                 available_volume: 10,
                 template_prep_kit_box_barcode: 'tpkbb1',
+                barcode: 'TRAC-1',
               },
-              2: { id: 2, tube: 2, request: 2, type: 'libraries' },
+              2: { id: 2, request: 2, type: 'libraries', barcode: 'TRAC-2' },
             },
             aliquots: {
               1: {
@@ -333,11 +333,6 @@ describe('PacbioRunWellEdit', () => {
                 source_id: 1,
                 source_type: 'Pacbio::Library',
               },
-            },
-            tubes: {
-              1: { barcode: 'TRAC-1', pools: [1] },
-              2: { barcode: 'TRAC-2', pools: [2] },
-              3: { barcode: 'TRAC-3', libraries: [1] },
             },
             requests: {
               1: { id: 1, sample_name: 'sample1' },
@@ -470,37 +465,37 @@ describe('PacbioRunWellEdit', () => {
             pools: {
               1: {
                 id: 1,
-                tube: 1,
                 used_aliquots: [],
                 type: 'pools',
                 volume: 10,
                 concentration: 10,
                 template_prep_kit_box_barcode: 'tpkbb1',
                 available_volume: 10,
+                barcode: 'TRAC-1',
               },
               2: {
                 id: 2,
-                tube: 2,
                 used_aliquots: [],
                 type: 'pools',
                 volume: 10,
                 concentration: 11,
                 template_prep_kit_box_barcode: 'tpkbb1',
                 available_volume: 10,
+                barcode: 'TRAC-2',
               },
             },
             libraries: {
               1: {
                 id: 1,
-                tube: 1,
                 request: 1,
                 type: 'libraries',
                 volume: 10,
                 concentration: 12,
                 template_prep_kit_box_barcode: 'tpkbb1',
                 available_volume: 10,
+                barcode: 'TRAC-1',
               },
-              2: { id: 2, tube: 2, used_aliquots: [], request: 2, type: 'libraries' },
+              2: { id: 2, used_aliquots: [], request: 2, type: 'libraries', barcode: 'TRAC-2' },
             },
             aliquots: {
               1: {
@@ -517,11 +512,6 @@ describe('PacbioRunWellEdit', () => {
                 used_by_type: 'Pacbio::Well',
                 volume: 5,
               },
-            },
-            tubes: {
-              1: { barcode: 'TRAC-1', pools: [1] },
-              2: { barcode: 'TRAC-2', pools: [2] },
-              3: { barcode: 'TRAC-3', libraries: [1] },
             },
             requests: {
               1: { id: 1, sample_name: 'sample1' },

--- a/tests/unit/stores/pacbioLibraryBatchCreate.spec.js
+++ b/tests/unit/stores/pacbioLibraryBatchCreate.spec.js
@@ -31,7 +31,6 @@ describe('usePacbioLibraryBatchCreateStore', () => {
     describe('librariesInBatch', () => {
       it('returns libraries in batch', () => {
         pacbioLibraryBatchCreateStore.libraries = pacbioLibraryBatchFactory.storeData.libraries
-        pacbioLibraryBatchCreateStore.tubes = pacbioLibraryBatchFactory.storeData.tubes
         pacbioRootStore.tags = pacbioTagSetFactory.storeData.tags
         expect(pacbioLibraryBatchCreateStore.librariesInBatch).toEqual(
           pacbioLibraryBatchFactory.storeData.librariesInBatch,
@@ -43,7 +42,6 @@ describe('usePacbioLibraryBatchCreateStore', () => {
     describe('librariesInfoInPrintFormat', () => {
       it('returns library data in print format', () => {
         pacbioLibraryBatchCreateStore.libraries = pacbioLibraryBatchFactory.storeData.libraries
-        pacbioLibraryBatchCreateStore.tubes = pacbioLibraryBatchFactory.storeData.tubes
         expect(pacbioLibraryBatchCreateStore.librariesInfoInPrintFormat).toEqual(
           pacbioLibraryBatchFactory.storeData.librariesInBatch.map(
             ({ barcode, source: source_identifier }) => ({
@@ -164,9 +162,6 @@ describe('usePacbioLibraryBatchCreateStore', () => {
         expect(success).toBeTruthy()
         expect(pacbioLibraryBatchCreateStore.libraries).toEqual(
           pacbioLibraryBatchFactory.storeData.libraries,
-        )
-        expect(pacbioLibraryBatchCreateStore.tubes).toEqual(
-          pacbioLibraryBatchFactory.storeData.tubes,
         )
         expect(result).toEqual(pacbioLibraryBatchCreateStore.librariesInBatch)
       })

--- a/tests/unit/stores/pacbioRunCreate.spec.js
+++ b/tests/unit/stores/pacbioRunCreate.spec.js
@@ -46,15 +46,15 @@ describe('usePacbioRunCreateStore', () => {
         )
       })
     })
-    describe('tubeContents', () => {
-      it('"tubeContents" returns denormalized pools from "state.pools and state.libraries"', () => {
+    describe('sourceItems', () => {
+      it('"sourceItems" returns denormalized pools from "state.pools and state.libraries"', () => {
         const store = usePacbioRunCreateStore()
         store.$state = {
           ...pacbioRunFactory.storeData,
           resources: { smrtLinkVersions: pacbioSmrtLinkVersionFactory.storeData },
         }
-        const tubeContents = store.tubeContents
-        expect(tubeContents.length).toEqual(
+        const sourceItems = store.sourceItems
+        expect(sourceItems.length).toEqual(
           Object.values(pacbioRunFactory.storeData.pools).concat(
             Object.values(pacbioRunFactory.storeData.libraries),
           ).length,
@@ -62,7 +62,7 @@ describe('usePacbioRunCreateStore', () => {
       })
 
       // needs refactoring. I am recreating some of the methods in pacbioRunCreate.
-      it('"tubeContentByBarcode" returns the correct library and samples given a barcode', () => {
+      it('"sourceByBarcode" returns the correct library and samples given a barcode', () => {
         const store = usePacbioRunCreateStore()
         store.$state = {
           ...pacbioRunFactory.storeData,
@@ -72,7 +72,7 @@ describe('usePacbioRunCreateStore', () => {
         const { request, tag } = library
         const { sample_name } = pacbioRunFactory.storeData.requests[request]
         const { group_id = '' } = pacbioRunFactory.storeData.tags[tag] || {}
-        const actual = store.tubeContentByBarcode(library.barcode)
+        const actual = store.sourceByBarcode(library.barcode)
         expect(actual).toEqual({
           ...library,
           samples: [`${sample_name}:${group_id}`],
@@ -80,7 +80,7 @@ describe('usePacbioRunCreateStore', () => {
       })
 
       // need to get run with pools which is the second run
-      it('"tubeContentByBarcode" returns the correct pool and samples given a barcode', () => {
+      it('"sourceByBarcode" returns the correct pool and samples given a barcode', () => {
         const store = usePacbioRunCreateStore()
         const pacbioRunFactoryWithPools = PacbioRunFactory({ findBy: 'Sequel IIe' })
         store.$state = {
@@ -96,7 +96,7 @@ describe('usePacbioRunCreateStore', () => {
           const { group_id = '' } = pacbioRunFactoryWithPools.storeData.tags[tag_id] || {}
           return `${sample_name}:${group_id}`
         })
-        const actual = store.tubeContentByBarcode(pool.barcode)
+        const actual = store.sourceByBarcode(pool.barcode)
         expect(actual).toEqual({
           ...pool,
           // ugh!


### PR DESCRIPTION
Closes #2227 

#### Changes proposed in this pull request

- Removes tube references in PacbioRunCreate store in favour of using library and pool barcode attribute.
- Renames tubeContents and tubeContentByBarcode to sourceItem and sourceByBarcode.
  - I think this is a more apt name because libraries and pools are well / aliquot 'sources'.
- Removes tube references from PacbioLibraryBatchCreate store.

