### PR TITLE
Y25-296 Import Kinnex samples

### DIFF
--- a/src/lib/receptions/MockReception.js
+++ b/src/lib/receptions/MockReception.js
@@ -45,10 +45,9 @@ const buildMockCompoundSampleAndRequest = (sample_names, requestOptions) => {
         ...requestOptions,
         external_study_id: crypto.randomUUID(),
       },
-    }))
+    })),
   }
 }
-
 
 /**
  * Generates a reception object containing mocked plates_attributes based on the provided barcodes.
@@ -146,7 +145,6 @@ const fetchCompoundSampleTubesFunction = async ({ requestOptions, barcodes }) =>
     foundBarcodes: new Set(barcodes),
   }
 }
-
 
 const MockReception = {
   fetchPlatesFunction,

--- a/src/lib/receptions/MockReception.js
+++ b/src/lib/receptions/MockReception.js
@@ -26,6 +26,31 @@ const buildMockSampleAndRequest = (sample_name, requestOptions) => {
 }
 
 /**
+ * A function to help encapsulate the logic of building a mock sample and request object.
+ *
+ * @param {string} sample_name - The name of the sample to be included in the mock data.
+ * @param {Object} requestOptions - An object containing request options to be included in each well's request.
+ * @returns {Object} A mock sample and request object.
+ */
+const buildMockCompoundSampleAndRequest = (sample_names, requestOptions) => {
+  return {
+    samples: sample_names.map((name) => ({
+      sample: {
+        name,
+        species: 'Human',
+        retention_instruction: 'long_term_storage',
+        external_id: crypto.randomUUID(),
+      },
+      request: {
+        ...requestOptions,
+        external_study_id: crypto.randomUUID(),
+      },
+    }))
+  }
+}
+
+
+/**
  * Generates a reception object containing mocked plates_attributes based on the provided barcodes.
  * Each plate contains a barcode and an array of well attributes. Each well
  * attribute includes a position, sample details, and request details.
@@ -93,11 +118,42 @@ const fetchTubesFunction = async ({ requestOptions, barcodes }) => {
   }
 }
 
+/**
+ * Generates a reception object containing mocked tubes_attributes for compound sample tubes based on the provided barcodes.
+ * Each tube contains a barcode and an array of samples, each with its own sample details and request details.
+ * The number of samples per tube is currently set to 3, and each sample name is generated using the barcode and index.
+ *
+ * @param {string[]} barcodes - An array of barcodes to use for the tubes.
+ * @param {Object} requestOptions - An object containing request options to be included in each sample's request.
+ * @returns {Object} A formatted reception object containing the following structure:
+ *   - `attributes` {Object}: The attributes of the reception, including:
+ *      - `source` {string}: The source of the reception, always "traction-ui.mock-reception".
+ *      - `tubes_attributes` {Object[]}: An array of tube attributes, each with a barcode and an array of samples.
+ *   - `foundBarcodes` {Set}: A set of found barcodes.
+ */
+const fetchCompoundSampleTubesFunction = async ({ requestOptions, barcodes }) => {
+  const compound_sample_tubes_attributes = barcodes.map((barcode, index) => {
+    const sample_names = Array.from({ length: 3 }, (_, i) => `${barcode}-sample-${i + 1}-${index}`)
+    return {
+      type: 'tubes',
+      barcode,
+      ...buildMockCompoundSampleAndRequest(sample_names, requestOptions),
+    }
+  })
+
+  return {
+    attributes: { source: 'traction-ui.mock-reception', compound_sample_tubes_attributes },
+    foundBarcodes: new Set(barcodes),
+  }
+}
+
+
 const MockReception = {
   fetchPlatesFunction,
   fetchTubesFunction,
+  fetchCompoundSampleTubesFunction,
 }
 
-export { fetchPlatesFunction, fetchTubesFunction }
+export { fetchPlatesFunction, fetchTubesFunction, fetchCompoundSampleTubesFunction }
 
 export default MockReception

--- a/src/lib/receptions/MockReception.js
+++ b/src/lib/receptions/MockReception.js
@@ -26,26 +26,16 @@ const buildMockSampleAndRequest = (sample_name, requestOptions) => {
 }
 
 /**
- * A function to help encapsulate the logic of building a mock sample and request object.
+ * A function to help encapsulate the logic of building a mock compound sample and request object.
+ * Uses buildMockSampleAndRequest for each sample name.
  *
- * @param {string} sample_name - The name of the sample to be included in the mock data.
- * @param {Object} requestOptions - An object containing request options to be included in each well's request.
- * @returns {Object} A mock sample and request object.
+ * @param {string[]} sample_names - The names of the samples to be included in the mock data.
+ * @param {Object} requestOptions - An object containing request options to be included in each sample's request.
+ * @returns {Object} A mock compound sample and request object.
  */
 const buildMockCompoundSampleAndRequest = (sample_names, requestOptions) => {
   return {
-    samples: sample_names.map((name) => ({
-      sample: {
-        name,
-        species: 'Human',
-        retention_instruction: 'long_term_storage',
-        external_id: crypto.randomUUID(),
-      },
-      request: {
-        ...requestOptions,
-        external_study_id: crypto.randomUUID(),
-      },
-    })),
+    samples: sample_names.map((name) => buildMockSampleAndRequest(name, requestOptions)),
   }
 }
 

--- a/src/lib/receptions/Sequencescape.js
+++ b/src/lib/receptions/Sequencescape.js
@@ -40,18 +40,10 @@ const fetchLabwareForReception = async ({ requests, barcodes, requestOptions }) 
   })
 }
 
-/**
- *
- * @returns {Array} Array of attribute keys
- */
-const getAttributeKeys = () =>
-  Object.keys(labwareTypes).flatMap((type) => labwareTypes[type].attributes)
-
 const Sequencescape = {
   fetchLabwareForReception,
-  getAttributeKeys,
 }
 
-export { fetchLabwareForReception, getAttributeKeys }
+export { fetchLabwareForReception }
 
 export default Sequencescape

--- a/src/lib/receptions/SequencescapeKinnexTubes.js
+++ b/src/lib/receptions/SequencescapeKinnexTubes.js
@@ -13,7 +13,7 @@ const labwareRequestConfig = {
     tubes: 'labware_barcode,receptacles',
     receptacles: 'aliquots',
     samples: 'sample_metadata,name,uuid',
-    sample_metadata: 'sample_common_name',
+    sample_metadata: 'sample_common_name,supplier_name,date_of_sample_collection,donor_id',
     studies: 'uuid',
     aliquots: 'study,library_type,sample',
   },

--- a/src/lib/receptions/SequencescapeKinnexTubes.js
+++ b/src/lib/receptions/SequencescapeKinnexTubes.js
@@ -40,7 +40,7 @@ const fetchLabwareForReception = async ({ requests, barcodes, requestOptions }) 
  *
  * @returns {Array} Array of attribute keys
  */
-const getAttributeKeys = () => ['tubes_attributes']
+const getAttributeKeys = () => ['compound_sample_tubes_attributes']
 
 const SequencescapeKinnexTubes = {
   fetchLabwareForReception,

--- a/src/lib/receptions/SequencescapeKinnexTubes.js
+++ b/src/lib/receptions/SequencescapeKinnexTubes.js
@@ -36,17 +36,11 @@ const fetchLabwareForReception = async ({ requests, barcodes, requestOptions }) 
     labwareRequestConfig,
   })
 }
-/**
- *
- * @returns {Array} Array of attribute keys
- */
-const getAttributeKeys = () => ['compound_sample_tubes_attributes']
 
 const SequencescapeKinnexTubes = {
   fetchLabwareForReception,
-  getAttributeKeys,
 }
 
-export { fetchLabwareForReception, getAttributeKeys }
+export { fetchLabwareForReception }
 
 export default SequencescapeKinnexTubes

--- a/src/lib/receptions/SequencescapeKinnexTubes.js
+++ b/src/lib/receptions/SequencescapeKinnexTubes.js
@@ -1,8 +1,4 @@
 import { fetchLabwareFromSequencescape, labwareTypes } from './sequencescapeUtils.js'
