### PR TITLE
Y25-579 - Library batch upload empty lines fix

### DIFF
--- a/src/lib/csv/pacbio.js
+++ b/src/lib/csv/pacbio.js
@@ -115,4 +115,24 @@ const getColumnValues = (csv, column, hasHeader = true) => {
     return column >= columns.length ? '' : columns[column]
   })
 }
-export { eachRecord, getColumnValues }
+
+/*
+ * Removes empty lines from a CSV string.
+ * @param {string} csv - The CSV data as a string.
+ * @returns {string} The CSV string with empty lines removed.
+ *
+ * @example
+ * const csv = 'header1,header2,header3\n\nvalue1,value2,value3\n\nvalue4,value5,value6\n,,,,\n';
+ * const cleanedCsv = removeEmptyLines(csv);
+ * console.log(cleanedCsv);
+ * // Output:
+ * // 'header1,header2,header3\nvalue1,value2,value3\nvalue4,value5,value6'
+ */
+const removeEmptyLines = (csv) => {
+  return csv
+    .split('\n')
+    .filter((row) => row.replace(/,/g, '').trim() !== '')
+    .join('\n')
+}
+
+export { eachRecord, getColumnValues, removeEmptyLines }

--- a/src/stores/pacbioLibraryBatchCreate.js
+++ b/src/stores/pacbioLibraryBatchCreate.js
@@ -9,7 +9,7 @@ import {
 } from '@/stores/utilities/pacbioLibraryBatches.js'
 import { dataToObjectById } from '@/api/JsonApi.js'
 import { usePacbioRootStore } from '@/stores/pacbioRoot.js'
-import { getColumnValues } from '@/lib/csv/pacbio.js'
+import { getColumnValues, removeEmptyLines } from '@/lib/csv/pacbio.js'
 import { findDuplicates } from '@/lib/DataHelpers.js'
 
 /**
@@ -82,7 +82,15 @@ export const usePacbioLibraryBatchCreateStore = defineStore('pacbioLibraryBatchC
         return { success: false, errors: 'csvFile is required' }
       }
       try {
-        const csv = await csvFile.text()
+        let csv = await csvFile.text()
+
+        // Remove empty lines from the CSV content
+        csv = removeEmptyLines(csv)
+        // Check if the CSV content is empty or has only headers
+        if (csv.length === 0 || csv.split('\n').length <= 1) {
+          return { success: false, errors: 'The provided csv file is empty' }
+        }
+
         const sources = getColumnValues(csv, 0)
         const tagNames = getColumnValues(csv, 1)
 

--- a/tests/unit/lib/csv/pacbio.spec.js
+++ b/tests/unit/lib/csv/pacbio.spec.js
@@ -3,7 +3,7 @@
 // We need to do this because node-based csv-parse library used in 'eachRecord' doesn't work with jsdom
 
 import fs from 'fs'
-import { eachRecord, getColumnValues } from '@/lib/csv/pacbio'
+import { eachRecord, getColumnValues, removeEmptyLines } from '@/lib/csv/pacbio'
 
 describe('eachRecord', () => {
   it('handles empty CSV data', () => {
@@ -145,5 +145,24 @@ describe('getColumnValues', () => {
     const csv = 'header1,header2,header3\nvalue1,,value3\nvalue4,value5,'
     const result = getColumnValues(csv, 1)
     expect(result).toEqual(['', 'value5'])
+  })
+})
+describe('removeEmptyLines', () => {
+  it('removes empty lines from CSV data', () => {
+    const csv = 'header1,header2,header3\n\nvalue1,value2,value3\n\nvalue4,value5,value6\n,,,,\n'
+    const result = removeEmptyLines(csv)
+    expect(result).toEqual('header1,header2,header3\nvalue1,value2,value3\nvalue4,value5,value6')
+  })
+
+  it('returns an empty string when CSV data is empty', () => {
+    const csv = ''
+    const result1 = removeEmptyLines(csv)
+    expect(result1).toEqual('')
+  })
+
+  it('returns the same CSV data when there are no empty lines', () => {
+    const csv = 'header1,header2,header3\nvalue1,value2,value3\nvalue4,value5,value6'
+    const result = removeEmptyLines(csv)
+    expect(result).toEqual(csv)
   })
 })

--- a/tests/unit/stores/pacbioLibraryBatchCreate.spec.js
+++ b/tests/unit/stores/pacbioLibraryBatchCreate.spec.js
@@ -85,6 +85,27 @@ describe('usePacbioLibraryBatchCreateStore', () => {
         expect(result.errors).toEqual('tagSet is required')
       })
 
+      it('returns error if csv file is empty', async () => {
+        csvFileTextContent = '\n\n\n,,,,\n'
+        const { success, errors } = await pacbioLibraryBatchCreateStore.createLibraryBatch(
+          csvFile,
+          tagSet,
+        )
+        expect(success).toBeFalsy()
+        expect(errors).toEqual('The provided csv file is empty')
+      })
+
+      it('returns error if csv file contains only headers', async () => {
+        csvFileTextContent =
+          'Sample Name,Tag,Template prep kit box barcode,Volume,Concentration,Insert Size\n\n\n,,,,\n'
+        const { success, errors } = await pacbioLibraryBatchCreateStore.createLibraryBatch(
+          csvFile,
+          tagSet,
+        )
+        expect(success).toBeFalsy()
+        expect(errors).toEqual('The provided csv file is empty')
+      })
+
       it('returns error if no requests are found', async () => {
         rootStore.api.traction.pacbio.requests.get.mockResolvedValue({ data: [] })
         csvFileTextContent = pacbioLibraryBatchFactory.createCsvFromLibraryBatchData(
@@ -98,7 +119,7 @@ describe('usePacbioLibraryBatchCreateStore', () => {
         expect(errors).toEqual('None of the given sources (/samples) were found')
       })
 
-      it('returns error if there are dupliacte sources', async () => {
+      it('returns error if there are duplicate sources', async () => {
         csvFileTextContent = pacbioLibraryBatchFactory.createCsvFromLibraryBatchData(
           pacbioTagSetFactory.storeData.tags,
         )


### PR DESCRIPTION
Closes #2477

#### Changes proposed in this pull request

- Removes empty lines from csv file on library batch page.
- Adds error messages for empty csv files or csv files with headers only.
