### PR TITLE
Y25-133 - Handle Traction Service down errors

### DIFF
--- a/src/api/ResponseHelper.js
+++ b/src/api/ResponseHelper.js
@@ -98,10 +98,15 @@ const handleResponse = async (promise, errorHandler) => {
     try {
       response = rawResponse.status === HTTP_STATUS_NO_CONTENT ? {} : await rawResponse.json()
     } catch {
+      // Console warn to help with developer debugging
+      console.warn(`Response from ${rawResponse.url} is not valid JSON`)
+      // User friendly error
       return newResponse({
         success: false,
         errorHandler,
-        errors: { 'Response is not valid JSON': ['Traction service may be down.'] },
+        errors: {
+          'Response is not valid JSON': ['The service you are trying to reach may be down'],
+        },
       })
     }
 

--- a/src/api/ResponseHelper.js
+++ b/src/api/ResponseHelper.js
@@ -91,7 +91,20 @@ const newResponse = ({
 const handleResponse = async (promise, errorHandler) => {
   try {
     const rawResponse = await promise
-    const response = rawResponse.status === HTTP_STATUS_NO_CONTENT ? {} : await rawResponse.json()
+    let response = {}
+    // Some responses (e.g. DELETE / 204's) do not return a body but are valid
+    // Response.json() can throw an error if the response is not valid JSON
+    // See https://developer.mozilla.org/en-US/docs/Web/API/Response/json_static#exceptions
+    try {
+      response = rawResponse.status === HTTP_STATUS_NO_CONTENT ? {} : await rawResponse.json()
+    } catch {
+      return newResponse({
+        success: false,
+        errorHandler,
+        errors: { 'Response is not valid JSON': ['Traction service may be down.'] },
+      })
+    }
+
     // Please check https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#checking_that_the_fetch_was_successful
     // for more information on the ok property
     if (!rawResponse.ok) {

--- a/tests/unit/api/ResponseHelper.spec.js
+++ b/tests/unit/api/ResponseHelper.spec.js
@@ -215,6 +215,19 @@ describe('ResponseHelper', () => {
       expect(response.errors).toEqual(error)
     })
 
+    it('failure if response is ok but its not json', async () => {
+      const mockResponse = {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: () => Promise.reject(new TypeError('Invalid JSON')),
+      }
+      const promise = Promise.resolve(mockResponse)
+      const response = await handleResponse(promise)
+      expect(response.success).toBeFalsy()
+      expect(response.errors).toEqual('Response is not valid JSON Traction service may be down.')
+    })
+
     it('print my barcode failure', async () => {
       const mockResponse = {
         ok: false,

--- a/tests/unit/api/ResponseHelper.spec.js
+++ b/tests/unit/api/ResponseHelper.spec.js
@@ -216,16 +216,21 @@ describe('ResponseHelper', () => {
     })
 
     it('failure if response is ok but its not json', async () => {
+      vi.spyOn(console, 'warn').mockImplementation(() => {})
       const mockResponse = {
         ok: true,
         status: 200,
         statusText: 'OK',
+        url: 'example-url',
         json: () => Promise.reject(new TypeError('Invalid JSON')),
       }
       const promise = Promise.resolve(mockResponse)
       const response = await handleResponse(promise)
+      expect(console.warn).toHaveBeenCalledWith('Response from example-url is not valid JSON')
       expect(response.success).toBeFalsy()
-      expect(response.errors).toEqual('Response is not valid JSON Traction service may be down.')
+      expect(response.errors).toEqual(
+        'Response is not valid JSON The service you are trying to reach may be down',
+      )
     })
 
     it('print my barcode failure', async () => {


### PR DESCRIPTION
Closes #2211 

#### Changes proposed in this pull request

- Adds graceful error handling for when the fetch response is not in JSON format.

#### Instructions for Reviewers

- This is most likely caused when the traction-service pumas are down and nginx is still accessible and returning a html response. This was not being read correctly and causing a type error when trying to call `json()` on the response.