-// This module replaces by services.Sequencescape which can be removed
-// when the pipeline-specific receptions are retired. While this change results
-// in temporary code duplication, it allows for complete decoupling of old and
-// new paths, greatly simplifying the removal.
 
 /**
  * Request parameters for retrieval of labware from Sequencescape v2 API

--- a/src/lib/receptions/SequencescapeKinnexTubes.js
+++ b/src/lib/receptions/SequencescapeKinnexTubes.js
@@ -1,0 +1,56 @@
+import { fetchLabwareFromSequencescape, labwareTypes } from './sequencescapeUtils.js'
+// This module replaces by services.Sequencescape which can be removed
+// when the pipeline-specific receptions are retired. While this change results
+// in temporary code duplication, it allows for complete decoupling of old and
+// new paths, greatly simplifying the removal.
+
+/**
+ * Request parameters for retrieval of labware from Sequencescape v2 API
+ */
+const labwareRequestConfig = {
+  include: 'receptacles.aliquots.sample.sample_metadata,receptacles.aliquots.study',
+  fields: {
+    tubes: 'labware_barcode,receptacles',
+    receptacles: 'aliquots',
+    samples: 'sample_metadata,name,uuid',
+    sample_metadata: 'sample_common_name',
+    studies: 'uuid',
+    aliquots: 'study,library_type,sample',
+  },
+}
+
+/**
+ * Makes a request to the Sequencescape v2 API to retrieve the labware
+ * associated with the provided barcodes. Uses the provided requestOptions to
+ * construct a reception object that can be posted to the traction receptions
+ * endpoint
+ * @param { Object } { sequencescape: { labware: { get: Function } } } requests The API requests store ($store.getters.api)
+ * @param { Array<String> } barcodes Array of barcodes to look up
+ * @param { Object } requestOptions Additional request parameters, will over-ride any
+ * imported from Sequencescape if present
+ * @returns { Object } Reception object ready for import into traction includes attributes and foundBarcodes
+ *
+ */
+const fetchLabwareForReception = async ({ requests, barcodes, requestOptions }) => {
+  return fetchLabwareFromSequencescape({
+    requests,
+    barcodes,
+    requestOptions,
+    labwareTypes: { tubes: { ...labwareTypes.kinnex_tubes, barcodeAttribute: 'human_barcode' } },
+    labwareRequestConfig,
+  })
+}
+/**
+ *
+ * @returns {Array} Array of attribute keys
+ */
+const getAttributeKeys = () => ['tubes_attributes']
+
+const SequencescapeKinnexTubes = {
+  fetchLabwareForReception,
+  getAttributeKeys,
+}
+
+export { fetchLabwareForReception, getAttributeKeys }
+
+export default SequencescapeKinnexTubes

--- a/src/lib/receptions/SequencescapeMultiplexedLibraries.js
+++ b/src/lib/receptions/SequencescapeMultiplexedLibraries.js
@@ -41,17 +41,10 @@ const fetchLabwareForReception = async ({ requests, barcodes, requestOptions, li
   })
 }
 
-/**
- *
- * @returns {Array} Array of attribute keys
- */
-const getAttributeKeys = () => ['tubes_attributes', 'pool_attributes']
-
 const SequencescapeMultiplexedLibraries = {
   fetchLabwareForReception,
-  getAttributeKeys,
 }
 
-export { fetchLabwareForReception, getAttributeKeys }
+export { fetchLabwareForReception }
 
 export default SequencescapeMultiplexedLibraries

--- a/src/lib/receptions/SequencescapeTubes.js
+++ b/src/lib/receptions/SequencescapeTubes.js
@@ -40,17 +40,11 @@ const fetchLabwareForReception = async ({ requests, barcodes, requestOptions }) 
     labwareRequestConfig,
   })
 }
-/**
- *
- * @returns {Array} Array of attribute keys
- */
-const getAttributeKeys = () => ['tubes_attributes']
 
 const SequencescapeTubes = {
   fetchLabwareForReception,
-  getAttributeKeys,
 }
 
-export { fetchLabwareForReception, getAttributeKeys }
+export { fetchLabwareForReception }
 
 export default SequencescapeTubes

