### PR TITLE
fix(sample-edit): fetches library types on sample index page load

### DIFF
--- a/src/components/pacbio/PacbioSampleMetadataEdit.vue
+++ b/src/components/pacbio/PacbioSampleMetadataEdit.vue
@@ -1,6 +1,11 @@
 <template>
   <div>
-    <traction-button :id="generateId('editSample', req.id)" size="sm" theme="edit" @click="show"
+    <traction-button
+      :id="generateId('editSample', req.id)"
+      data-attribute="sample-edit"
+      size="sm"
+      theme="edit"
+      @click="show"
       >Edit</traction-button
     >
 
@@ -49,7 +54,9 @@
       <template #modal-footer="{ cancel }">
         <traction-button @click="cancel()"> Cancel </traction-button>
 
-        <traction-button theme="update" @click="update()"> Update Sample </traction-button>
+        <traction-button theme="update" data-attribute="update-sample-btn" @click="update()">
+          Update Sample
+        </traction-button>
       </template>
     </traction-modal>
   </div>

--- a/src/views/pacbio/PacbioSampleIndex.vue
+++ b/src/views/pacbio/PacbioSampleIndex.vue
@@ -77,6 +77,7 @@ import PrinterModal from '@/components/labelPrinting/PrinterModal.vue'
 import FilterCard from '@/components/FilterCard.vue'
 import DataFetcher from '@/components/DataFetcher.vue'
 import useLocationFetcher from '@/composables/useLocationFetcher.js'
+import useRootStore from '@/stores/index.js'
 
 import useQueryParams from '@/composables/useQueryParams.js'
 import { getCurrentDate } from '@/lib/DateHelpers.js'
@@ -90,6 +91,7 @@ import { formatRequests } from '@/lib/requestHelpers.js'
 const { fetchWithQueryParams } = useQueryParams()
 const { fetchLocations } = useLocationFetcher()
 const pacbioRequestsStore = usePacbioRequestsStore()
+const rootStore = useRootStore()
 const labwareLocations = ref([])
 const { showAlert } = useAlert()
 
@@ -164,6 +166,11 @@ const printLabels = async (printerName) => {
 /*Fetches the requests from the api and adds location data
   @returns {Object} { success: Boolean, errors: Array }*/
 const provider = async () => {
+  // Ensure library types are fetched for the Library Type select
+  const { success: libTypeSuccess, errors: libTypeErrors } = await rootStore.fetchLibraryTypes()
+  if (!libTypeSuccess) {
+    showAlert('Failed to fetch library types: ' + libTypeErrors, 'danger')
+  }
   const { success, errors } = await fetchWithQueryParams(
     pacbioRequestsStore.setRequests,
     state.filterOptions,

--- a/tests/e2e/specs/pacbio/pacbio_samples_view.cy.js
+++ b/tests/e2e/specs/pacbio/pacbio_samples_view.cy.js
@@ -2,11 +2,13 @@ import PacbioTagSetFactory from '../../../factories/PacbioTagSetFactory.js'
 import PrinterFactory from '../../../factories/PrinterFactory.js'
 import PacbioRequestFactory from '../../../factories/PacbioRequestFactory.js'
 import PacbioLibraryFactory from '../../../factories/PacbioLibraryFactory.js'
+import LibraryTypeFactory from '../../../factories/LibraryTypeFactory.js'
 
 describe('Pacbio samples view', () => {
   beforeEach(() => {
     cy.wrap(PacbioTagSetFactory()).as('pacbioTagSetFactory')
     cy.wrap(PrinterFactory()).as('printerFactory')
+    cy.wrap(LibraryTypeFactory()).as('libraryTypeFactory')
     cy.wrap(PacbioRequestFactory({ includeRelationships: false })).as('pacbioRequestFactory')
     cy.wrap(PacbioLibraryFactory({ count: 1 })).as('pacbioLibraryFactory')
 
@@ -28,6 +30,13 @@ describe('Pacbio samples view', () => {
       cy.intercept('GET', '/v1/printers', {
         statusCode: 200,
         body: printerFactory.content,
+      })
+    })
+
+    cy.get('@libraryTypeFactory').then((libraryTypeFactory) => {
+      cy.intercept('/v1/library_types', {
+        statusCode: 200,
+        body: libraryTypeFactory.content,
       })
     })
 
@@ -116,5 +125,27 @@ describe('Pacbio samples view', () => {
     cy.get('#create-btn').click()
     cy.get('#libraryForm').should('not.exist')
     cy.contains('Created library with barcode TRAC-2-721')
+  })
+
+  it('edits a sample successfully', () => {
+    // Stub the PATCH request for updating a sample
+    // N.B. Use a wildcard for the sample ID so we don't tie the test to a specific fixture
+    cy.intercept('PATCH', '/v1/pacbio/requests/*', {
+      statusCode: 200,
+      body: {
+        data: {},
+      },
+    })
+    cy.visit('#/pacbio/samples')
+    cy.get('#samples-table').contains('td', '5')
+    cy.get('[data-attribute="sample-edit"]').first().click()
+    cy.get('[data-attribute="modal"]').should('be.visible')
+    cy.get('[data-attribute="library-type-list"]').select('Pacbio_HiFi_mplx')
+    cy.get('#estimateOfGBRequired').type(1)
+    cy.get('#numberOfSMRTCells').type('2')
+    cy.get('#costCode').type(123)
+    cy.get('[data-attribute="update-sample-btn"]').click()
+    cy.get('[data-attribute="modal"]').should('not.exist')
+    cy.contains('Sample updated')
   })
 })

--- a/tests/unit/views/pacbio/PacbioSampleIndex.spec.js
+++ b/tests/unit/views/pacbio/PacbioSampleIndex.spec.js
@@ -2,8 +2,11 @@ import PacbioSampleIndex from '@/views/pacbio/PacbioSampleIndex.vue'
 import { mountWithStore, flushPromises } from '@support/testHelper.js'
 import { beforeEach, describe, expect, it } from 'vitest'
 import PacbioRequestFactory from '@tests/factories/PacbioRequestFactory.js'
+import LibraryTypeFactory from '@tests/factories/LibraryTypeFactory.js'
 import { usePacbioRequestsStore } from '@/stores/pacbioRequests.js'
+import useRootStore from '@/stores/index.js'
 
+const libraryTypeFactory = LibraryTypeFactory()
 const mockShowAlert = vi.fn()
 vi.mock('@/composables/useAlert', () => ({
   default: () => ({
@@ -29,6 +32,9 @@ describe('PacbioSamples.vue', () => {
           store.api.traction.pacbio.requests.get = vi
             .fn()
             .mockResolvedValue(pacbioRequestFactory.responses.fetch)
+          store.api.traction.library_types.get = vi
+            .fn()
+            .mockResolvedValue(libraryTypeFactory.responses.fetch)
         }
       },
     ]
@@ -39,7 +45,10 @@ describe('PacbioSamples.vue', () => {
           template: '<div ref="printerModal"></div>',
         },
       },
-      createStore: () => usePacbioRequestsStore(),
+      createStore: () => {
+        usePacbioRequestsStore()
+        useRootStore()
+      },
     }))
     await flushPromises()
   })


### PR DESCRIPTION
Relates to: https://sanger.freshservice.com/a/tickets/47808?current_tab=details

#### Changes proposed in this pull request

- Fetches library types on sample index page load to ensure they are populated for sample edits.
- Adds cypress test for sample edits.
