### PR TITLE
fix(tests): resolve invalid JSON responses in unit test mocks (Y25-571)

### DIFF
--- a/tests/unit/stores/ontPoolCreate.spec.js
+++ b/tests/unit/stores/ontPoolCreate.spec.js
@@ -324,7 +324,7 @@ describe('useOntPoolCreateStore', () => {
       it('handles failure', async () => {
         const get = vi.fn()
         rootStore.api = { traction: { ont: { pools: { get } } } }
-        get.mockResolvedValue(failedResponse)
+        get.mockResolvedValue(failedResponse())
         const { success } = await store.fetchOntPools()
         expect(success).toEqual(false)
       })
@@ -455,7 +455,7 @@ describe('useOntPoolCreateStore', () => {
       it('handles failure', async () => {
         const get = vi.fn()
         rootStore.api = { traction: { ont: { tag_sets: { get } } } }
-        get.mockResolvedValue(failedResponse)
+        get.mockResolvedValue(failedResponse())
         const { success } = await store.fetchOntTagSets()
         expect(success).toEqual(false)
       })

--- a/tests/unit/stores/pacbioLibraryBatchCreate.spec.js
+++ b/tests/unit/stores/pacbioLibraryBatchCreate.spec.js
@@ -107,7 +107,9 @@ describe('usePacbioLibraryBatchCreateStore', () => {
       })
 
       it('returns error if no requests are found', async () => {
-        rootStore.api.traction.pacbio.requests.get.mockResolvedValue({ data: [] })
+        rootStore.api.traction.pacbio.requests.get.mockResolvedValue(
+          successfulResponse({ data: [] }),
+        )
         csvFileTextContent = pacbioLibraryBatchFactory.createCsvFromLibraryBatchData(
           pacbioTagSetFactory.storeData.tags,
         )

--- a/tests/unit/stores/pacbioPoolCreate.spec.js
+++ b/tests/unit/stores/pacbioPoolCreate.spec.js
@@ -1061,7 +1061,7 @@ describe('usePacbioPoolCreateStore', () => {
       })
 
       it('returns an error and an empty list when plate barcode cannot be found', async () => {
-        get.mockResolvedValue({ data: [] })
+        get.mockResolvedValue(successfulResponse({ data: [] }))
 
         const { success, errors } = await store.findPacbioPlate({ barcode: 'fake-barcode' })
         expect(errors).toEqual(['Unable to find plate with barcode: fake-barcode'])
@@ -1101,7 +1101,7 @@ describe('usePacbioPoolCreateStore', () => {
       })
 
       it('returns an error and an empty list when tube barcode cannot be found', async () => {
-        get.mockResolvedValue({ data: [] })
+        get.mockResolvedValue(successfulResponse({ data: [] }))
 
         const { success, errors } = await store.findPacbioTube({ barcode: 'fake-barcode' })
         expect(errors).toEqual(['Unable to find tube with barcode: fake-barcode'])

--- a/tests/unit/stores/pacbioRequests.spec.js
+++ b/tests/unit/stores/pacbioRequests.spec.js
@@ -34,7 +34,7 @@ describe('pacbioRequests', () => {
       })
       it('returns success false if request fails', async () => {
         const rootStore = useRootStore()
-        rootStore.api.traction.pacbio.requests.get = vi.fn().mockResolvedValue({ success: false })
+        rootStore.api.traction.pacbio.requests.get = vi.fn().mockResolvedValue(failedResponse())
         const { success } = await store.setRequests()
         expect(success).toEqual(false)
       })

--- a/tests/unit/stores/utilities/pabioLibraryBatches.spec.js
+++ b/tests/unit/stores/utilities/pabioLibraryBatches.spec.js
@@ -6,6 +6,7 @@ import {
 import PacbioRequestFactory from '@tests/factories/PacbioRequestFactory.js'
 import PacbioTagSetFactory from '@tests/factories/PacbioTagSetFactory.js'
 import useRootStore from '@/stores'
+import { failedResponse } from '@support/testHelper.js'
 
 const pacbioRequestFactory = PacbioRequestFactory()
 const pacbioTagSetFactory = PacbioTagSetFactory()
@@ -134,7 +135,7 @@ describe('pacbioLibraryBatches', () => {
     })
 
     it('returns null tags if tag set fetch fails', async () => {
-      rootStore.api.traction.pacbio.tag_sets.get.mockResolvedValue({ success: false })
+      rootStore.api.traction.pacbio.tag_sets.get.mockResolvedValue(failedResponse())
 
       const { requests, tags } = await fetchTagsAndRequests(sources, tagSet.name)
 
@@ -150,7 +151,7 @@ describe('pacbioLibraryBatches', () => {
     })
 
     it('returns empty requests if request fetch fails', async () => {
-      rootStore.api.traction.pacbio.requests.get.mockResolvedValue({ success: false })
+      rootStore.api.traction.pacbio.requests.get.mockResolvedValue(failedResponse())
 
       const { requests } = await fetchTagsAndRequests(sources, tagSet.name)
 


### PR DESCRIPTION
## Summary
Fixes noisy unit test output by correcting invalid mocked API responses in Y25-571.

## Background
Several unit tests were logging repeated
"Response from undefined is not valid JSON" messages due to incorrectly shaped mock responses and missing helper usage.

## Changes Made
- Fixed broken mock responses in affected tests
- Ensured failedResponse() is always invoked correctly
- Standardized empty data mocks using successfulResponse({ data: [] })
- Added missing helper imports where required

## Files Updated
- tests/unit/stores/ontPoolCreate.spec.js
- tests/unit/stores/pacbioPoolCreate.spec.js
- tests/unit/stores/pacbioLibraryBatchCreate.spec.js
- tests/unit/stores/utilities/pabioLibraryBatches.spec.js
- tests/unit/stores/pacbioRequests.spec.js

## Testing Performed
- npm run test:unit (all 1535 tests passing)
- ESLint clean
- No console warnings or JSON parsing errors observed

## Scope
- Test-only changes
- No production code modified
- No unrelated formatting or documentation changes

## Related Issue
Closes #2468 (Y25-571)