### PR TITLE
docs: fixes empty jsdoc returns tag

### DIFF
--- a/src/stores/multiPoolCreate.js
+++ b/src/stores/multiPoolCreate.js
@@ -26,7 +26,7 @@ export const useMultiPoolCreateStore = defineStore('multiPoolCreate', {
      * Fetches a multi pool by its id and populates the store state with the retrieved data.
      *
      * @param {*} multiPoolId the id of the multi pool to fetch
-     * @returns
+     * @returns {Promise<Object>} A promise that resolves to an object containing the success status and any errors.
      */
     async fetchMultiPool(multiPoolId) {
       const rootStore = useRootStore()


### PR DESCRIPTION
Fix empty returns tag causing jsdoc action to fail
e.g. https://github.com/sanger/traction-ui/actions/runs/21947764414/job/63389837355?pr=2611

#### Changes proposed in this pull request

- Adds return information to multiPoolCreate.js fetchMultiPool method 
