### PR TITLE
feat: adds pool barcode to flexible pool well

### DIFF
--- a/src/components/labware/FlexiblePoolWell.vue
+++ b/src/components/labware/FlexiblePoolWell.vue
@@ -7,7 +7,7 @@
       @mouseleave.prevent="hover = false"
       @click="onClick"
     >
-      <p class="wrap-anywhere whitespace-normal p-1 overflow-hidden">{{ pool.id }}</p>
+      <p class="wrap-anywhere whitespace-normal p-1 overflow-hidden">{{ pool.pool_barcode }}</p>
     </div>
     <p data-attribute="well-position" class="truncate font-light text-xs">{{ position }}</p>
   </div>

--- a/tests/unit/components/labware/FlexiblePoolWell.spec.js
+++ b/tests/unit/components/labware/FlexiblePoolWell.spec.js
@@ -1,11 +1,12 @@
 import FlexiblePoolWell from '@/components/labware/FlexiblePoolWell.vue'
-import { mountWithStore } from '@support/testHelper.js'
+import { mountWithStore, nextTick } from '@support/testHelper.js'
 import { useMultiPoolCreateStore } from '@/stores/multiPoolCreate.js'
 import { beforeEach } from 'vitest'
 
 const storePool = {
   position: '1',
   type: 'MultiPoolPosition',
+  pool_barcode: 'TRAC-2-1213',
 }
 const props = {
   position: '1',
@@ -32,5 +33,19 @@ describe('FlexiblePoolWell.vue', () => {
 
   it('must have a position', () => {
     expect(well.position).toEqual(props.position)
+  })
+
+  describe('pool barcode', () => {
+    it('shows the pool barcode if it exists', () => {
+      expect(wrapper.find('[data-attribute="flexible-pool-well"]').text()).toContain(
+        storePool.pool_barcode,
+      )
+    })
+
+    it('shows nothing if there is no pool barcode', async () => {
+      wrapper.setProps({ position: '2' })
+      await nextTick()
+      expect(wrapper.find('[data-attribute="flexible-pool-well"]').text()).toBe('')
+    })
   })
 })


### PR DESCRIPTION
#### Changes proposed in this pull request

- Displays pool barcode instead of ID for existing pools in a multi pool

#### Instructions for Reviewers
Coupled with: https://github.com/sanger/traction-service/pull/1794