### PR TITLE
Y26-117 - Collect flexible pooling errors for all pools

### DIFF
--- a/src/stores/multiPoolCreate.js
+++ b/src/stores/multiPoolCreate.js
@@ -139,6 +139,8 @@ export const useMultiPoolCreateStore = defineStore('multiPoolCreate', {
         pacbioPoolCreateStore.$reset()
         // Array to collect errors from building each pool. If any pool fails to build, we will return these errors and not store any valid pools.
         const poolBuildErrors = []
+        // Object to hold the new multi pool positions. We will only set this to the store state if all pools are built successfully.
+        const newMultiPoolPositions = {}
 
         // Transform the pool groups into the multi pool positions format
         for (const [poolNumber, poolRecords] of Object.entries(poolGroups)) {
@@ -157,7 +159,7 @@ export const useMultiPoolCreateStore = defineStore('multiPoolCreate', {
           }
 
           // If the pool was successfully built, add it to the multi pool positions
-          this.multiPoolPositions[poolNumber] = JSON.parse(
+          newMultiPoolPositions[poolNumber] = JSON.parse(
             JSON.stringify(pacbioPoolCreateStore.$state),
           )
 
@@ -166,13 +168,13 @@ export const useMultiPoolCreateStore = defineStore('multiPoolCreate', {
         }
 
         if (poolBuildErrors.length) {
-          // Ensure we do not keep partial data from valid pools when any pool in the file fails validation
-          this.multiPoolPositions = {}
           return {
             success: false,
             errors: poolBuildErrors,
           }
         }
+        // If all pools were built successfully, set the multi pool positions
+        this.multiPoolPositions = newMultiPoolPositions
 
         return { success, errors }
       } catch (error) {

--- a/src/stores/multiPoolCreate.js
+++ b/src/stores/multiPoolCreate.js
@@ -137,28 +137,41 @@ export const useMultiPoolCreateStore = defineStore('multiPoolCreate', {
         const pacbioPoolCreateStore = usePacbioPoolCreateStore()
         // Ensure we reset the pacbio pool create store state before building the pools in case there is any residual data from previous builds that could interfere with the new build process
         pacbioPoolCreateStore.$reset()
+        // Array to collect errors from building each pool. If any pool fails to build, we will return these errors and not store any valid pools.
+        const poolBuildErrors = []
+
         // Transform the pool groups into the multi pool positions format
-        for (const [poolNumber, records] of Object.entries(poolGroups)) {
-          const { success: buildPoolSuccess, errors: buildPoolErrors } =
-            await pacbioPoolCreateStore.buildPoolFromMultiPoolCsvRecords(records, poolNumber)
+        for (const [poolNumber, poolRecords] of Object.entries(poolGroups)) {
+          const { success: buildPoolSuccess, errors: buildPoolErrors = [] } =
+            await pacbioPoolCreateStore.buildPoolFromMultiPoolCsvRecords(poolRecords, poolNumber)
+
           if (!buildPoolSuccess) {
-            // If there was an error building the pool, reset the multi pool positions to an empty object to avoid any partial data in the store and return the errors
-            this.multiPoolPositions = {}
+            const formattedErrors = buildPoolErrors.map(
+              (error) => `Error building pool number ${poolNumber}: ${error}`,
+            )
+            poolBuildErrors.push(...formattedErrors)
+
             // Reset the pacbio pool create store state to ensure it is cleared of any data from the failed build attempt
             pacbioPoolCreateStore.$reset()
-            // Return the error message
-            return {
-              success: false,
-              errors: [`Error building pool number ${poolNumber}: ${buildPoolErrors}`],
-            }
+            continue
           }
 
           // If the pool was successfully built, add it to the multi pool positions
           this.multiPoolPositions[poolNumber] = JSON.parse(
             JSON.stringify(pacbioPoolCreateStore.$state),
           )
+
           // Ensure we reset the pacbio pool create store state before building the next pool to avoid any data leakage between pools
           pacbioPoolCreateStore.$reset()
+        }
+
+        if (poolBuildErrors.length) {
+          // Ensure we do not keep partial data from valid pools when any pool in the file fails validation
+          this.multiPoolPositions = {}
+          return {
+            success: false,
+            errors: poolBuildErrors,
+          }
         }
 
         return { success, errors }

--- a/src/views/FlexiblePoolCreate.vue
+++ b/src/views/FlexiblePoolCreate.vue
@@ -240,7 +240,9 @@ const uploadFile = async (evt) => {
     if (success) {
       showAlert('CSV file successfully processed', 'success')
     } else {
-      showAlert(errors.join(', '), 'danger')
+      errors.forEach((error) => {
+        showAlert(error, 'danger')
+      })
     }
   } else {
     showAlert('No file selected. Please select a CSV file to upload.', 'warning')

--- a/tests/unit/stores/multiPoolCreate.spec.js
+++ b/tests/unit/stores/multiPoolCreate.spec.js
@@ -237,6 +237,40 @@ describe('useMultiPoolCreateStore', () => {
         expect(errors).toEqual(['Error building pool number 1: Error building pool'])
         expect(store.multiPoolPositions).toEqual({})
       })
+
+      it('validates all pools and returns combined errors across multiple pools', async () => {
+        pacbioPoolCreateStore.buildPoolFromMultiPoolCsvRecords = vi.fn()
+        pacbioPoolCreateStore.buildPoolFromMultiPoolCsvRecords.mockResolvedValueOnce({
+          success: false,
+          errors: ['Pool 1 failed'],
+        })
+        pacbioPoolCreateStore.buildPoolFromMultiPoolCsvRecords.mockResolvedValueOnce({
+          success: true,
+          errors: [],
+        })
+        pacbioPoolCreateStore.buildPoolFromMultiPoolCsvRecords.mockResolvedValueOnce({
+          success: false,
+          errors: ['Pool 3 issue A', 'Pool 3 issue B'],
+        })
+
+        fileTextContent = `${requiredHeaders.join(',')}\n`
+        fileTextContent += '1,Sample1,Set1,Tag1,Barcode1,10,20,500\n'
+        fileTextContent += '2,Sample2,Set1,Tag2,Barcode2,10,20,500\n'
+        // Add a valid pool to ensure valid pools are processed but not included in the error results
+        // and not stored in multiPoolPositions since the first two pools failed to build
+        fileTextContent += '3,Sample3,Set1,Tag3,Barcode3,10,20,500\n'
+
+        const { success, errors } = await store.parsePoolingCsvFile(file)
+
+        expect(success).toBeFalsy()
+        expect(errors).toEqual([
+          'Error building pool number 1: Pool 1 failed',
+          'Error building pool number 3: Pool 3 issue A',
+          'Error building pool number 3: Pool 3 issue B',
+        ])
+        expect(pacbioPoolCreateStore.buildPoolFromMultiPoolCsvRecords).toHaveBeenCalledTimes(3)
+        expect(store.multiPoolPositions).toEqual({})
+      })
     })
 
     describe('isValidPersisted', () => {


### PR DESCRIPTION
Closes #2687 

#### Changes proposed in this pull request

- Processes all pools in the multi pool upfront and collect errors instead of early exit on first failed pool.
