### PR TITLE
Index pages Labwhere location fetch refactor

### DIFF
--- a/src/views/ont/ONTPoolIndex.vue
+++ b/src/views/ont/ONTPoolIndex.vue
@@ -1,6 +1,6 @@
 <template>
-  <DataFetcher :fetcher="fetchPools">
-    <FilterCard :fetcher="fetchPools" :filter-options="filterOptions" />
+  <DataFetcher :fetcher="provider">
+    <FilterCard :fetcher="provider" :filter-options="filterOptions" />
     <div class="flex flex-col">
       <div class="clearfix">
         <traction-pagination class="float-right" aria-controls="pool-index"> </traction-pagination>
@@ -90,7 +90,7 @@
 import DataFetcher from '@/components/DataFetcher.vue'
 import FilterCard from '@/components/FilterCard.vue'
 import PrinterModal from '@/components/labelPrinting/PrinterModal.vue'
-import { ref, computed, watch } from 'vue'
+import { ref, computed } from 'vue'
 import { getCurrentDate } from '@/lib/DateHelpers.js'
 import useQueryParams from '@/composables/useQueryParams.js'
 import { usePrintingStore } from '@/stores/printing.js'
@@ -138,18 +138,7 @@ const { fetchLocations } = useLocationFetcher()
 const printingStore = usePrintingStore()
 
 // --- Getters ---
-const pools = computed(() => ontPoolCreateStore.pools)
-const barcodes = computed(() => pools.value.map((pool) => pool.barcode))
-const displayedPools = computed(() => locationBuilder(pools.value, labwareLocations.value))
-
-// --- Watchers ---
-watch(
-  barcodes,
-  async (newBarcodes) => {
-    labwareLocations.value = await fetchLocations(newBarcodes)
-  },
-  { immediate: true },
-)
+const displayedPools = computed(() => locationBuilder(ontPoolCreateStore.pools, labwareLocations.value))
 
 // --- Methods ---
 /**
@@ -188,16 +177,6 @@ async function printLabels(printerName) {
 }
 
 /**
- * Fetch pools with query params
- */
-async function fetchPools() {
-  return await fetchWithQueryParams(fetchOntPools, filterOptions)
-}
-
-// Pinia action
-const fetchOntPools = (...args) => ontPoolCreateStore.fetchOntPools(...args)
-
-/**
  * Format source identifier for display
  * @param {String} sourceIdentifier
  * @returns {String}
@@ -207,5 +186,20 @@ function formattedSourceIdentifier(sourceIdentifier) {
   const sources = sourceIdentifier.split(',')
   if (sources.length < 5) return sourceIdentifier
   return `${sources[0]}  ...   ${sources[sources.length - 1]}`
+}
+
+/*Fetches the pools from the api and adds location data
+  @returns {Object} { success: Boolean, errors: Array }*/
+const provider = async () => {
+  const { success, errors } =  await fetchWithQueryParams(ontPoolCreateStore.fetchOntPools, filterOptions)
+  // We only want to fetch labware locations if the requests were fetched successfully
+  if (success) {
+    // We don't need to fail if labware locations can't be fetched, so we don't return anything
+    const poolsArray = ontPoolCreateStore.pools
+    const barcodes = poolsArray.map(({ barcode }) => barcode)
+    labwareLocations.value = await fetchLocations(barcodes)
+  }
+  
+  return { success, errors }
 }
 </script>

--- a/src/views/ont/ONTSampleIndex.vue
+++ b/src/views/ont/ONTSampleIndex.vue
@@ -1,6 +1,6 @@
 <template>
-  <DataFetcher :fetcher="fetchRequests">
-    <FilterCard :fetcher="fetchRequests" :filter-options="filterOptions" />
+  <DataFetcher :fetcher="provider">
+    <FilterCard :fetcher="provider" :filter-options="filterOptions" />
     <div class="flex flex-col">
       <div class="clearfix">
         <traction-pagination
@@ -49,7 +49,7 @@
 </template>
 
 <script setup>
-import { ref, computed, watch } from 'vue'
+import { ref, computed } from 'vue'
 import DataFetcher from '@/components/DataFetcher.vue'
 import FilterCard from '@/components/FilterCard.vue'
 import useQueryParams from '@/composables/useQueryParams.js'
@@ -91,26 +91,20 @@ const { fetchWithQueryParams } = useQueryParams()
 const { fetchLocations } = useLocationFetcher()
 
 // --- Getters ---