--- a/src/lib/receptions/index.js
+++ b/src/lib/receptions/index.js
@@ -102,25 +102,21 @@ const Receptions = {
     ...ReceptionTypes.Sequencescape,
     fetchFunction: Sequencescape.fetchLabwareForReception,
     barcodeComponent: MultiBarcode,
-    getAttributeKeysFunction: Sequencescape.getAttributeKeys,
   },
   SequencescapeTubes: {
     ...ReceptionTypes.SequencescapeTubes,
     fetchFunction: SequencescapeTubes.fetchLabwareForReception,
     barcodeComponent: MultiBarcode,
-    getAttributeKeysFunction: SequencescapeTubes.getAttributeKeys,
   },
   SequencescapeMultiplexedLibraries: {
     ...ReceptionTypes.SequencescapeMultiplexedLibraries,
     fetchFunction: SequencescapeMultiplexedLibraries.fetchLabwareForReception,
     barcodeComponent: MultiplexedLibraryBarcode,
-    getAttributeKeysFunction: SequencescapeMultiplexedLibraries.getAttributeKeys,
   },
   SequencescapeKinnexTubes: {
     ...ReceptionTypes.SequencescapeKinnexTubes,
     fetchFunction: SequencescapeKinnexTubes.fetchLabwareForReception,
     barcodeComponent: MultiBarcode,
-    getAttributeKeysFunction: SequencescapeTubes.getAttributeKeys,
   },
   MockedPlates: {
     ...MockReceptionTypes.MockedPlates,

--- a/src/lib/receptions/index.js
+++ b/src/lib/receptions/index.js
@@ -89,6 +89,12 @@ const MockReceptionTypes = {
     value: 'MockedTubes',
     pipelines: ['PacBio', 'ONT'],
   },
+  MockedKinnexTubes: {
+    name: 'mocked-kinnex-tubes',
+    text: 'Mocked Kinnex tubes',
+    value: 'MockedKinnexTubes',
+    pipelines: ['PacBio'],
+  },
 }
 
 const Receptions = {
@@ -124,6 +130,11 @@ const Receptions = {
   MockedTubes: {
     ...MockReceptionTypes.MockedTubes,
     fetchFunction: MockReception.fetchTubesFunction,
+    barcodeComponent: MultiBarcode,
+  },
+  MockedKinnexTubes: {
+    ...MockReceptionTypes.MockedKinnexTubes,
+    fetchFunction: MockReception.fetchCompoundSampleTubesFunction,
     barcodeComponent: MultiBarcode,
   },
 }

--- a/src/lib/receptions/index.js
+++ b/src/lib/receptions/index.js
@@ -1,5 +1,6 @@
 import * as Sequencescape from './Sequencescape.js'
 import * as SequencescapeTubes from './SequencescapeTubes.js'
+import * as SequencescapeKinnexTubes from './SequencescapeKinnexTubes.js'
 import * as SequencescapeMultiplexedLibraries from './SequencescapeMultiplexedLibraries.js'
 import * as MockReception from './MockReception.js'
 
@@ -67,6 +68,12 @@ const ReceptionTypes = {
     value: 'SequencescapeMultiplexedLibraries',
     pipelines: ['ONT'],
   },
+  SequencescapeKinnexTubes: {
+    name: 'sequencescape-kinnex-tubes',
+    text: 'Sequencescape Kinnex Tubes',
+    value: 'SequencescapeKinnexTubes',
+    pipelines: ['PacBio'],
+  },
 }
 
 const MockReceptionTypes = {
@@ -102,6 +109,12 @@ const Receptions = {
     fetchFunction: SequencescapeMultiplexedLibraries.fetchLabwareForReception,
     barcodeComponent: MultiplexedLibraryBarcode,
     getAttributeKeysFunction: SequencescapeMultiplexedLibraries.getAttributeKeys,
+  },
+  SequencescapeKinnexTubes: {
+    ...ReceptionTypes.SequencescapeKinnexTubes,
+    fetchFunction: SequencescapeKinnexTubes.fetchLabwareForReception,
+    barcodeComponent: MultiBarcode,
+    getAttributeKeysFunction: SequencescapeTubes.getAttributeKeys,
   },
   MockedPlates: {
     ...MockReceptionTypes.MockedPlates,

--- a/src/lib/receptions/sequencescapeUtils.js
+++ b/src/lib/receptions/sequencescapeUtils.js
@@ -230,8 +230,13 @@ const buildKinnexRequestAndSample = ({
     },
     sample: {
       external_id: sample.attributes.uuid,
-      name: sample.attributes.name,
+      // For Kinnex tubes, use supplier_name as the sample name.
+      // All samples in a Kinnex tube share the same supplier_name, which serves as a unique identifier
+      // for the compound sample created in Traction to represent all samples in the tube.
+      name: sample_metadata.attributes.supplier_name,
       species: sample_metadata.attributes.sample_common_name,
+      donor_id: sample_metadata.attributes.donor_id,
+      date_of_sample_collection: sample_metadata.attributes.date_of_sample_collection,
       retention_instruction,
     },
   }

--- a/src/lib/receptions/sequencescapeUtils.js
+++ b/src/lib/receptions/sequencescapeUtils.js
@@ -257,7 +257,7 @@ const buildKinnexRequestAndSample = ({
       const { sample, sample_metadata } = sample_data
       return {
         external_id: sample.attributes.uuid,
-        name:  sample.attributes.name,
+        name: sample.attributes.name,
         supplier_name: sample_metadata.attributes.supplier_name,
         species: sample_metadata.attributes.sample_common_name,
         donor_id: sample_metadata.attributes.donor_id,

--- a/src/views/GeneralReception.vue
+++ b/src/views/GeneralReception.vue
@@ -228,10 +228,9 @@ const workflowOptions = computed(() => [
 
 const environment = ref(import.meta.env['VITE_ENVIRONMENT'])
 
-
 const receptionOptions = async () => {
   let receptionTypes = Object.values(ReceptionTypes)
-   const isKinnexEnabled = await checkFeatureFlag('kinnex_sample_reception')
+  const isKinnexEnabled = await checkFeatureFlag('kinnex_sample_reception')
   // Filter out SequencescapeKinnexTubes if the feature flag is not enabled
   if (!isKinnexEnabled) {
     receptionTypes = receptionTypes.filter((type) => type.value !== 'SequencescapeKinnexTubes')
@@ -245,7 +244,7 @@ const receptionOptions = async () => {
 
   return [...receptionTypes]
 }
-onMounted( async () => {
+onMounted(async () => {
   receptionOptionsList.value = await receptionOptions()
 })
 

--- a/src/views/GeneralReception.vue
+++ b/src/views/GeneralReception.vue
@@ -15,7 +15,7 @@
             id="sourceSelect"
             v-model="source"
             class="inline-block w-full"
-            :options="receptionOptions()"
+            :options="receptionOptionsList"
             data-type="source-list"
             @update:model-value="updatePipeline()"
           />
@@ -185,12 +185,13 @@
 </template>
 
 <script setup>
-import { ref, computed } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import Receptions, { WorkflowsLocations } from '@/lib/receptions'
 import TractionHeading from '../components/TractionHeading.vue'
 import LibraryTypeSelect from '@/components/shared/LibraryTypeSelect.vue'
 import DataTypeSelect from '@/components/shared/DataTypeSelect.vue'
 import { defaultRequestOptions, ReceptionTypes, MockReceptionTypes } from '@/lib/receptions'
+import { checkFeatureFlag } from '@/api/FeatureFlag.js'
 
 // We don't expect the modal to display without a message. If we end up in this
 // state then something has gone horribly wrong.
@@ -213,6 +214,8 @@ const user_code = ref('')
 
 const workflow = ref('')
 
+const receptionOptionsList = ref([])
+
 const workflowOptions = computed(() => [
   { value: '', text: '' }, // Empty option
   ...Object.values(WorkflowsLocations)
@@ -224,16 +227,27 @@ const workflowOptions = computed(() => [
 ])
 
 const environment = ref(import.meta.env['VITE_ENVIRONMENT'])
-const receptionOptions = () => {
+
+
+const receptionOptions = async () => {
+  let receptionTypes = Object.values(ReceptionTypes)
+   const isKinnexEnabled = await checkFeatureFlag('kinnex_sample_reception')
+  // Filter out SequencescapeKinnexTubes if the feature flag is not enabled
+  if (!isKinnexEnabled) {
+    receptionTypes = receptionTypes.filter((type) => type.value !== 'SequencescapeKinnexTubes')
+  }
   if (environment.value == 'uat' || environment.value == 'development') {
     return [
-      ...Object.values(ReceptionTypes),
+      ...receptionTypes,
       { label: 'Mock receptions (UAT only)', options: [...Object.values(MockReceptionTypes)] },
     ]
   }
 
-  return [...Object.values(ReceptionTypes)]
+  return [...receptionTypes]
 }
+onMounted( async () => {
+  receptionOptionsList.value = await receptionOptions()
+})
 
 const workflowLocation = computed(() => {
   const workflowsMap = new Map(

--- a/tests/e2e/fixtures/tractionLibraryTypes.json
+++ b/tests/e2e/fixtures/tractionLibraryTypes.json
@@ -153,6 +153,17 @@
         "name": "ONT_Ultralong",
         "pipeline": "ont"
       }
+    },
+    {
+      "id": "15",
+      "type": "library_types",
+      "links": {
+        "self": "http://127.0.0.1:3100/v1/library_types/15"
+      },
+      "attributes": {
+        "name": "Kinnex_Single_Cell_5",
+        "pipeline": "pacbio"
+      }
     }
   ]
 }

--- a/tests/e2e/specs/reception/import_samples_from_sequencescape.cy.js
+++ b/tests/e2e/specs/reception/import_samples_from_sequencescape.cy.js
@@ -21,6 +21,12 @@ describe('Import samples from Sequencescape', () => {
     cy.intercept('v1/library_types?fields[library_types]=name,pipeline', {
       fixture: 'tractionLibraryTypes.json',
     })
+    cy.intercept('flipper/api/actors/User', {
+      flipper_id: 'User',
+      features: {
+        kinnex_sample_reception: { enabled: true },
+      },
+    })
   })
   describe('Successfully - V2', () => {
     beforeEach(() => {

--- a/tests/e2e/specs/reception/import_samples_from_sequencescapeKinnexTubes.cy.js
+++ b/tests/e2e/specs/reception/import_samples_from_sequencescapeKinnexTubes.cy.js
@@ -14,6 +14,14 @@ describe('Import samples from Sequencescape Kinnex Tubes', () => {
         body: printerFactory.content,
       })
     })
+
+
+    cy.intercept('flipper/api/actors/User', {
+      flipper_id: 'User',
+      features: {
+        kinnex_sample_reception: { enabled: true }
+      },
+    })
   })
   describe('Importing samples from Sequencescape Kinnex Tubes - Success', () => {
     beforeEach(() => {

--- a/tests/e2e/specs/reception/import_samples_from_sequencescapeKinnexTubes.cy.js
+++ b/tests/e2e/specs/reception/import_samples_from_sequencescapeKinnexTubes.cy.js
@@ -62,7 +62,7 @@ describe('Import samples from Sequencescape Kinnex Tubes', () => {
       cy.intercept('POST', '/api/scans', {
         statusCode: 201,
         body: {
-          message: 'SE108532I successfully stored in LRT006 Draw 1',
+          message: 'NT1O successfully stored in LRT006 Draw 1',
         },
       })
       cy.get('#barcodes').type('3980000067791\n')
@@ -71,7 +71,7 @@ describe('Import samples from Sequencescape Kinnex Tubes', () => {
       cy.get('[data-action="import-labware"]').click()
       cy.contains('DN9000002A imported from Sequencescape Kinnex Tubes')
       cy.contains('NT1O imported from Sequencescape Kinnex Tubes')
-      cy.contains('SE108532I successfully stored in LRT006 Draw 1')
+      cy.contains('NT1O successfully stored in LRT006 Draw 1')
     })
 
     it('successfully import to traction but fails to scan in to labWhere', () => {

--- a/tests/e2e/specs/reception/import_samples_from_sequencescapeKinnexTubes.cy.js
+++ b/tests/e2e/specs/reception/import_samples_from_sequencescapeKinnexTubes.cy.js
@@ -1,0 +1,152 @@
+import SequencescapeKinnexTubeFactory from '../../../factories/SequencescapeKinnexTubeFactory.js'
+import PrinterFactory from '../../../factories/PrinterFactory.js'
+
+describe('Import samples from Sequencescape Kinnex Tubes', () => {
+  beforeEach(() => {
+    cy.intercept('v1/library_types?fields[library_types]=name,pipeline', {
+      fixture: 'tractionLibraryTypes.json',
+    })
+
+    cy.wrap(PrinterFactory()).as('printerFactory')
+    cy.get('@printerFactory').then((printerFactory) => {
+      cy.intercept('GET', '/v1/printers', {
+        statusCode: 200,
+        body: printerFactory.content,
+      })
+    })
+  })
+  describe('Successfully - V2', () => {
+    beforeEach(() => {
+      cy.visit('#/reception')
+      cy.get('#workflowSelect').select('Pacbio -20 samples')
+      cy.get('#userCode').type('usercodeX')
+      cy.get('[data-type="source-list"]').select('Sequencescape Kinnex Tubes')
+      cy.contains('Scan barcodes')
+      cy.get('#cost_code').type('aCostCodeExample')
+
+      cy.get('[data-attribute=estimate_of_gb_required]').type('3')
+      cy.intercept(
+        {
+          url: '/api/v2/labware*',
+          query: {
+            'filter[barcode]': '3980000067791',
+            include: 'receptacles.aliquots.sample.sample_metadata,receptacles.aliquots.study',
+            'fields[tubes]': 'labware_barcode,receptacles',
+            'fields[aliquots]': 'study,library_type,sample',
+            'fields[receptacles]': 'aliquots',
+            'fields[sample_metadata]': 'sample_common_name',
+            'fields[samples]': 'sample_metadata,name,uuid',
+            'fields[studies]': 'uuid',
+          },
+        },
+        {
+          statusCode: 200,
+          body: SequencescapeKinnexTubeFactory().content,
+        },
+      )
+      cy.intercept('POST', '/v1/receptions', {
+        body: {
+          data: {
+            attributes: {
+              labware: {
+                DN9000002A: { imported: 'success' },
+                NT1O: { imported: 'success' },
+              },
+            },
+          },
+        },
+      })
+    })
+    it('successfully import to traction and scanning in to labWhere', () => {
+      cy.intercept('POST', '/api/scans', {
+        statusCode: 201,
+        body: {
+          message: 'SE108532I successfully stored in LRT006 Draw 1',
+        },
+      })
+      cy.get('#barcodes').type('3980000067791\n')
+      cy.contains('Import 1 labware into PacBio from Sequencescape Kinnex Tubes')
+      cy.contains('The imported labware will be scanned into LRT006 Draw 1')
+      cy.get('[data-action="import-labware"]').click()
+      cy.contains('DN9000002A imported from Sequencescape Kinnex Tubes')
+      cy.contains('NT1O imported from Sequencescape Kinnex Tubes')
+      cy.contains('SE108532I successfully stored in LRT006 Draw 1')
+    })
+
+    it('successfully import to traction but fails to scan in to labWhere', () => {
+      cy.intercept('POST', '/api/scans', {
+        statusCode: 422,
+        errors: ['Failed to access LabWhere'],
+      })
+      cy.get('#barcodes').type('3980000067791\n')
+      cy.contains('Import 1 labware into PacBio from Sequencescape Kinnex Tubes')
+      cy.contains('The imported labware will be scanned into LRT006 Draw 1')
+      cy.get('[data-action="import-labware"]').click()
+      cy.contains('DN9000002A imported from Sequencescape Kinnex Tubes')
+      cy.contains('NT1O imported from Sequencescape Kinnex Tubes')
+      cy.contains('Failed to access LabWhere')
+    })
+  })
+
+  it('Unsuccessfully - when the tubes do not exist', () => {
+    cy.visit('#/reception')
+    cy.contains('Scan barcodes')
+    cy.get('[data-type="source-list"]').select('Sequencescape Kinnex Tubes')
+    cy.intercept(
+      {
+        url: '/api/v2/labware*',
+        query: {
+          'filter[barcode]': 'NT10',
+          include: 'receptacles.aliquots.sample.sample_metadata,receptacles.aliquots.study',
+          'fields[tubes]': 'labware_barcode,receptacles',
+          'fields[aliquots]': 'study,library_type,sample',
+          'fields[receptacles]': 'aliquots',
+          'fields[sample_metadata]': 'sample_common_name',
+          'fields[samples]': 'sample_metadata,name,uuid',
+          'fields[studies]': 'uuid',
+        },
+      },
+      {
+        statusCode: 200,
+        body: { data: [] },
+      },
+    )
+    cy.get('#barcodes').type('NT10\n')
+    cy.contains('Import 0 labware into PacBio from Sequencescape Kinnex Tubes')
+    cy.get('[data-action="import-labware"]').click()
+    cy.contains('No labware to import')
+  })
+
+  it('Unsuccessfully - when there is an error from traction', () => {
+    cy.visit('#/reception')
+    cy.get('[data-type="source-list"]').select('Sequencescape Kinnex Tubes')
+    cy.contains('Scan barcodes')
+    cy.intercept(
+      {
+        url: '/api/v2/labware*',
+        query: {
+          'filter[barcode]': '3980000001795',
+          include: 'receptacles.aliquots.sample.sample_metadata,receptacles.aliquots.study',
+          'fields[tubes]': 'labware_barcode,receptacles',
+          'fields[aliquots]': 'study,library_type,sample',
+          'fields[receptacles]': 'aliquots',
+          'fields[sample_metadata]': 'sample_common_name',
+          'fields[samples]': 'sample_metadata,name,uuid',
+          'fields[studies]': 'uuid',
+        },
+      },
+      {
+        statusCode: 200,
+        body: SequencescapeKinnexTubeFactory().content,
+      },
+    )
+    cy.intercept('/v1/receptions', {
+      statusCode: 422,
+      body: { errors: [{ title: 'receptions', detail: 'There was an error.' }] },
+    })
+    cy.get('#barcodes').type('3980000001795\n')
+    cy.contains('Import 1 labware into PacBio from Sequencescape Kinnex Tubes')
+    cy.get('[data-action="import-labware"]').click()
+    cy.contains('There was an error.')
+  })
+})

--- a/tests/e2e/specs/reception/import_samples_from_sequencescapeKinnexTubes.cy.js
+++ b/tests/e2e/specs/reception/import_samples_from_sequencescapeKinnexTubes.cy.js
@@ -15,11 +15,10 @@ describe('Import samples from Sequencescape Kinnex Tubes', () => {
       })
     })
 
-
     cy.intercept('flipper/api/actors/User', {
       flipper_id: 'User',
       features: {
-        kinnex_sample_reception: { enabled: true }
+        kinnex_sample_reception: { enabled: true },
       },
     })
   })

--- a/tests/e2e/specs/reception/import_samples_from_sequencescapeKinnexTubes.cy.js
+++ b/tests/e2e/specs/reception/import_samples_from_sequencescapeKinnexTubes.cy.js
@@ -34,7 +34,7 @@ describe('Import samples from Sequencescape Kinnex Tubes', () => {
             'fields[tubes]': 'labware_barcode,receptacles',
             'fields[aliquots]': 'study,library_type,sample',
             'fields[receptacles]': 'aliquots',
-            'fields[sample_metadata]': 'sample_common_name',
+            'fields[sample_metadata]': 'sample_common_name,donor_id,date_of_sample_collection',
             'fields[samples]': 'sample_metadata,name,uuid',
             'fields[studies]': 'uuid',
           },
@@ -57,7 +57,7 @@ describe('Import samples from Sequencescape Kinnex Tubes', () => {
         },
       })
     })
-    it('successfully import to traction and scanning in to labWhere', () => {
+    it.only('successfully import to traction and scanning in to labWhere', () => {
       cy.intercept('POST', '/api/scans', {
         statusCode: 201,
         body: {

--- a/tests/e2e/specs/reception/import_samples_from_sequencescapeKinnexTubes.cy.js
+++ b/tests/e2e/specs/reception/import_samples_from_sequencescapeKinnexTubes.cy.js
@@ -15,7 +15,7 @@ describe('Import samples from Sequencescape Kinnex Tubes', () => {
       })
     })
   })
-  describe('Successfully - V2', () => {
+  describe('Importing samples from Sequencescape Kinnex Tubes - Success', () => {
     beforeEach(() => {
       cy.visit('#/reception')
       cy.get('#workflowSelect').select('Pacbio -20 samples')
@@ -34,7 +34,8 @@ describe('Import samples from Sequencescape Kinnex Tubes', () => {
             'fields[tubes]': 'labware_barcode,receptacles',
             'fields[aliquots]': 'study,library_type,sample',
             'fields[receptacles]': 'aliquots',
-            'fields[sample_metadata]': 'sample_common_name,donor_id,date_of_sample_collection',
+            'fields[sample_metadata]':
+              'sample_common_name,supplier_name,donor_id,date_of_sample_collection',
             'fields[samples]': 'sample_metadata,name,uuid',
             'fields[studies]': 'uuid',
           },
@@ -57,7 +58,7 @@ describe('Import samples from Sequencescape Kinnex Tubes', () => {
         },
       })
     })
-    it.only('successfully import to traction and scanning in to labWhere', () => {
+    it('successfully import to traction and scanning in to labWhere', () => {
       cy.intercept('POST', '/api/scans', {
         statusCode: 201,
         body: {
@@ -101,7 +102,8 @@ describe('Import samples from Sequencescape Kinnex Tubes', () => {
           'fields[tubes]': 'labware_barcode,receptacles',
           'fields[aliquots]': 'study,library_type,sample',
           'fields[receptacles]': 'aliquots',
-          'fields[sample_metadata]': 'sample_common_name',
+          'fields[sample_metadata]':
+            'sample_common_name,supplier_name,donor_id,date_of_sample_collection',
           'fields[samples]': 'sample_metadata,name,uuid',
           'fields[studies]': 'uuid',
         },
@@ -130,7 +132,8 @@ describe('Import samples from Sequencescape Kinnex Tubes', () => {
           'fields[tubes]': 'labware_barcode,receptacles',
           'fields[aliquots]': 'study,library_type,sample',
           'fields[receptacles]': 'aliquots',
-          'fields[sample_metadata]': 'sample_common_name',
+          'fields[sample_metadata]':
+            'sample_common_name,supplier_name,donor_id,date_of_sample_collection',
           'fields[samples]': 'sample_metadata,name,uuid',
           'fields[studies]': 'uuid',
         },

--- a/tests/e2e/specs/reception/import_samples_from_sequencescapeMultiplexedLibraries.cy.js
+++ b/tests/e2e/specs/reception/import_samples_from_sequencescapeMultiplexedLibraries.cy.js
@@ -27,6 +27,13 @@ describe('Import samples from Sequencescape Multiplexed Libraries', () => {
     cy.intercept('v1/data_types?fields[data_types]=name,pipeline', {
       fixture: 'tractionDataTypes.json',
     })
+
+    cy.intercept('flipper/api/actors/User', {
+      flipper_id: 'User',
+      features: {
+        kinnex_sample_reception: { enabled: true },
+      },
+    })
   })
   describe('Successfully - V2', () => {
     beforeEach(() => {

--- a/tests/e2e/specs/reception/import_samples_from_sequencescapeTubes.cy.js
+++ b/tests/e2e/specs/reception/import_samples_from_sequencescapeTubes.cy.js
@@ -14,6 +14,12 @@ describe('Import samples from Sequencescape Tubes', () => {
         body: printerFactory.content,
       })
     })
+    cy.intercept('flipper/api/actors/User', {
+      flipper_id: 'User',
+      features: {
+        kinnex_sample_reception: { enabled: true },
+      },
+    })
   })
   describe('Successfully - V2', () => {
     beforeEach(() => {

--- a/tests/e2e/specs/reception/print_samples_from_sequencescapeTube.cy.js
+++ b/tests/e2e/specs/reception/print_samples_from_sequencescapeTube.cy.js
@@ -7,6 +7,13 @@ describe('Print samples from Sequencescape Tubes', () => {
       fixture: 'tractionLibraryTypes.json',
     })
 
+    cy.intercept('flipper/api/actors/User', {
+      flipper_id: 'User',
+      features: {
+        kinnex_sample_reception: { enabled: true },
+      },
+    })
+
     cy.wrap(PrinterFactory()).as('printerFactory')
     cy.get('@printerFactory').then((printerFactory) => {
       cy.intercept('GET', '/v1/printers', {
@@ -39,12 +46,6 @@ describe('Print samples from Sequencescape Tubes', () => {
         body: SequencescapeLabwareFactory().content,
       },
     )
-    cy.intercept('flipper/api/actors/User', {
-      flipper_id: 'User',
-      features: {
-        kinnex_sample_reception: { enabled: true },
-      },
-    })
 
     cy.get('#barcodes').type('3980000001795\n')
     cy.get('#print-barcodes').should('have.value', 'NT1O')

--- a/tests/e2e/specs/reception/print_samples_from_sequencescapeTube.cy.js
+++ b/tests/e2e/specs/reception/print_samples_from_sequencescapeTube.cy.js
@@ -39,6 +39,12 @@ describe('Print samples from Sequencescape Tubes', () => {
         body: SequencescapeLabwareFactory().content,
       },
     )
+    cy.intercept('flipper/api/actors/User', {
+      flipper_id: 'User',
+      features: {
+        kinnex_sample_reception: { enabled: true },
+      },
+    })
 
     cy.get('#barcodes').type('3980000001795\n')
     cy.get('#print-barcodes').should('have.value', 'NT1O')

--- a/tests/factories/SequencescapeKinnexTubeFactory.js
+++ b/tests/factories/SequencescapeKinnexTubeFactory.js
@@ -1,0 +1,210 @@
+import BaseFactory from './BaseFactory.js'
+
+/*
+ * Factory for creating a list of sequencescape labware
+ * @returns a base factory object with the labware data
+ */
+const SequencescapeKinnexTubeFactory = () => {
+  const data = {
+    data: [
+      {
+        id: '82',
+        type: 'tubes',
+        links: {
+          self: 'http://localhost:3000/api/v2/tubes/82',
+        },
+        attributes: {
+          labware_barcode: {
+            ean13_barcode: '3980000067791',
+            machine_barcode: '3980000067791',
+            human_barcode: 'NT67O',
+          },
+        },
+        relationships: {
+          receptacles: {
+            links: {
+              self: 'http://localhost:3000/api/v2/tubes/82/relationships/receptacles',
+              related: 'http://localhost:3000/api/v2/tubes/82/receptacles',
+            },
+            data: [
+              {
+                type: 'receptacles',
+                id: '1507',
+              },
+            ],
+          },
+        },
+      },
+    ],
+    included: [
+      {
+        id: '1507',
+        type: 'receptacles',
+        links: {
+          self: 'http://localhost:3000/api/v2/receptacles/1507',
+        },
+        relationships: {
+          aliquots: {
+            links: {
+              self: 'http://localhost:3000/api/v2/receptacles/1507/relationships/aliquots',
+              related: 'http://localhost:3000/api/v2/receptacles/1507/aliquots',
+            },
+            data: [
+              { type: 'aliquots', id: '315' },
+              { type: 'aliquots', id: '316' },
+              { type: 'aliquots', id: '317' },
+            ],
+          },
+        },
+      },
+      // Aliquots for 1507
+      {
+        id: '315',
+        type: 'aliquots',
+        links: { self: 'http://localhost:3000/api/v2/aliquots/315' },
+        attributes: { library_type: null },
+        relationships: {
+          study: {
+            links: {
+              self: 'http://localhost:3000/api/v2/aliquots/315/relationships/study',
+              related: 'http://localhost:3000/api/v2/aliquots/315/study',
+            },
+            data: { type: 'studies', id: '1' },
+          },
+          sample: {
+            links: {
+              self: 'http://localhost:3000/api/v2/aliquots/315/relationships/sample',
+              related: 'http://localhost:3000/api/v2/aliquots/315/sample',
+            },
+            data: { type: 'samples', id: '212' },
+          },
+        },
+      },
+      {
+        id: '316',
+        type: 'aliquots',
+        links: { self: 'http://localhost:3000/api/v2/aliquots/316' },
+        attributes: { library_type: null },
+        relationships: {
+          study: {
+            links: {
+              self: 'http://localhost:3000/api/v2/aliquots/316/relationships/study',
+              related: 'http://localhost:3000/api/v2/aliquots/316/study',
+            },
+            data: { type: 'studies', id: '1' },
+          },
+          sample: {
+            links: {
+              self: 'http://localhost:3000/api/v2/aliquots/316/relationships/sample',
+              related: 'http://localhost:3000/api/v2/aliquots/316/sample',
+            },
+            data: { type: 'samples', id: '213' },
+          },
+        },
+      },
+      {
+        id: '317',
+        type: 'aliquots',
+        links: { self: 'http://localhost:3000/api/v2/aliquots/317' },
+        attributes: { library_type: null },
+        relationships: {
+          study: {
+            links: {
+              self: 'http://localhost:3000/api/v2/aliquots/317/relationships/study',
+              related: 'http://localhost:3000/api/v2/aliquots/317/study',
+            },
+            data: { type: 'studies', id: '1' },
+          },
+          sample: {
+            links: {
+              self: 'http://localhost:3000/api/v2/aliquots/317/relationships/sample',
+              related: 'http://localhost:3000/api/v2/aliquots/317/sample',
+            },
+            data: { type: 'samples', id: '214' },
+          },
+        },
+      },
+      // Study
+      {
+        id: '1',
+        type: 'studies',
+        links: { self: 'http://localhost:3000/api/v2/studies/1' },
+        attributes: { uuid: '3b1cf0ac-4079-11f0-805f-e2df7c04b5f2' },
+      },
+      // Samples
+      {
+        id: '212',
+        type: 'samples',
+        links: { self: 'http://localhost:3000/api/v2/samples/212' },
+        attributes: { name: 'sample_1_SQPD-9015_A4', uuid: 'f3e18688-4142-11f0-ac8e-e2df7c04b5f2' },
+        relationships: {
+          sample_metadata: {
+            links: {
+              self: 'http://localhost:3000/api/v2/samples/212/relationships/sample_metadata',
+              related: 'http://localhost:3000/api/v2/samples/212/sample_metadata',
+            },
+            data: { type: 'sample_metadata', id: '212' },
+          },
+        },
+      },
+      {
+        id: '213',
+        type: 'samples',
+        links: { self: 'http://localhost:3000/api/v2/samples/213' },
+        attributes: { name: 'sample_2_SQPD-9015_A4', uuid: 'f3e372c2-4142-11f0-ac8e-e2df7c04b5f2' },
+        relationships: {
+          sample_metadata: {
+            links: {
+              self: 'http://localhost:3000/api/v2/samples/213/relationships/sample_metadata',
+              related: 'http://localhost:3000/api/v2/samples/213/sample_metadata',
+            },
+            data: { type: 'sample_metadata', id: '213' },
+          },
+        },
+      },
+      {
+        id: '214',
+        type: 'samples',
+        links: { self: 'http://localhost:3000/api/v2/samples/214' },
+        attributes: { name: 'sample_3_SQPD-9015_A4', uuid: 'f3e4f250-4142-11f0-ac8e-e2df7c04b5f2' },
+        relationships: {
+          sample_metadata: {
+            links: {
+              self: 'http://localhost:3000/api/v2/samples/214/relationships/sample_metadata',
+              related: 'http://localhost:3000/api/v2/samples/214/sample_metadata',
+            },
+            data: { type: 'sample_metadata', id: '214' },
+          },
+        },
+      },
+      // Sample metadata
+      {
+        id: '212',
+        type: 'sample_metadata',
+        links: { self: 'http://localhost:3000/api/v2/sample_metadata/212' },
+        attributes: { sample_common_name: 'human' },
+      },
+      {
+        id: '213',
+        type: 'sample_metadata',
+        links: { self: 'http://localhost:3000/api/v2/sample_metadata/213' },
+        attributes: { sample_common_name: 'human' },
+      },
+      {
+        id: '214',
+        type: 'sample_metadata',
+        links: { self: 'http://localhost:3000/api/v2/sample_metadata/214' },
+        attributes: { sample_common_name: 'human' },
+      },
+    ],
+    links: {
+      first:
+        'http://localhost:3000/api/v2/labware?fields%5Baliquots%5D=study%2Clibrary_type%2Csample&fields%5Breceptacles%5D=aliquots&fields%5Bsample_metadata%5D=sample_common_name&fields%5Bsamples%5D=sample_metadata%2Cname%2Cuuid&fields%5Bstudies%5D=uuid&fields%5Btubes%5D=labware_barcode%2Creceptacles&filter%5Bbarcode%5D=NT67O%2CNT68P&include=receptacles.aliquots.sample.sample_metadata%2Creceptacles.aliquots.study&page%5Bnumber%5D=1&page%5Bsize%5D=100',
+      last: 'http://localhost:3000/api/v2/labware?fields%5Baliquots%5D=study%2Clibrary_type%2Csample&fields%5Breceptacles%5D=aliquots&fields%5Bsample_metadata%5D=sample_common_name&fields%5Bsamples%5D=sample_metadata%2Cname%2Cuuid&fields%5Bstudies%5D=uuid&fields%5Btubes%5D=labware_barcode%2Creceptacles&filter%5Bbarcode%5D=NT67O%2CNT68P&include=receptacles.aliquots.sample.sample_metadata%2Creceptacles.aliquots.study&page%5Bnumber%5D=1&page%5Bsize%5D=100',
+    },
+  }
+
+  return BaseFactory(data)
+}
+
+export default SequencescapeKinnexTubeFactory

--- a/tests/factories/SequencescapeKinnexTubeFactory.js
+++ b/tests/factories/SequencescapeKinnexTubeFactory.js
@@ -182,19 +182,34 @@ const SequencescapeKinnexTubeFactory = () => {
         id: '212',
         type: 'sample_metadata',
         links: { self: 'http://localhost:3000/api/v2/sample_metadata/212' },
-        attributes: { sample_common_name: 'human' },
+        attributes: {
+          sample_common_name: 'human',
+          supplier_name: 'Supplier A',
+          date_of_sample_collection: '2023-01-01',
+          donor_id: 'Donor 1',
+        },
       },
       {
         id: '213',
         type: 'sample_metadata',
         links: { self: 'http://localhost:3000/api/v2/sample_metadata/213' },
-        attributes: { sample_common_name: 'human' },
+        attributes: {
+          sample_common_name: 'human',
+          supplier_name: 'Supplier A',
+          date_of_sample_collection: '2023-01-02',
+          donor_id: 'Donor 1',
+        },
       },
       {
         id: '214',
         type: 'sample_metadata',
         links: { self: 'http://localhost:3000/api/v2/sample_metadata/214' },
-        attributes: { sample_common_name: 'human' },
+        attributes: {
+          sample_common_name: 'human',
+          supplier_name: 'Supplier A',
+          date_of_sample_collection: '2023-01-03',
+          donor_id: 'Donor 1',
+        },
       },
     ],
     links: {

--- a/tests/support/testHelper.js
+++ b/tests/support/testHelper.js
@@ -130,6 +130,22 @@ function mountWithStore(component, options = {}) {
   return { wrapper, store }
 }
 
+/**
+ * Helper to select an option by its visible text.
+ * @param {Wrapper} selectWrapper - The wrapper for the <select> element.
+ * @param {string} text - The visible text of the option to select.
+ */
+async function selectOptionByText(selectWrapper, text) {
+  const option = selectWrapper.findAll('option').find((opt) => opt.text() === text)
+  if (option) {
+    await selectWrapper.setValue(option.element.value)
+  } else {
+    throw new Error(`Option with text "${text}" not found`)
+  }
+}
+
+// ...existing code...
+
 export {
   mount,
   store,
@@ -140,6 +156,7 @@ export {
   setActivePinia,
   createPinia,
   createTestingPinia,
+  selectOptionByText,
   findAllByText,
   findByText,
   successfulResponse,

--- a/tests/unit/lib/receptions/MockReception.spec.js
+++ b/tests/unit/lib/receptions/MockReception.spec.js
@@ -1,4 +1,8 @@
-import { fetchPlatesFunction, fetchTubesFunction, fetchCompoundSampleTubesFunction } from '@/lib/receptions/MockReception'
+import {
+  fetchPlatesFunction,
+  fetchTubesFunction,
+  fetchCompoundSampleTubesFunction,
+} from '@/lib/receptions/MockReception'
 
 describe('MockReception', () => {
   describe('#fetchPlatesFunction', () => {
@@ -81,7 +85,9 @@ describe('MockReception', () => {
         expect(tube.barcode).toBe(barcodes[tubeIndex])
         expect(tube.samples).toHaveLength(3)
         tube.samples.forEach((sampleObj, sampleIndex) => {
-          expect(sampleObj.sample.name).toBe(`${tube.barcode}-sample-${sampleIndex + 1}-${tubeIndex}`)
+          expect(sampleObj.sample.name).toBe(
+            `${tube.barcode}-sample-${sampleIndex + 1}-${tubeIndex}`,
+          )
           expect(sampleObj.sample.species).toBe('Human')
           expect(sampleObj.sample.retention_instruction).toBe('long_term_storage')
           expect(sampleObj.sample.external_id).toBeDefined()

--- a/tests/unit/lib/receptions/MockReception.spec.js
+++ b/tests/unit/lib/receptions/MockReception.spec.js
@@ -1,4 +1,4 @@
-import { fetchPlatesFunction, fetchTubesFunction } from '@/lib/receptions/MockReception'
+import { fetchPlatesFunction, fetchTubesFunction, fetchCompoundSampleTubesFunction } from '@/lib/receptions/MockReception'
 
 describe('MockReception', () => {
   describe('#fetchPlatesFunction', () => {
@@ -58,6 +58,37 @@ describe('MockReception', () => {
         expect(tube.request.external_study_id).toBeDefined()
         expect(tube.request.library_type).toBe('Example')
         expect(tube.request.cost_code).toBe('aCostCodeExample')
+      })
+    })
+  })
+
+  describe('#fetchCompoundSampleTubesFunction', () => {
+    it('returns a reception object with mocked compound sample tubes data', async () => {
+      const barcodes = ['test-compound-tube1', 'test-compound-tube2']
+      const { attributes, foundBarcodes } = await fetchCompoundSampleTubesFunction({
+        barcodes,
+        requestOptions: {
+          library_type: 'Example',
+          cost_code: 'aCostCodeExample',
+        },
+      })
+
+      expect(foundBarcodes).toEqual(new Set(barcodes))
+      expect(attributes.source).toBe('traction-ui.mock-reception')
+      expect(attributes.compound_sample_tubes_attributes).toHaveLength(2)
+      attributes.compound_sample_tubes_attributes.forEach((tube, tubeIndex) => {
+        expect(tube.type).toBe('tubes')
+        expect(tube.barcode).toBe(barcodes[tubeIndex])
+        expect(tube.samples).toHaveLength(3)
+        tube.samples.forEach((sampleObj, sampleIndex) => {
+          expect(sampleObj.sample.name).toBe(`${tube.barcode}-sample-${sampleIndex + 1}-${tubeIndex}`)
+          expect(sampleObj.sample.species).toBe('Human')
+          expect(sampleObj.sample.retention_instruction).toBe('long_term_storage')
+          expect(sampleObj.sample.external_id).toBeDefined()
+          expect(sampleObj.request.external_study_id).toBeDefined()
+          expect(sampleObj.request.library_type).toBe('Example')
+          expect(sampleObj.request.cost_code).toBe('aCostCodeExample')
+        })
       })
     })
   })

--- a/tests/unit/lib/receptions/SequencescapeKinnexTubes.spec.js
+++ b/tests/unit/lib/receptions/SequencescapeKinnexTubes.spec.js
@@ -1,6 +1,6 @@
 import { fetchLabwareForReception } from '@/lib/receptions/SequencescapeKinnexTubes.js'
 import { store } from '@support/testHelper.js'
-import SequencescapeLabwareFactory from '@tests/factories/SequencescapeLabwareFactory.js'
+import SequencescapeKinnexTubeFactory from '@tests/factories/SequencescapeKinnexTubeFactory.js'
 
 describe('SequencescapeKinnexTubes', () => {
   describe('#fetchLabwareForReception', () => {
@@ -13,7 +13,7 @@ describe('SequencescapeKinnexTubes', () => {
     })
 
     it('successfully', async () => {
-      request.mockResolvedValue(SequencescapeLabwareFactory().responses.fetch)
+      request.mockResolvedValue(SequencescapeKinnexTubeFactory().responses.fetch)
 
       const { attributes, foundBarcodes } = await fetchLabwareForReception({
         requests,
@@ -30,29 +30,31 @@ describe('SequencescapeKinnexTubes', () => {
         fields: {
           aliquots: 'study,library_type,sample',
           receptacles: 'aliquots',
-          sample_metadata: 'sample_common_name',
+          sample_metadata: 'sample_common_name,supplier_name,date_of_sample_collection,donor_id',
           samples: 'sample_metadata,name,uuid',
           studies: 'uuid',
           tubes: 'labware_barcode,receptacles',
         },
       })
 
-      expect(foundBarcodes).toEqual(new Set(['NT1O']))
+      expect(foundBarcodes).toEqual(new Set(['NT67O']))
       expect(attributes).toEqual({
         source: 'traction-ui.sequencescape',
         tubes_attributes: [
           {
-            barcode: 'NT1O',
+            barcode: 'NT67O',
             request: {
-              external_study_id: '5b173660-94c9-11ec-8c89-acde48001122',
+              external_study_id: '3b1cf0ac-4079-11f0-805f-e2df7c04b5f2',
               library_type: 'Example',
               cost_code: 'aCostCodeExample',
             },
             sample: {
-              name: '2STDY97',
-              external_id: '0db37dd8-94ca-11ec-a9e3-acde48001122',
-              species: 'Gryphon',
-              retention_instruction: 'return_to_customer_after_2_years',
+              name: 'Supplier A',
+              external_id: 'f3e18688-4142-11f0-ac8e-e2df7c04b5f2',
+              species: 'human',
+              retention_instruction: null,
+              date_of_sample_collection: '2023-01-01',
+              donor_id: 'Donor 1',
             },
           },
         ],

--- a/tests/unit/lib/receptions/SequencescapeKinnexTubes.spec.js
+++ b/tests/unit/lib/receptions/SequencescapeKinnexTubes.spec.js
@@ -40,7 +40,7 @@ describe('SequencescapeKinnexTubes', () => {
       expect(foundBarcodes).toEqual(new Set(['NT67O']))
       expect(attributes).toEqual({
         source: 'traction-ui.sequencescape',
-        tubes_attributes: [
+        compound_sample_tubes_attributes: [
           {
             barcode: 'NT67O',
             request: {
@@ -48,14 +48,35 @@ describe('SequencescapeKinnexTubes', () => {
               library_type: 'Example',
               cost_code: 'aCostCodeExample',
             },
-            sample: {
-              name: 'Supplier A',
-              external_id: 'f3e18688-4142-11f0-ac8e-e2df7c04b5f2',
-              species: 'human',
-              retention_instruction: null,
-              date_of_sample_collection: '2023-01-01',
-              donor_id: 'Donor 1',
-            },
+            samples: [
+              {
+                date_of_sample_collection: '2023-01-01',
+                donor_id: 'Donor 1',
+                external_id: 'f3e18688-4142-11f0-ac8e-e2df7c04b5f2',
+                name: 'sample_1_SQPD-9015_A4',
+                retention_instruction: null,
+                species: 'human',
+                supplier_name: 'Supplier A',
+              },
+              {
+                date_of_sample_collection: '2023-01-02',
+                donor_id: 'Donor 1',
+                external_id: 'f3e372c2-4142-11f0-ac8e-e2df7c04b5f2',
+                name: 'sample_2_SQPD-9015_A4',
+                retention_instruction: null,
+                species: 'human',
+                supplier_name: 'Supplier A',
+              },
+              {
+                date_of_sample_collection: '2023-01-03',
+                donor_id: 'Donor 1',
+                external_id: 'f3e4f250-4142-11f0-ac8e-e2df7c04b5f2',
+                name: 'sample_3_SQPD-9015_A4',
+                retention_instruction: null,
+                species: 'human',
+                supplier_name: 'Supplier A',
+              },
+            ],
           },
         ],
       })

--- a/tests/unit/lib/receptions/SequencescapeKinnexTubes.spec.js
+++ b/tests/unit/lib/receptions/SequencescapeKinnexTubes.spec.js
@@ -1,0 +1,80 @@
+import { fetchLabwareForReception } from '@/lib/receptions/SequencescapeKinnexTubes.js'
+import { store } from '@support/testHelper.js'
+import SequencescapeLabwareFactory from '@tests/factories/SequencescapeLabwareFactory.js'
+
+describe('SequencescapeKinnexTubes', () => {
+  describe('#fetchLabwareForReception', () => {
+    const barcodes = ['3980000001795']
+    const requests = store.getters.api
+    let request
+
+    beforeEach(() => {
+      request = vi.spyOn(requests.sequencescape.labware, 'get')
+    })
+
+    it('successfully', async () => {
+      request.mockResolvedValue(SequencescapeLabwareFactory().responses.fetch)
+
+      const { attributes, foundBarcodes } = await fetchLabwareForReception({
+        requests,
+        barcodes,
+        requestOptions: {
+          library_type: 'Example',
+          cost_code: 'aCostCodeExample',
+        },
+      })
+
+      expect(request).toHaveBeenCalledWith({
+        filter: { barcode: barcodes.join(',') },
+        include: 'receptacles.aliquots.sample.sample_metadata,receptacles.aliquots.study',
+        fields: {
+          aliquots: 'study,library_type,sample',
+          receptacles: 'aliquots',
+          sample_metadata: 'sample_common_name',
+          samples: 'sample_metadata,name,uuid',
+          studies: 'uuid',
+          tubes: 'labware_barcode,receptacles',
+        },
+      })
+
+      expect(foundBarcodes).toEqual(new Set(['NT1O']))
+      expect(attributes).toEqual({
+        source: 'traction-ui.sequencescape',
+        tubes_attributes: [
+          {
+            barcode: 'NT1O',
+            request: {
+              external_study_id: '5b173660-94c9-11ec-8c89-acde48001122',
+              library_type: 'Example',
+              cost_code: 'aCostCodeExample',
+            },
+            sample: {
+              name: '2STDY97',
+              external_id: '0db37dd8-94ca-11ec-a9e3-acde48001122',
+              species: 'Gryphon',
+              retention_instruction: 'return_to_customer_after_2_years',
+            },
+          },
+        ],
+      })
+    })
+
+    it('unsuccessfully', async () => {
+      const failedResponse = {
+        data: {},
+        status: 500,
+        json: () =>
+          Promise.resolve({
+            errors: [{ title: 'error1', detail: 'There was an error.', status: '500' }],
+          }),
+        ok: false,
+        statusText: 'Internal Server Error',
+      }
+      request.mockResolvedValue(failedResponse)
+
+      await expect(() => fetchLabwareForReception({ requests, barcodes })).rejects.toThrow(
+        'There was an error',
+      )
+    })
+  })
+})

--- a/tests/unit/views/GeneralReception.spec.js
+++ b/tests/unit/views/GeneralReception.spec.js
@@ -11,6 +11,10 @@ vi.mock('@/composables/useAlert', () => ({
   }),
 }))
 
+vi.mock('@/api/FeatureFlag', () => ({
+  checkFeatureFlag: vi.fn().mockReturnValue(true),
+}))
+
 const printerFactory = PrinterFactory()
 
 describe('GeneralReception', () => {

--- a/tests/unit/views/GeneralReception.spec.js
+++ b/tests/unit/views/GeneralReception.spec.js
@@ -80,6 +80,7 @@ describe('GeneralReception', () => {
       'Sequencescape',
       'Sequencescape Tubes',
       'Sequencescape Multiplexed Libraries',
+      'Sequencescape Kinnex Tubes',
       'Mocked plates',
       'Mocked tubes',
     ])
@@ -99,6 +100,11 @@ describe('GeneralReception', () => {
       await wrapper.find('[data-type=source-list]').findAll('option')[2].setSelected()
       expect(wrapper.find('[data-type=pipeline-list]').findAll('option').length).toBe(1)
       expect(wrapper.find('[data-type=pipeline-list]').findAll('option')[0].text()).toBe('ONT')
+    })
+    it('only shows Pacbio for Sequencescape Kinnex Tubes', async () => {
+      await wrapper.find('[data-type=source-list]').findAll('option')[3].setSelected()
+      expect(wrapper.find('[data-type=pipeline-list]').findAll('option').length).toBe(1)
+      expect(wrapper.find('[data-type=pipeline-list]').findAll('option')[0].text()).toBe('PacBio')
     })
 
     it('sets pipeline to the first available pipeline if the source changes and the pipeline is no longer valid', async () => {

--- a/tests/unit/views/GeneralReception.spec.js
+++ b/tests/unit/views/GeneralReception.spec.js
@@ -87,6 +87,7 @@ describe('GeneralReception', () => {
       'Sequencescape Kinnex Tubes',
       'Mocked plates',
       'Mocked tubes',
+      'Mocked Kinnex tubes',
     ])
     // It defaults to Sequencescape
     expect(wrapper.find('[data-type=source-list]').element.value).toEqual('Sequencescape')

--- a/tests/unit/views/GeneralReception.spec.js
+++ b/tests/unit/views/GeneralReception.spec.js
@@ -1,4 +1,4 @@
-import { mountWithStore } from '@support/testHelper.js'
+import { mountWithStore, selectOptionByText } from '@support/testHelper.js'
 import GeneralReception from '@/views/GeneralReception.vue'
 import Receptions from '@/lib/receptions'
 import { expect, it } from 'vitest'
@@ -97,12 +97,19 @@ describe('GeneralReception', () => {
     })
 
     it('only shows ONT for SequencescapeMultiplexedLibraries', async () => {
-      await wrapper.find('[data-type=source-list]').findAll('option')[2].setSelected()
+      // Find the option with the desired text and get its value
+      await selectOptionByText(
+        wrapper.find('[data-type=source-list]'),
+        'Sequencescape Multiplexed Libraries',
+      )
       expect(wrapper.find('[data-type=pipeline-list]').findAll('option').length).toBe(1)
       expect(wrapper.find('[data-type=pipeline-list]').findAll('option')[0].text()).toBe('ONT')
     })
     it('only shows Pacbio for Sequencescape Kinnex Tubes', async () => {
-      await wrapper.find('[data-type=source-list]').findAll('option')[3].setSelected()
+      await selectOptionByText(
+        wrapper.find('[data-type=source-list]'),
+        'Sequencescape Kinnex Tubes',
+      )
       expect(wrapper.find('[data-type=pipeline-list]').findAll('option').length).toBe(1)
       expect(wrapper.find('[data-type=pipeline-list]').findAll('option')[0].text()).toBe('PacBio')
     })
@@ -110,7 +117,10 @@ describe('GeneralReception', () => {
     it('sets pipeline to the first available pipeline if the source changes and the pipeline is no longer valid', async () => {
       // This example sets source to SequencescapeMultiplexedLibraries which only has ONT as a pipeline
       expect(wrapper.vm.pipeline).toEqual('PacBio')
-      await wrapper.find('[data-type=source-list]').findAll('option')[2].setSelected()
+      await selectOptionByText(
+        wrapper.find('[data-type=source-list]'),
+        'Sequencescape Multiplexed Libraries',
+      )
       expect(wrapper.vm.pipeline).toEqual('ONT')
     })
   })
@@ -122,8 +132,7 @@ describe('GeneralReception', () => {
 
     it('shows ONT options when ONT is selected', async () => {
       // Select ONT pipeline
-      await wrapper.find('[data-type=pipeline-list]').findAll('option')[1].setSelected()
-
+      await selectOptionByText(wrapper.find('[data-type=pipeline-list]'), 'ONT')
       // Library type
       const libraryType = wrapper.find('[data-attribute=library-type-list]')
       expect(libraryType.find('option[value="ONT_GridIon"]').exists()).toBe(true)
@@ -140,7 +149,7 @@ describe('GeneralReception', () => {
 
     it('shows PacBio options when PacBio is selected', async () => {
       // Select PacBio pipeline
-      await wrapper.find('[data-type=pipeline-list]').findAll('option')[0].setSelected()
+      await selectOptionByText(wrapper.find('[data-type=pipeline-list]'), 'PacBio')
 
       // Library type
       const libraryType = wrapper.find('[data-attribute=library-type-list]')


### PR DESCRIPTION
Closes https://github.com/sanger/traction-ui/issues/2316

#### Changes proposed in this pull request

This pull request introduces support for handling "Sequencescape Kinnex Tubes" in the reception pipeline.

Kinnex tubes contain multiple samples that share the same supplier_name. A compound sample is created using this supplier_name, which is stored as the sample_name and used as the key.

Key changes include adding a new module for processing Kinnex Tubes, updating configurations to integrate this new type into the system, and implementing corresponding tests to ensure functionality.

### New Feature: Support for Sequencescape Kinnex Tubes
* Added `src/lib/receptions/SequencescapeKinnexTubes.js` to handle fetching and transforming labware data for Kinnex Tubes, including `fetchLabwareForReception` and `getAttributeKeys` methods. 
* Updated `src/lib/receptions/index.js` to include Sequencescape Kinnex Tubes in `ReceptionTypes` and `Receptions`. 
* Added `buildKinnexRequestAndSample` and `transformKinnexTube` functions to `src/lib/receptions/sequencescapeUtils.js` for request and sample object creation and data transformation. 
* Introduced a new `kinnex_tubes` type in `labwareTypes` in `src/lib/receptions/sequencescapeUtils.js`

Below is a UI screenshot demonstrating the newly added Kinnex Tubes import feature in the Reception page.

![Screenshot 2025-06-05 at 13 57 09](https://github.com/user-attachments/assets/e555e1dd-7ebe-4901-85db-d9ce53f2f993)

#### Instructions for Reviewers
1. Kinnex Methods
It was agreed during the discussion that it’s beneficial to keep the logic for fetching and transforming labware data for Kinnex Tubes as separate methods and utility functions.
Though this introduces some code repetition, the added clarity and modularity are considered worthwhile trade-offs.

2. Attributes 
   - Attribute Mapping : The following attributes are assumed to be equivalent:
      a. Sample name → supplier_sample_name (All samples in a Kinnex tube share the same supplier_name, which serves    as a unique identifier for the compound sample created in Traction to represent all samples in the tube.)
      b. Sample type → donor_id (represents donor information per sample)
      c. Study number / Study name → study_id
      d. Date submitted → sample_collection_date
  
   - Attributes Requiring Further Clarification: The following attributes still need input or confirmation from stakeholders:
      
      Sample ID
      Cohort
      Cell type and Number of requested cells

3. Sequencescape PR
     A SS [PR](https://github.com/sanger/sequencescape/pull/4985) is created which introduces a new attribute, date_of_sample_collection, to the SampleMetadataResource class 
          

