### PR TITLE
Add configurable support link to footer (Y25-580)

### DIFF
--- a/src/components/InfoFooter.vue
+++ b/src/components/InfoFooter.vue
@@ -47,6 +47,28 @@
             {{ getRelease() }}
           </a>
         </li>
+        <li v-if="supportUrl">
+          <a
+            class="flex flex-row items-center justify-start gap-1"
+            :href="supportUrl"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              height="24px"
+              viewBox="0 0 24 24"
+              width="24px"
+              fill="currentColor"
+            >
+              <path d="M0 0h24v24H0z" fill="none" />
+              <path
+                d="M11 18h2v-2h-2v2zm1-16C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm0-14c-2.21 0-4 1.79-4 4h2c0-1.1.9-2 2-2s2 .9 2 2c0 2-3 1.75-3 5h2c0-2.25 3-2.5 3-5 0-2.21-1.79-4-4-4z"
+              />
+            </svg>
+            Support
+          </a>
+        </li>
       </ul>
       <div class="mx-auto my-2 text-center text-xs font-medium text-gray-500">
         &copy; {{ new Date().getFullYear() }} Genome Research Ltd.
@@ -66,6 +88,7 @@ export default {
       repo: '',
       linkSlice: 51, //length needed for to slice github URL down to release name
       defaultRelease: 'https://github.com/sanger/traction-ui/releases',
+      supportUrl: import.meta.env['VITE_SUPPORT_URL'],
     }
   },
   computed: {
@@ -79,6 +102,7 @@ export default {
   created() {
     this.provider()
   },
+
   methods: {
     getRelease() {
       if (this.repo != this.defaultRelease) {


### PR DESCRIPTION
## Summary
This PR adds a configurable "Support" link to the Traction footer, allowing users to access Fresh Service Support when required.

## Changes
- Added `VITE_SUPPORT_URL` environment variable across all env files
- Conditionally render support link in footer when URL is configured
- Open link in new tab with secure attributes
- Graceful fallback when variable is unset
- Added unit tests for rendering and fallback behavior

## Testing
- ESLint passed
- Prettier formatting verified
- Unit tests added for link visibility and attributes

Closes #2478
