### PR TITLE
Y24-361 - Mock reception

### DIFF
--- a/src/lib/receptions/MockReception.js
+++ b/src/lib/receptions/MockReception.js
@@ -44,7 +44,7 @@ const fetchPlatesFunction = async ({ requestOptions, barcodes }) => {
 
     for (let i = 0; i < 48; i++) {
       const position = String.fromCharCode(65 + Math.floor(i / 12)) + ((i % 12) + 1)
-      const sample_name = `${barcode}-${i}`
+      const sample_name = `${barcode}-sample-${i}`
       wells_attributes.push({
         type: 'wells',
         position,
@@ -79,7 +79,7 @@ const fetchPlatesFunction = async ({ requestOptions, barcodes }) => {
  */
 const fetchTubesFunction = async ({ requestOptions, barcodes }) => {
   const tubes_attributes = barcodes.map((barcode, index) => {
-    const sample_name = `${barcode}-${index}`
+    const sample_name = `${barcode}-sample-${index}`
     return {
       type: 'tubes',
       barcode,

--- a/src/lib/receptions/MockReception.js
+++ b/src/lib/receptions/MockReception.js
@@ -4,7 +4,29 @@
 // It is not intended for production use
 
 /**
- * Generates a reception object containing mocked plate attributes based on the provided barcodes.
+ * A function to help encapsulate the logic of building a mock sample and request object.
+ *
+ * @param {string} sample_name - The name of the sample to be included in the mock data.
+ * @param {Object} requestOptions - An object containing request options to be included in each well's request.
+ * @returns {Object} A mock sample and request object.
+ */
+const buildMockSampleAndRequest = (sample_name, requestOptions) => {
+  return {
+    sample: {
+      name: sample_name,
+      species: 'Human',
+      retention_instruction: 'long_term_storage',
+      external_id: crypto.randomUUID(),
+    },
+    request: {
+      ...requestOptions,
+      external_study_id: crypto.randomUUID(),
+    },
+  }
+}
+
+/**
+ * Generates a reception object containing mocked plates_attributes based on the provided barcodes.
  * Each plate contains a barcode and an array of well attributes. Each well
  * attribute includes a position, sample details, and request details.
  *
@@ -22,19 +44,11 @@ const fetchPlatesFunction = async ({ requestOptions, barcodes }) => {
 
     for (let i = 0; i < 48; i++) {
       const position = String.fromCharCode(65 + Math.floor(i / 12)) + ((i % 12) + 1)
+      const sample_name = `${barcode}-${i}`
       wells_attributes.push({
         type: 'wells',
         position,
-        sample: {
-          name: `${barcode}-${i}`,
-          species: 'Human',
-          retention_instruction: 'long_term_storage',
-          external_id: crypto.randomUUID(),
-        },
-        request: {
-          ...requestOptions,
-          external_study_id: crypto.randomUUID(),
-        },
+        ...buildMockSampleAndRequest(sample_name, requestOptions),
       })
     }
 
@@ -51,21 +65,25 @@ const fetchPlatesFunction = async ({ requestOptions, barcodes }) => {
   }
 }
 
+/**
+ * Generates a reception object containing mocked tubes_attributes based on the provided barcodes.
+ * Each tube contains a barcode, sample details and request details.
+ *
+ * @param {string[]} barcodes - An array of barcodes to use for the tubes.
+ * @param {Object} requestOptions - An object containing request options to be included in each well's request.
+ * @returns {Object} A formatted reception object containing the following structure:
+ *   - `attributes` {Object}: The attributes of the reception, including:
+ *      - `source` {string}: The source of the reception, always "traction-ui.mock-reception".
+ *      - `tubes_attributes` {Object[]}: An array of tube attributes.
+ *   - `foundBarcodes` {Set}: A set of found barcodes.
+ */
 const fetchTubesFunction = async ({ requestOptions, barcodes }) => {
   const tubes_attributes = barcodes.map((barcode, index) => {
+    const sample_name = `${barcode}-${index}`
     return {
       type: 'tubes',
       barcode,
-      sample: {
-        name: `${barcode} ${index}`,
-        species: 'Human',
-        retention_instruction: 'long_term_storage',
-        external_id: crypto.randomUUID(),
-      },
-      request: {
-        ...requestOptions,
-        external_study_id: crypto.randomUUID(),
-      },
+      ...buildMockSampleAndRequest(sample_name, requestOptions),
     }
   })
 

--- a/src/lib/receptions/MockReception.js
+++ b/src/lib/receptions/MockReception.js
@@ -1,0 +1,85 @@
+// A mock reception class for testing purposes
+// This class is used to simulate the behavior of a real reception class
+// It produces randomized data for testing purposes without relying on external APIs
+// It is not intended for production use
+
+/**
+ * Generates a reception object containing mocked plate attributes based on the provided barcodes.
+ * Each plate contains a barcode and an array of well attributes. Each well
+ * attribute includes a position, sample details, and request details.
+ *
+ * @param {string[]} barcodes - An array of barcodes to use for the plates.
+ * @param {Object} requestOptions - An object containing request options to be included in each well's request.
+ * @returns {Object} A formatted reception object containing the following structure:
+ *   - `attributes` {Object}: The attributes of the reception, including:
+ *      - `source` {string}: The source of the reception, always "traction-ui.mock-reception".
+ *      - `plates_attributes` {Object[]}: An array of plate attributes.
+ *   - `foundBarcodes` {Set}: A set of found barcodes.
+ */
+const fetchPlatesFunction = async ({ requestOptions, barcodes }) => {
+  const plates_attributes = barcodes.map((barcode) => {
+    const wells_attributes = []
+
+    for (let i = 0; i < 48; i++) {
+      const position = String.fromCharCode(65 + Math.floor(i / 12)) + ((i % 12) + 1)
+      wells_attributes.push({
+        type: 'wells',
+        position,
+        sample: {
+          name: `${barcode}-${i}`,
+          species: 'Human',
+          retention_instruction: 'long_term_storage',
+          external_id: crypto.randomUUID(),
+        },
+        request: {
+          ...requestOptions,
+          external_study_id: crypto.randomUUID(),
+        },
+      })
+    }
+
+    return {
+      type: 'plates',
+      barcode,
+      wells_attributes,
+    }
+  })
+
+  return {
+    attributes: { source: 'traction-ui.mock-reception', plates_attributes },
+    foundBarcodes: new Set(barcodes),
+  }
+}
+
+const fetchTubesFunction = async ({ requestOptions, barcodes }) => {
+  const tubes_attributes = barcodes.map((barcode, index) => {
+    return {
+      type: 'tubes',
+      barcode,
+      sample: {
+        name: `${barcode} ${index}`,
+        species: 'Human',
+        retention_instruction: 'long_term_storage',
+        external_id: crypto.randomUUID(),
+      },
+      request: {
+        ...requestOptions,
+        external_study_id: crypto.randomUUID(),
+      },
+    }
+  })
+
+  return {
+    attributes: { source: 'traction-ui.mock-reception', tubes_attributes },
+    foundBarcodes: new Set(barcodes),
+  }
+}
+
+const MockReception = {
+  fetchPlatesFunction,
+  fetchTubesFunction,
+}
+
+export { fetchPlatesFunction, fetchTubesFunction }
+
+export default MockReception

--- a/src/lib/receptions/index.js
+++ b/src/lib/receptions/index.js
@@ -85,7 +85,7 @@ const MockReceptionTypes = {
 }
 
 const receptionOptions = () => {
-  const environment = import.meta.env.VITE_ENVIRONMENT
+  const environment = import.meta.env['VITE_ENVIRONMENT']
   if (environment === 'uat' || environment === 'development') {
     return [
       ...Object.values(ReceptionTypes),

--- a/src/lib/receptions/index.js
+++ b/src/lib/receptions/index.js
@@ -86,6 +86,7 @@ const MockReceptionTypes = {
 
 const receptionOptions = () => {
   const environment = import.meta.env['VITE_ENVIRONMENT']
+  console.log('Environment:', environment)
   if (environment === 'uat' || environment === 'development') {
     return [
       ...Object.values(ReceptionTypes),

--- a/src/lib/receptions/index.js
+++ b/src/lib/receptions/index.js
@@ -97,7 +97,7 @@ function receptionOptions() {
 }
 
 const Receptions = {
-  options: receptionOptions(),
+  options: receptionOptions,
   Sequencescape: {
     ...ReceptionTypes.Sequencescape,
     fetchFunction: Sequencescape.fetchLabwareForReception,

--- a/src/lib/receptions/index.js
+++ b/src/lib/receptions/index.js
@@ -84,20 +84,7 @@ const MockReceptionTypes = {
   },
 }
 
-function receptionOptions() {
-  const environment = import.meta.env['VITE_ENVIRONMENT']
-  if (environment === 'uat' || environment === 'development') {
-    return [
-      ...Object.values(ReceptionTypes),
-      { label: 'Mock receptions (UAT only)', options: [...Object.values(MockReceptionTypes)] },
-    ]
-  }
-
-  return [...Object.values(ReceptionTypes)]
-}
-
 const Receptions = {
-  options: receptionOptions,
   Sequencescape: {
     ...ReceptionTypes.Sequencescape,
     fetchFunction: Sequencescape.fetchLabwareForReception,
@@ -129,4 +116,4 @@ const Receptions = {
 }
 
 export default Receptions
-export { defaultRequestOptions, WorkflowsLocations }
+export { defaultRequestOptions, WorkflowsLocations, ReceptionTypes, MockReceptionTypes }

--- a/src/lib/receptions/index.js
+++ b/src/lib/receptions/index.js
@@ -1,6 +1,7 @@
 import * as Sequencescape from './Sequencescape.js'
 import * as SequencescapeTubes from './SequencescapeTubes.js'
 import * as SequencescapeMultiplexedLibraries from './SequencescapeMultiplexedLibraries.js'
+import * as MockReception from './MockReception.js'
 
 import MultiBarcode from '@/components/reception/MultiBarcode.vue'
 import MultiplexedLibraryBarcode from '@/components/reception/MultiplexedLibraryBarcode.vue'
@@ -68,8 +69,26 @@ const ReceptionTypes = {
   },
 }
 
+const MockReceptionTypes = {
+  MockedPlates: {
+    name: 'mocked-plates',
+    text: 'Mocked plates',
+    value: 'MockedPlates',
+    pipelines: ['PacBio', 'ONT'],
+  },
+  MockedTubes: {
+    name: 'mocked-tubes',
+    text: 'Mocked tubes',
+    value: 'MockedTubes',
+    pipelines: ['PacBio', 'ONT'],
+  },
+}
+
 const Receptions = {
-  options: Object.values(ReceptionTypes),
+  options: [
+    ...Object.values(ReceptionTypes),
+    { label: 'Mock receptions (UAT only)', options: [...Object.values(MockReceptionTypes)] },
+  ],
   Sequencescape: {
     ...ReceptionTypes.Sequencescape,
     fetchFunction: Sequencescape.fetchLabwareForReception,
@@ -87,6 +106,16 @@ const Receptions = {
     fetchFunction: SequencescapeMultiplexedLibraries.fetchLabwareForReception,
     barcodeComponent: MultiplexedLibraryBarcode,
     getAttributeKeysFunction: SequencescapeMultiplexedLibraries.getAttributeKeys,
+  },
+  MockedPlates: {
+    ...MockReceptionTypes.MockedPlates,
+    fetchFunction: MockReception.fetchPlatesFunction,
+    barcodeComponent: MultiBarcode,
+  },
+  MockedTubes: {
+    ...MockReceptionTypes.MockedTubes,
+    fetchFunction: MockReception.fetchTubesFunction,
+    barcodeComponent: MultiBarcode,
   },
 }
 

--- a/src/lib/receptions/index.js
+++ b/src/lib/receptions/index.js
@@ -84,9 +84,8 @@ const MockReceptionTypes = {
   },
 }
 
-const receptionOptions = () => {
+function receptionOptions() {
   const environment = import.meta.env['VITE_ENVIRONMENT']
-  console.log('Environment:', environment)
   if (environment === 'uat' || environment === 'development') {
     return [
       ...Object.values(ReceptionTypes),

--- a/src/lib/receptions/index.js
+++ b/src/lib/receptions/index.js
@@ -84,11 +84,20 @@ const MockReceptionTypes = {
   },
 }
 
+const receptionOptions = () => {
+  const environment = import.meta.env.VITE_ENVIRONMENT
+  if (environment === 'uat' || environment === 'development') {
+    return [
+      ...Object.values(ReceptionTypes),
+      { label: 'Mock receptions (UAT only)', options: [...Object.values(MockReceptionTypes)] },
+    ]
+  }
+
+  return [...Object.values(ReceptionTypes)]
+}
+
 const Receptions = {
-  options: [
-    ...Object.values(ReceptionTypes),
-    { label: 'Mock receptions (UAT only)', options: [...Object.values(MockReceptionTypes)] },
-  ],
+  options: receptionOptions(),
   Sequencescape: {
     ...ReceptionTypes.Sequencescape,
     fetchFunction: Sequencescape.fetchLabwareForReception,

--- a/src/views/GeneralReception.vue
+++ b/src/views/GeneralReception.vue
@@ -223,10 +223,9 @@ const workflowOptions = computed(() => [
     })),
 ])
 
+const environment = ref(import.meta.env['VITE_ENVIRONMENT'])
 const receptionOptions = () => {
-  const environment = import.meta.env['VITE_ENVIRONMENT']
-  console.log(environment)
-  if (environment == 'uat' || environment == 'development') {
+  if (environment.value == 'uat' || environment.value == 'development') {
     return [
       ...Object.values(ReceptionTypes),
       { label: 'Mock receptions (UAT only)', options: [...Object.values(MockReceptionTypes)] },

--- a/src/views/GeneralReception.vue
+++ b/src/views/GeneralReception.vue
@@ -225,7 +225,8 @@ const workflowOptions = computed(() => [
 
 const receptionOptions = () => {
   const environment = import.meta.env['VITE_ENVIRONMENT']
-  if (environment === 'uat' || environment === 'development') {
+  console.log(environment)
+  if (environment == 'uat' || environment == 'development') {
     return [
       ...Object.values(ReceptionTypes),
       { label: 'Mock receptions (UAT only)', options: [...Object.values(MockReceptionTypes)] },

--- a/src/views/GeneralReception.vue
+++ b/src/views/GeneralReception.vue
@@ -15,7 +15,7 @@
             id="sourceSelect"
             v-model="source"
             class="inline-block w-full"
-            :options="Receptions.options"
+            :options="Receptions.options()"
             data-type="source-list"
             @update:model-value="updatePipeline()"
           />

--- a/src/views/GeneralReception.vue
+++ b/src/views/GeneralReception.vue
@@ -15,7 +15,7 @@
             id="sourceSelect"
             v-model="source"
             class="inline-block w-full"
-            :options="Receptions.options()"
+            :options="receptionOptions()"
             data-type="source-list"
             @update:model-value="updatePipeline()"
           />
@@ -190,7 +190,7 @@ import Receptions, { WorkflowsLocations } from '@/lib/receptions'
 import TractionHeading from '../components/TractionHeading.vue'
 import LibraryTypeSelect from '@/components/shared/LibraryTypeSelect.vue'
 import DataTypeSelect from '@/components/shared/DataTypeSelect.vue'
-import { defaultRequestOptions } from '@/lib/receptions'
+import { defaultRequestOptions, ReceptionTypes, MockReceptionTypes } from '@/lib/receptions'
 
 // We don't expect the modal to display without a message. If we end up in this
 // state then something has gone horribly wrong.
@@ -222,6 +222,18 @@ const workflowOptions = computed(() => [
       text: workflow.name,
     })),
 ])
+
+const receptionOptions = () => {
+  const environment = import.meta.env['VITE_ENVIRONMENT']
+  if (environment === 'uat' || environment === 'development') {
+    return [
+      ...Object.values(ReceptionTypes),
+      { label: 'Mock receptions (UAT only)', options: [...Object.values(MockReceptionTypes)] },
+    ]
+  }
+
+  return [...Object.values(ReceptionTypes)]
+}
 
 const workflowLocation = computed(() => {
   const workflowsMap = new Map(

--- a/tests/unit/lib/receptions/MockReception.spec.js
+++ b/tests/unit/lib/receptions/MockReception.spec.js
@@ -22,7 +22,7 @@ describe('MockReception', () => {
         plate.wells_attributes.forEach((well, index) => {
           expect(well.type).toBe('wells')
           expect(well.position).toBeDefined()
-          expect(well.sample.name).toEqual(`${plate.barcode}-${index}`)
+          expect(well.sample.name).toEqual(`${plate.barcode}-sample-${index}`)
           expect(well.sample.species).toBe('Human')
           expect(well.sample.retention_instruction).toBe('long_term_storage')
           expect(well.sample.external_id).toBeDefined()
@@ -51,7 +51,7 @@ describe('MockReception', () => {
       attributes.tubes_attributes.forEach((tube, index) => {
         expect(tube.type).toBe('tubes')
         expect(tube.barcode).toBe(barcodes[index])
-        expect(tube.sample.name).toEqual(`${tube.barcode}-${index}`)
+        expect(tube.sample.name).toEqual(`${tube.barcode}-sample-${index}`)
         expect(tube.sample.species).toBe('Human')
         expect(tube.sample.retention_instruction).toBe('long_term_storage')
         expect(tube.sample.external_id).toBeDefined()

--- a/tests/unit/lib/receptions/MockReception.spec.js
+++ b/tests/unit/lib/receptions/MockReception.spec.js
@@ -1,0 +1,64 @@
+import { fetchPlatesFunction, fetchTubesFunction } from '@/lib/receptions/MockReception'
+
+describe('MockReception', () => {
+  describe('#fetchPlatesFunction', () => {
+    it('returns a reception object with mocked data', async () => {
+      const barcodes = ['test-plate1', 'test-plate2']
+      const { attributes, foundBarcodes } = await fetchPlatesFunction({
+        barcodes,
+        requestOptions: {
+          library_type: 'Example',
+          cost_code: 'aCostCodeExample',
+        },
+      })
+
+      expect(foundBarcodes).toEqual(new Set(barcodes))
+      expect(attributes.source).toBe('traction-ui.mock-reception')
+      expect(attributes.plates_attributes).toHaveLength(2)
+      attributes.plates_attributes.forEach((plate, index) => {
+        expect(plate.type).toBe('plates')
+        expect(plate.barcode).toBe(barcodes[index])
+        expect(plate.wells_attributes).toHaveLength(48)
+        plate.wells_attributes.forEach((well, index) => {
+          expect(well.type).toBe('wells')
+          expect(well.position).toBeDefined()
+          expect(well.sample.name).toEqual(`${plate.barcode}-${index}`)
+          expect(well.sample.species).toBe('Human')
+          expect(well.sample.retention_instruction).toBe('long_term_storage')
+          expect(well.sample.external_id).toBeDefined()
+          expect(well.request.external_study_id).toBeDefined()
+          expect(well.request.library_type).toBe('Example')
+          expect(well.request.cost_code).toBe('aCostCodeExample')
+        })
+      })
+    })
+  })
+
+  describe('#fetchTubesFunction', () => {
+    it('returns a reception object with mocked data', async () => {
+      const barcodes = ['test-tube1', 'test-tube2']
+      const { attributes, foundBarcodes } = await fetchTubesFunction({
+        barcodes,
+        requestOptions: {
+          library_type: 'Example',
+          cost_code: 'aCostCodeExample',
+        },
+      })
+
+      expect(foundBarcodes).toEqual(new Set(barcodes))
+      expect(attributes.source).toBe('traction-ui.mock-reception')
+      expect(attributes.tubes_attributes).toHaveLength(2)
+      attributes.tubes_attributes.forEach((tube, index) => {
+        expect(tube.type).toBe('tubes')
+        expect(tube.barcode).toBe(barcodes[index])
+        expect(tube.sample.name).toEqual(`${tube.barcode}-${index}`)
+        expect(tube.sample.species).toBe('Human')
+        expect(tube.sample.retention_instruction).toBe('long_term_storage')
+        expect(tube.sample.external_id).toBeDefined()
+        expect(tube.request.external_study_id).toBeDefined()
+        expect(tube.request.library_type).toBe('Example')
+        expect(tube.request.cost_code).toBe('aCostCodeExample')
+      })
+    })
+  })
+})

--- a/tests/unit/views/GeneralReception.spec.js
+++ b/tests/unit/views/GeneralReception.spec.js
@@ -76,7 +76,13 @@ describe('GeneralReception', () => {
         .find('[data-type=source-list]')
         .findAll('option')
         .map((element) => element.text()),
-    ).toEqual(['Sequencescape', 'Sequencescape Tubes', 'Sequencescape Multiplexed Libraries'])
+    ).toEqual([
+      'Sequencescape',
+      'Sequencescape Tubes',
+      'Sequencescape Multiplexed Libraries',
+      'Mocked plates',
+      'Mocked tubes',
+    ])
     // It defaults to Sequencescape
     expect(wrapper.find('[data-type=source-list]').element.value).toEqual('Sequencescape')
   })


### PR DESCRIPTION
Closes #https://github.com/sanger/traction-service/issues/1448

#### Changes proposed in this pull request

- Adds plate and tube mock-receptions to general reception page.

#### Additional notes / thought process

- A lot of the metadata and data setup in the mock receptions is fixed. E.g. sample retention instructions, number of wells in a plate. In order to make this customisable we could create a custom barcode scanning component instead of using the existing ones, allowing us to enter data for these values. But it is a fair amount of extra work for not much benefit so I have not done that in this story.
- I chose to add this as an extra reception in the general reception page instead of as a new 'UAT action' page or similar because it keeps the logic in one place and it is intuitive.
- I would recommend pulling down and using it to test it since it is a dev-focused feature it won't require UAT.

#### Screenshots
![Screenshot 2025-05-12 at 11 09 51](https://github.com/user-attachments/assets/b33e88f7-8ffd-457c-8626-9f030d191116)