-const requests = computed(() => ontRequestsStore.requests)
-const barcodes = computed(() => requests.value.map(({ source_identifier }) => source_identifier))
-const displayedRequests = computed(() => formatRequests(requests.value, labwareLocations.value))
+const displayedRequests = computed(() => formatRequests(ontRequestsStore.requests, labwareLocations.value))
 
-// --- Watchers ---
-watch(
-  barcodes,
-  async (newBarcodes) => {
-    labwareLocations.value = await fetchLocations(newBarcodes)
-  },
-  { immediate: true },
-)
-
-// --- Methods ---
-// this needs a bit of a think. We should not need to rewrite this method
-// there will be a JavaScript way of doing this e.g. using bind
-// probably using a higher-order function. Worth a tech debt story to dig into DataFetcher
-const fetchHandler = (...args) => ontRequestsStore.fetchRequests(...args)
-
-async function fetchRequests() {
-  return await fetchWithQueryParams(fetchHandler, filterOptions)
+/*Fetches the requests from the api and adds location data
+  @returns {Object} { success: Boolean, errors: Array }*/
+const provider = async () => {
+  const { success, errors } =  await fetchWithQueryParams(ontRequestsStore.fetchRequests, filterOptions)
+  // We only want to fetch labware locations if the requests were fetched successfully
+  if (success) {
+    // We don't need to fail if labware locations can't be fetched, so we don't return anything
+    const requestArray = ontRequestsStore.requests
+    const sources = requestArray.map(({ source_identifier }) => source_identifier)
+    labwareLocations.value = await fetchLocations(sources)
+  }
+  
+  return { success, errors }
 }
 </script>

--- a/src/views/pacbio/PacbioLibraryIndex.vue
+++ b/src/views/pacbio/PacbioLibraryIndex.vue
@@ -1,6 +1,6 @@
 <template>
-  <DataFetcher :fetcher="fetchLibraries">
-    <FilterCard :fetcher="fetchLibraries" :filter-options="state.filterOptions" />
+  <DataFetcher :fetcher="provider">
+    <FilterCard :fetcher="provider" :filter-options="state.filterOptions" />
     <div class="flex flex-col">
       <div class="clearfix">
         <printerModal
@@ -110,7 +110,7 @@ import DataFetcher from '@/components/DataFetcher.vue'
 import useLocationFetcher from '@/composables/useLocationFetcher.js'
 import useQueryParams from '@/composables/useQueryParams.js'
 import useAlert from '@/composables/useAlert.js'
-import { ref, reactive, computed, watchEffect } from 'vue'
+import { ref, reactive, computed } from 'vue'
 import { usePacbioLibrariesStore } from '@/stores/pacbioLibraries.js'
 import PacbioLibraryEdit from '@/components/pacbio/PacbioLibraryEdit.vue'
 import { locationBuilder } from '@/services/labwhere/helpers.js'
@@ -194,11 +194,15 @@ const state = reactive({
 //Define refs
 // Sort By id descending by default
 const sortBy = ref('id')
+const labwareLocations = ref([])
+const showConfirmationModal = ref(false)
+
 
 //Composables
 const { showAlert } = useAlert()
 const { fetchWithQueryParams } = useQueryParams()
 const { printLabels } = usePacbioLibraryPrint()
+const { fetchLocations } = useLocationFetcher()
 
 //Create Pinia store
 const librariesStore = usePacbioLibrariesStore()
@@ -206,26 +210,13 @@ const librariesStore = usePacbioLibrariesStore()
 //computed
 const libraries = computed(() => librariesStore.librariesArray)
 
-const showConfirmationModal = ref(false)
-
-const barcodes = computed(() => libraries.value.map(({ barcode }) => barcode))
-
-const { fetchLocations } = useLocationFetcher()
 
 // Computed property for displayed libraries with updated location information
 const displayedLibraries = computed(() => {
   return locationBuilder(libraries.value, labwareLocations.value)
 })
 
-const labwareLocations = ref([])
-
-watchEffect(async () => {
-  const barcodesValue = barcodes.value
-  labwareLocations.value = await fetchLocations(barcodesValue)
-})
-
 //methods
-
 const handleLibraryDelete = async () => {
   try {
     const selectedIds = state.selected.map((s) => s.id)
@@ -272,5 +263,20 @@ const getEditLibrary = (row) => {
 const exhausted = (row) => {
   const value = getEditLibrary(row)
   return isLibraryExhausted(value)
+}
+
+/*Fetches the libraries from the api and adds location data
+  @returns {Object} { success: Boolean, errors: Array }*/
+const provider = async () => {
+  const { success, errors } =  await fetchWithQueryParams(librariesStore.fetchLibraries, state.filterOptions)
+  // We only want to fetch labware locations if the libraries were fetched successfully
+  if (success) {
+    // We don't need to fail if labware locations can't be fetched, so we don't return anything
+    const librariesArray = librariesStore.librariesArray
+    const barcodes = librariesArray.map(({ barcode }) => barcode)
+    labwareLocations.value = await fetchLocations(barcodes)
+  }
+  
+  return { success, errors }
 }
 </script>

--- a/src/views/pacbio/PacbioPoolIndex.vue
+++ b/src/views/pacbio/PacbioPoolIndex.vue
@@ -1,6 +1,6 @@
 <template>
-  <DataFetcher :fetcher="fetchPools">
-    <FilterCard :fetcher="fetchPools" :filter-options="state.filterOptions" />
+  <DataFetcher :fetcher="provider">
+    <FilterCard :fetcher="provider" :filter-options="state.filterOptions" />
     <div class="flex flex-col">
       <div class="clearfix">
         <printerModal
@@ -87,7 +87,7 @@ import { usePacbioPoolsStore } from '@/stores/pacbioPools.js'
 import useQueryParams from '@/composables/useQueryParams.js'
 import useAlert from '@/composables/useAlert.js'
 import { getCurrentDate } from '@/lib/DateHelpers.js'
-import { ref, reactive, computed, watchEffect } from 'vue'
+import { ref, reactive, computed } from 'vue'
 import { usePrintingStore } from '@/stores/printing.js'
 import { locationBuilder } from '@/services/labwhere/helpers.js'
 /**
@@ -164,6 +164,7 @@ const state = reactive({
 })
 //Define refs
 const sortBy = ref('created_at')
+const labwareLocations = ref([])
 
 //Composables
 const { showAlert } = useAlert()
@@ -172,22 +173,12 @@ const { fetchLocations } = useLocationFetcher()
 
 //Create Pinia store
 const poolsStore = usePacbioPoolsStore()
-const pools = computed(() => poolsStore.poolsArray)
 
 //create printing store
 const printingStore = usePrintingStore()
 
 // Location fetching
-const displayedPools = computed(() => locationBuilder(pools.value, labwareLocations.value))
-
-const barcodes = computed(() => pools.value.map(({ barcode }) => barcode))
-
-const labwareLocations = ref([])
-
-watchEffect(async () => {
-  const barcodesValue = barcodes.value
-  labwareLocations.value = await fetchLocations(barcodesValue)
-})
+const displayedPools = computed(() => locationBuilder(poolsStore.poolsArray, labwareLocations.value))
 
 //methods
 const createLabels = () => {
@@ -224,14 +215,18 @@ const printLabels = async (printerName) => {
   showAlert(message, success ? 'success' : 'danger')
 }
 
-/**
- * This asynchronous function fetches pools using the `fetchPools` method from `poolsStore`.
- * It passes `state.filterOptions` as query parameters to the `fetchPools` method.
- *
- * @async
- * @returns {Promise<any>} A promise that resolves to the result of the `fetchPools` method.
- */
-const fetchPools = async () => {
-  return await fetchWithQueryParams(poolsStore.fetchPools, state.filterOptions)
+/*Fetches the pools from the api and adds location data
+  @returns {Object} { success: Boolean, errors: Array }*/
+const provider = async () => {
+  const { success, errors } =  await fetchWithQueryParams(poolsStore.fetchPools, state.filterOptions)
+  // We only want to fetch labware locations if the pools were fetched successfully
+  if (success) {
+    // We don't need to fail if labware locations can't be fetched, so we don't return anything
+    const poolsArray = poolsStore.poolsArray
+    const barcodes = poolsArray.map(({ barcode }) => barcode)
+    labwareLocations.value = await fetchLocations(barcodes)
+  }
+  
+  return { success, errors }
 }
 </script>


### PR DESCRIPTION
#### Changes proposed in this pull request

- Removes watch effect for fetching labware locations in favour of a single fetch on page load.

#### Additional context
Since labware locations cant change while the user is on the page it does't make sense to refetch them after the page loads. These changes prevent refetches, e.g. on edit.