### PR TITLE
Fix mock Kinnex tubes option for receptions

### DIFF
--- a/src/lib/receptions/MockReception.js
+++ b/src/lib/receptions/MockReception.js
@@ -31,11 +31,20 @@ const buildMockSampleAndRequest = (sample_name, requestOptions) => {
  *
  * @param {string[]} sample_names - The names of the samples to be included in the mock data.
  * @param {Object} requestOptions - An object containing request options to be included in each sample's request.
- * @returns {Object} A mock compound sample and request object.
+ * @returns {Object} A mock compound request and multiple sample objects. NB the sample name is sent as the supplier sample name.
  */
 const buildMockCompoundSampleAndRequest = (sample_names, requestOptions) => {
   return {
-    samples: sample_names.map((name) => buildMockSampleAndRequest(name, requestOptions)),
+    request: {
+      ...requestOptions,
+      external_study_id: crypto.randomUUID(),
+    },
+    samples: sample_names.map((name) => ({
+      supplier_name: name,
+      species: 'Human',
+      retention_instruction: 'long_term_storage',
+      external_id: crypto.randomUUID(),
+    })),
   }
 }
 

--- a/tests/unit/lib/receptions/MockReception.spec.js
+++ b/tests/unit/lib/receptions/MockReception.spec.js
@@ -83,17 +83,16 @@ describe('MockReception', () => {
       attributes.compound_sample_tubes_attributes.forEach((tube, tubeIndex) => {
         expect(tube.type).toBe('tubes')
         expect(tube.barcode).toBe(barcodes[tubeIndex])
-        expect(tube.samples).toHaveLength(3)
+        expect(tube.request.external_study_id).toBeDefined()
+        expect(tube.request.library_type).toBe('Example')
+        expect(tube.request.cost_code).toBe('aCostCodeExample')
         tube.samples.forEach((sampleObj, sampleIndex) => {
-          expect(sampleObj.sample.name).toBe(
+          expect(sampleObj.supplier_name).toBe(
             `${tube.barcode}-sample-${sampleIndex + 1}-${tubeIndex}`,
           )
-          expect(sampleObj.sample.species).toBe('Human')
-          expect(sampleObj.sample.retention_instruction).toBe('long_term_storage')
-          expect(sampleObj.sample.external_id).toBeDefined()
-          expect(sampleObj.request.external_study_id).toBeDefined()
-          expect(sampleObj.request.library_type).toBe('Example')
-          expect(sampleObj.request.cost_code).toBe('aCostCodeExample')
+          expect(sampleObj.species).toBe('Human')
+          expect(sampleObj.retention_instruction).toBe('long_term_storage')
+          expect(sampleObj.external_id).toBeDefined()
         })
       })
     })


### PR DESCRIPTION

#### Changes proposed in this pull request
This pull request modifies the `MockReception` functionality to update the structure of mock compound samples and requests, ensuring better alignment with external systems. The most important changes include restructuring the data returned by `buildMockCompoundSampleAndRequest` and updating the corresponding unit tests to reflect the new structure.

### Updates to mock data structure:

* [`src/lib/receptions/MockReception.js`](diffhunk://#diff-bf7417645dae350ede08fb9de315d1d5e44df059516d46f122e3e2c0af44d630L34-R47): Refactored `buildMockCompoundSampleAndRequest` to separate the `request` object from the `samples` array, adding new properties like `external_study_id` to the request and `supplier_name` to each sample.

### Updates to unit tests:

* [`tests/unit/lib/receptions/MockReception.spec.js`](diffhunk://#diff-7313600b45b064d995a86d70a7d19f338ceb3efda30ebe7e3d0199492290ceedL86-R95): Updated tests to validate the new structure, including checks for `request.external_study_id`, `supplier_name`, and other sample properties. Removed redundant checks that were previously part of the sample object.

- 

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
