### PR TITLE
style: centers flexi-pool numbering and barcodes

### DIFF
--- a/src/components/labware/FlexiblePoolWell.vue
+++ b/src/components/labware/FlexiblePoolWell.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <router-link :to="poolLink" class="block">
+    <router-link :to="poolLink" class="block text-center">
       <div
         :class="wellClassNames"
         :data-attribute="`flexible-pool-well-${position}`"


### PR DESCRIPTION
#### Changes proposed in this pull request

- Fixes flexible pooling well text alignment

Before:
<img width="140" height="160" alt="Screenshot 2026-07-14 at 08 58 19" src="https://github.com/user-attachments/assets/b01ba5a6-d621-4c94-b3b5-66cbab5e492a" />

After:
<img width="140" height="160" alt="Screenshot 2026-07-14 at 08 58 34" src="https://github.com/user-attachments/assets/be50d350-a037-42f3-bc9a-d0a1e94a1db1" />
