### PR TITLE
Refactor getLabwhereLocations to streamline response handling and update tests for consistency

### DIFF
--- a/src/services/labwhere/client.js
+++ b/src/services/labwhere/client.js
@@ -37,10 +37,9 @@ const getLabwhereLocations = async (labwhereBarcodes, fetchWrapper = labwhereFet
 
   const response = await fetchWrapper.post('/api/labwares/searches', params, 'multipart/form-data')
 
-  if (response.success) {
-    response.data = extractLocationsForLabwares(response.data, labwhereBarcodes)
-  }
-  return response
+  return response.success
+    ? { ...response, data: extractLocationsForLabwares(response.data, labwhereBarcodes) }
+    : response
 }
 
 /**

--- a/tests/unit/services/labwhere/client.spec.js
+++ b/tests/unit/services/labwhere/client.spec.js
@@ -5,23 +5,16 @@ import {
 } from '@/services/labwhere/client.js'
 import * as pacbioLibraryUtilities from '@/stores/utilities/pacbioLibraries.js'
 import * as pacbioLibraryService from '@/services/traction/PacbioLibrary.js'
-import * as helpers from '@/services/labwhere/helpers.js'
 import { createPinia, setActivePinia } from '@support/testHelper.js'
 import { beforeEach, describe, it } from 'vitest'
 
-const spyPost = vi.fn()
 const mockFetchWrapper = {
-  post: spyPost,
+  post: vi.fn(),
   baseUrl: 'http://test',
   serviceName: 'test',
 }
 
 describe('getLabwhereLocations', () => {
-  let spyExtractLocations
-  beforeEach(() => {
-    spyExtractLocations = vi.spyOn(helpers, 'extractLocationsForLabwares')
-  })
-
   it('should return an error if no barcodes are provided', async () => {
     const result = await getLabwhereLocations([], mockFetchWrapper)
     expect(result).toEqual({ success: false, errors: ['No barcodes provided'], data: {} })
@@ -33,14 +26,12 @@ describe('getLabwhereLocations', () => {
       errors: ['Failed to access LabWhere: Network error'],
       data: {},
     }
-    spyPost.mockReturnValue(response)
+    mockFetchWrapper.post.mockResolvedValue(response)
     const result = await getLabwhereLocations(['barcode1'], mockFetchWrapper)
     expect(result).toEqual(response)
-    expect(spyExtractLocations).not.toHaveBeenCalled()
   })
 
   it('should call extractLocationsForLabwares if post succeeds', async () => {
-    spyPost.mockReturnValue({ success: true })
     const data = [
       {
         barcode: 'barcode1',
@@ -51,13 +42,18 @@ describe('getLabwhereLocations', () => {
         location: 'location2',
       },
     ]
-    spyExtractLocations.mockReturnValue(data)
-    const result = await getLabwhereLocations(['barcode1'], mockFetchWrapper)
-    expect(result).toEqual({ success: true, data })
-    expect(spyExtractLocations).toHaveBeenCalled()
+    const mockResponse = { success: true, errors: [], data }
+    mockFetchWrapper.post.mockResolvedValue(mockResponse)
+    const result = await getLabwhereLocations(['barcode1', 'barcode2'], mockFetchWrapper)
+    expect(result).toEqual({
+      ...mockResponse,
+      data: { barcode1: 'location1', barcode2: 'location2' },
+    })
   })
 })
-describe('scanBarcodesInLabwhereLocation', () => {
+
+//TODO: fix issues with posts
+describe.skip('scanBarcodesInLabwhereLocation', () => {
   it('should return an error if required parameters are missing', async () => {
     const result = await scanBarcodesInLabwhereLocation('', '', '', null, mockFetchWrapper)
     expect(result).toEqual({
@@ -67,7 +63,7 @@ describe('scanBarcodesInLabwhereLocation', () => {
   })
 
   it('should return formatted result for post response', async () => {
-    spyPost.mockResolvedValue({
+    mockFetchWrapper.post.mockResolvedValue({
       success: true,
       errors: [],
       data: { message: 'Labware stored to location 1' },
@@ -79,12 +75,12 @@ describe('scanBarcodesInLabwhereLocation', () => {
       null,
       mockFetchWrapper,
     )
-    expect(spyPost).toHaveBeenCalledWith(
+    expect(mockFetchWrapper.post).toHaveBeenCalledWith(
       '/api/scans',
       expect.any(String),
       'application/x-www-form-urlencoded',
     )
-    const callArgs = spyPost.mock.calls[0]
+    const callArgs = mockFetchWrapper.post.mock.calls[0]
     const params = new URLSearchParams(callArgs[1])
     expect(params.get('scan[start_position]')).toBe(null)
     expect(params.get('scan[user_code]')).toBe('user123')
@@ -98,9 +94,9 @@ describe('scanBarcodesInLabwhereLocation', () => {
   })
 
   it('should include start position if provided', async () => {
-    spyPost.mockResolvedValue({ success: true, errors: [], data: { message: '' } })
+    mockFetchWrapper.post.mockResolvedValue({ success: true, errors: [], data: { message: '' } })
     await scanBarcodesInLabwhereLocation('user123', 'location123', 'barcode1', 1, mockFetchWrapper)
-    const callArgs = spyPost.mock.calls[0]
+    const callArgs = mockFetchWrapper.post.mock.calls[0]
     const params = new URLSearchParams(callArgs[1])
     expect(params.get('scan[start_position]')).toBe('1')
   })

--- a/tests/unit/services/labwhere/client.spec.js
+++ b/tests/unit/services/labwhere/client.spec.js
@@ -52,8 +52,7 @@ describe('getLabwhereLocations', () => {
   })
 })
 
-//TODO: fix issues with posts
-describe.skip('scanBarcodesInLabwhereLocation', () => {
+describe('scanBarcodesInLabwhereLocation', () => {
   it('should return an error if required parameters are missing', async () => {
     const result = await scanBarcodesInLabwhereLocation('', '', '', null, mockFetchWrapper)
     expect(result).toEqual({
@@ -102,6 +101,7 @@ describe.skip('scanBarcodesInLabwhereLocation', () => {
   })
 })
 
+// TODO: remove mocks
 describe('exhaustLibraryVolumeIfDestroyed', () => {
   beforeEach(() => {
     const pinia = createPinia()


### PR DESCRIPTION
Closes #

This pull request refactors the `getLabwhereLocations` function and updates its associated unit tests to improve code clarity, reduce redundancy, and simplify mocking. The main changes include modifying the function's return logic and replacing a custom spy with a direct mock for `post` calls in tests.

### Refactoring of `getLabwhereLocations`:

* Simplified the return logic in `getLabwhereLocations` to directly return a transformed response object when the `post` call is successful, reducing conditional complexity. (`src/services/labwhere/client.js`, [src/services/labwhere/client.jsL40-R42](diffhunk://#diff-9d4707ebf977e5b0fc1dd11997f99c13ec6d6edb610e7a5ec7b45e67e8de8871L40-R42))

### Updates to Unit Tests:

* Replaced the custom spy (`spyPost`) with a direct mock (`mockFetchWrapper.post`) for `post` calls, streamlining test setup and improving readability. (`tests/unit/services/labwhere/client.spec.js`, [[1]](diffhunk://#diff-cb57b7a95c9b63484f58cab4345ed689e1f88bd0d82c7a72d44731bb83fc9abaL8-L24) [[2]](diffhunk://#diff-cb57b7a95c9b63484f58cab4345ed689e1f88bd0d82c7a72d44731bb83fc9abaL36-L43) [[3]](diffhunk://#diff-cb57b7a95c9b63484f58cab4345ed689e1f88bd0d82c7a72d44731bb83fc9abaL70-R65) [[4]](diffhunk://#diff-cb57b7a95c9b63484f58cab4345ed689e1f88bd0d82c7a72d44731bb83fc9abaL82-R82) [[5]](diffhunk://#diff-cb57b7a95c9b63484f58cab4345ed689e1f88bd0d82c7a72d44731bb83fc9abaL101-R104)
* Updated test cases for `getLabwhereLocations` to align with the refactored function, ensuring accurate assertions for both success and error scenarios. (`tests/unit/services/labwhere/client.spec.js`, [[1]](diffhunk://#diff-cb57b7a95c9b63484f58cab4345ed689e1f88bd0d82c7a72d44731bb83fc9abaL36-L43) [[2]](diffhunk://#diff-cb57b7a95c9b63484f58cab4345ed689e1f88bd0d82c7a72d44731bb83fc9abaL54-R54)
* Added mock responses to replace redundant spies for `extractLocationsForLabwares`, reducing unnecessary dependencies in tests. (`tests/unit/services/labwhere/client.spec.js`, [tests/unit/services/labwhere/client.spec.jsL54-R54](diffhunk://#diff-cb57b7a95c9b63484f58cab4345ed689e1f88bd0d82c7a72d44731bb83fc9abaL54-R54))

These changes collectively enhance the maintainability and readability of both the implementation and its tests.

#### Changes proposed in this pull request

- 

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
