### PR TITLE
Y25-300 - Print sample ids on tube lids

### DIFF
--- a/src/lib/LabelPrintingHelpers.js
+++ b/src/lib/LabelPrintingHelpers.js
@@ -157,18 +157,38 @@ const WorkflowListType = (attributes = {}) => {
 }
 
 /**
+ *
+ * @param {*} barcode - a barcode string
+ * @returns {Object} - { prefix, id } where prefix is the start of a barcode, otherwise an empty string, and id is the rest of the barcode
+ * This takes a barcode and splits it if it contains a certain prefix (NT) otherwise returns the barcode as the id
+ */
+const splitBarcodeByPrefix = (barcode) => {
+  if (barcode.startsWith('NT')) {
+    const prefix = 'NT'
+    const id = barcode.slice(2)
+    return { prefix, id }
+  }
+  return { prefix: '', id: barcode }
+}
+
+/**
  * @param {Object} barcodeItem - an object which contains the barcode and other information
  * @returns {Object} - { barcode, first_line, second_line, label_name } label suitable for printing to a tube printer
  * This is a basic label with just the barcode and date
  */
 const createBasicTubeBarcodeLabel = (barcodeItem) => {
-  const {
+  const { prefix: round_label_lower_line, id: round_label_bottom_line } = splitBarcodeByPrefix(
+    barcodeItem.barcode,
+  )
+  const { barcode, date: first_line, barcode: second_line } = barcodeItem
+  return {
     barcode,
-    date: first_line,
-    barcode: second_line,
-    barcode: round_label_bottom_line,
-  } = barcodeItem
-  return { barcode, first_line, second_line, round_label_bottom_line, label_name: 'main_label' }
+    first_line,
+    second_line,
+    round_label_bottom_line,
+    round_label_lower_line,
+    label_name: 'main_label',
+  }
 }
 
 /**
@@ -176,6 +196,9 @@ const createBasicTubeBarcodeLabel = (barcodeItem) => {
  * @returns {Object} - { barcode, first_line, second_line, third_line, fourth_line, round_label_top_line, label_name } label suitable for printing to a tube printer
  */
 const createWorkflowTubeBarcodeLabel = (barcodeItem) => {
+  const { prefix: round_label_lower_line, id: round_label_bottom_line } = splitBarcodeByPrefix(
+    barcodeItem.sourceBarcode,
+  )
   const {
     barcode,
     date: first_line,
@@ -183,7 +206,6 @@ const createWorkflowTubeBarcodeLabel = (barcodeItem) => {
     sourceBarcode: third_line,
     parsedSuffixes: fourth_line,
     number: round_label_top_line,
-    sourceBarcode: round_label_bottom_line,
   } = barcodeItem
   return {
     barcode,
@@ -193,6 +215,7 @@ const createWorkflowTubeBarcodeLabel = (barcodeItem) => {
     fourth_line,
     round_label_top_line,
     round_label_bottom_line,
+    round_label_lower_line,
     label_name: 'main_label',
   }
 }

--- a/tests/unit/lib/LabelPrintingHelpers.spec.js
+++ b/tests/unit/lib/LabelPrintingHelpers.spec.js
@@ -301,6 +301,7 @@ describe('LabelPrintingHelpers.js', () => {
         fourth_line,
         round_label_top_line,
         round_label_bottom_line,
+        round_label_lower_line,
         label_name,
       } = createWorkflowTubeBarcodeLabel(workflowItemType)
 
@@ -311,6 +312,38 @@ describe('LabelPrintingHelpers.js', () => {
       expect(fourth_line).toEqual(workflowItemType.parsedSuffixes)
       expect(round_label_top_line).toEqual(workflowItemType.number)
       expect(round_label_bottom_line).toEqual(workflowItemType.sourceBarcode)
+      expect(round_label_lower_line).toEqual('')
+      expect(label_name).toEqual('main_label')
+    })
+
+    it('#createWorkflowTubeBarcodeLabel (NT barcode)', () => {
+      const workflowItemType = {
+        sourceBarcode: 'NT1234',
+        date: getCurrentDate(),
+        stage: 'ST1 - Stage 1',
+        suffixes: ['ST1'],
+        number: 1,
+      }
+      const {
+        barcode,
+        first_line,
+        second_line,
+        third_line,
+        fourth_line,
+        round_label_top_line,
+        round_label_bottom_line,
+        round_label_lower_line,
+        label_name,
+      } = createWorkflowTubeBarcodeLabel(workflowItemType)
+
+      expect(barcode).toEqual(workflowItemType.barcode)
+      expect(first_line).toEqual(workflowItemType.date)
+      expect(second_line).toEqual(workflowItemType.stage)
+      expect(third_line).toEqual(workflowItemType.sourceBarcode)
+      expect(fourth_line).toEqual(workflowItemType.parsedSuffixes)
+      expect(round_label_top_line).toEqual(workflowItemType.number)
+      expect(round_label_bottom_line).toEqual('1234')
+      expect(round_label_lower_line).toEqual('NT')
       expect(label_name).toEqual('main_label')
     })
 
@@ -327,11 +360,33 @@ describe('LabelPrintingHelpers.js', () => {
     })
 
     it('#createBasicTubeBarcodeLabel', () => {
+      console.log(workflowItemType)
       const barcodeItem = { barcode: workflowItemType.sourceBarcode, date: workflowItemType.date }
-      const { barcode, first_line, second_line } = createBasicTubeBarcodeLabel(barcodeItem)
+      const { barcode, first_line, second_line, round_label_bottom_line, round_label_lower_line } =
+        createBasicTubeBarcodeLabel(barcodeItem)
       expect(barcode).toEqual(workflowItemType.sourceBarcode)
       expect(first_line).toEqual(workflowItemType.date)
       expect(second_line).toEqual(workflowItemType.sourceBarcode)
+      expect(round_label_bottom_line).toEqual(workflowItemType.sourceBarcode)
+      expect(round_label_lower_line).toEqual('')
+    })
+
+    it('#createBasicTubeBarcodeLabel (NT barcode)', () => {
+      const workflowItemType = {
+        sourceBarcode: 'NT1234',
+        date: getCurrentDate(),
+        stage: 'ST1 - Stage 1',
+        suffixes: ['ST1'],
+        number: 1,
+      }
+      const barcodeItem = { barcode: workflowItemType.sourceBarcode, date: workflowItemType.date }
+      const { barcode, first_line, second_line, round_label_bottom_line, round_label_lower_line } =
+        createBasicTubeBarcodeLabel(barcodeItem)
+      expect(barcode).toEqual(workflowItemType.sourceBarcode)
+      expect(first_line).toEqual(workflowItemType.date)
+      expect(second_line).toEqual(workflowItemType.sourceBarcode)
+      expect(round_label_bottom_line).toEqual('1234')
+      expect(round_label_lower_line).toEqual('NT')
     })
 
     it('#createTubeBloodVacBarcodeLabel', () => {


### PR DESCRIPTION
Follow on from https://github.com/sanger/traction-ui/pull/2351

#### Changes proposed in this pull request

- Adds prefix splitter for NT barcodes to allow barcodes to fix on lid.


#### Additional notes
The prefix splitting is a bit crude but I don't want to create unpredictable behaviour for non NT barcodes. I think we can refine this if we add more prefixes when needed.

Added a new line round_label_lower_line in https://github.com/sanger/deployment/pull/679/files for the prefix. This should really be named as the 'bottom line' but since this template is also used in Sequencescape we would need to do renaming there too if we were to change the current line names.
