### PR TITLE
fix: added missing action to get the release version

### DIFF
--- a/.github/workflows/automated_release.yml
+++ b/.github/workflows/automated_release.yml
@@ -16,6 +16,10 @@ jobs:
       - name: Checkout Repository
         uses: sanger/.github/.github/actions/setup/checkout@master
 
+      - name: Get release version
+        id: get_version
+        run: echo "RELEASE_VERSION=$(cat .release-version)" >> "$GITHUB_ENV"
+
       - name: Set release tag
         id: set_tag
         uses: sanger/.github/.github/actions/release/set-release-tag@master


### PR DESCRIPTION
Closes N/A

#### Changes proposed in this pull request

- The action to grab the release version was missing which caused broken release names

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
